### PR TITLE
[checker] Unbreak private class type checking

### DIFF
--- a/samlang-core/src/checker/__tests/global-typing-context-builder.test.ts
+++ b/samlang-core/src/checker/__tests/global-typing-context-builder.test.ts
@@ -111,6 +111,12 @@ it('can handle imports and definitions', () => {
           m1: { isPublic: true, type: functionType([], intType), typeParameters: [] },
         },
       },
+      Class2: {
+        typeParameters: [],
+        typeDefinition,
+        functions: {},
+        methods: {},
+      },
     },
     importedClasses: {
       Class0: { typeParameters: [], typeDefinition, functions: {}, methods: {} },
@@ -182,6 +188,12 @@ it('can handle incremental update', () => {
         methods: {
           m1: { isPublic: true, type: functionType([], intType), typeParameters: [] },
         },
+      },
+      Class2: {
+        typeParameters: [],
+        typeDefinition,
+        functions: {},
+        methods: {},
       },
     },
     importedClasses: {},

--- a/samlang-core/src/checker/global-typing-context-builder.ts
+++ b/samlang-core/src/checker/global-typing-context-builder.ts
@@ -38,12 +38,10 @@ const buildClassTypingContext = ({
 const buildModuleTypingContextPhase1 = (samlangModule: SamlangModule): ModuleTypingContext => ({
   definedClasses: Object.fromEntries(
     samlangModule.classes
-      .map((classDeclaration) => {
-        if (!classDeclaration.isPublic) {
-          return null;
-        }
-        return [classDeclaration.name, buildClassTypingContext(classDeclaration)] as const;
-      })
+      .map(
+        (classDeclaration) =>
+          [classDeclaration.name, buildClassTypingContext(classDeclaration)] as const
+      )
       .filter(isNotNull)
   ),
   importedClasses: {},

--- a/samlang-core/src/test-programs.ts
+++ b/samlang-core/src/test-programs.ts
@@ -315,11 +315,13 @@ class Main {
     testName: 'private-classes',
     sourceCode: `
 private class Util {}
-private class Foo(val bar: int) {}
+private class Foo(val bar: int) {
+  function create(): Foo = { bar: 42 }
+}
 private class Jar(Bar(int), Baz(bool)) {}
 
 class Main {
-  function main(): unit = {}
+  function main(): unit = println(intToString(Foo.create().bar))
 }
 `,
   },


### PR DESCRIPTION
### Summary

Private class support seems to be broken since it was introduced. The problem is that the private class is NOT registered in the global typing context. Therefore, when you try to use a private class within a module, it will fail. It's not caught in a test even though we have a test on private classes, because in that test we never tried to use the private classes.

In this diff, we no longer ignore private classes in global typing context. We don't need to worry about accidentally using private classes in another module, because imports of private classes are checked:

https://github.com/SamChou19815/samlang/blob/f7bade8fecd27429154b4d7d15534eef3b610b7c/samlang-core/src/checker/undefined-imports-checker.ts#L30-L33

### Test Plan

Modified the test to include use of private classes. It still passed.