### PR TITLE
[interpreter] Fix confusing tests with arguments with wrong types given to stringToInt and intToString

### DIFF
--- a/samlang-core/src/interpreter/__tests__/expression-interpreter.test.ts
+++ b/samlang-core/src/interpreter/__tests__/expression-interpreter.test.ts
@@ -149,10 +149,9 @@ it('panic expression evaluates correctly', () => {
 });
 
 it('built in function call expression evaluates correctly', () => {
-  // FIXME: the test clearly shows that the stringToInt and intToString got messed up.
-  expect(interpret('stringToInt(5)')).toEqual(BigInt(5));
+  expect(interpret('stringToInt("5")')).toEqual(BigInt(5));
   expect(() => interpret('stringToInt("value")')).toThrow(`Cannot convert \`value\` to int.`);
-  expect(interpret('intToString("5")')).toEqual('5');
+  expect(interpret('intToString(5)')).toEqual('5');
 
   const temporaryInterpreterForPrint = new ExpressionInterpreter();
   expect(temporaryInterpreterForPrint.eval(getExpression('println("value")'), EMPTY)).toEqual({


### PR DESCRIPTION
## Summary

We don't really care about how the interpreter behave when the program doesn't type check, so I don't plan to add more sanity checks to interpreter now. Instead, I will just change the confusing tests.

## Test Plan

`yarn test`