### PR TITLE
[ts-rewrite][expression-interpreter-tests] Add nested StatementBlock variable scope test

### DIFF
--- a/typescript-rewrite/samlang-core/src/interpreter/__tests__/expression-interpreter.test.ts
+++ b/typescript-rewrite/samlang-core/src/interpreter/__tests__/expression-interpreter.test.ts
@@ -715,7 +715,60 @@ it('statement block expression evalutes correctly', () => {
     type: intType,
     block: statementBlockFail,
   });
+  const nestedBlockExpressionFail = EXPRESSION_STATEMENT_BLOCK({
+    range: exampleRange,
+    type: intType,
+    block: {
+      range: exampleRange,
+      statements: [
+        {
+          pattern: {
+            type: 'VariablePattern',
+            name: 'diffVar',
+            range: exampleRange,
+          },
+          typeAnnotation: intType,
+          assignedExpression: EXPRESSION_STATEMENT_BLOCK({
+            range: exampleRange,
+            type: intType,
+            block: {
+              range: exampleRange,
+              statements: [
+                {
+                  pattern: variablePattern,
+                  range: exampleRange,
+                  typeAnnotation: intType,
+                  assignedExpression: intLiteralExpression,
+                },
+              ],
+              expression: variableExpression,
+            },
+          }),
+          range: exampleRange,
+        },
+        variableStatement,
+      ],
+    },
+  });
+  const nestedBlockExpressionPass = EXPRESSION_STATEMENT_BLOCK({
+    range: exampleRange,
+    type: intType,
+    block: {
+      range: exampleRange,
+      statements: [
+        {
+          pattern: variablePattern,
+          typeAnnotation: intType,
+          assignedExpression: intLiteralExpression,
+          range: exampleRange,
+        },
+      ],
+      expression: variableExpression,
+    },
+  });
   expect(interpreter.eval(statementBlockExpression, variableContext)).toEqual({ type: 'unit' });
+  expect(() => interpreter.eval(nestedBlockExpressionFail)).toThrow('Missing variable var');
   expect(interpreter.eval(statementBlockExpressionWithBlockExpression)).toEqual(BigInt(5));
+  expect(interpreter.eval(nestedBlockExpressionPass)).toEqual(BigInt(5));
   expect(() => interpreter.eval(statementBlockExpressionFail)).toThrow('');
 });


### PR DESCRIPTION
This PR adds the missing tests in #32 for variable scope on the `StatementBlockExpression` case. Here in the outer block we assign a variable `diffVar` to the result of the inner block containing a statement that sets variable `var` to `5n` and then retrieves that variable to assign to `diffVar` outside. We then try to retrieve `var` again using the same `variableStatement` but `var` is out of scope and we throw an error. 

On the success case, we set the variable `var` to `5n` and then retrieve it in the expression in the same block so that should pass and give us `5n`. (This is different from the test on the line above since that test doesn't use variables)