### PR TITLE
[ast][hir] Introduce while true statement to HIR

### DIFF
--- a/samlang-core/src/ast/hir/hir-expressions.ts
+++ b/samlang-core/src/ast/hir/hir-expressions.ts
@@ -63,6 +63,11 @@ export interface HighIRIfElseStatement extends BaseHighIRStatement {
   readonly s2: readonly HighIRStatement[];
 }
 
+export interface HighIRWhileTrueStatement extends BaseHighIRStatement {
+  readonly __type__: 'HighIRWhileTrueStatement';
+  readonly statements: readonly HighIRStatement[];
+}
+
 export interface HighIRVariantPatternToStatement {
   readonly tagOrder: number;
   readonly statements: readonly HighIRStatement[];
@@ -88,6 +93,7 @@ export interface HighIRReturnStatement extends BaseHighIRStatement {
 export type HighIRStatement =
   | HighIRFunctionCallStatement
   | HighIRIfElseStatement
+  | HighIRWhileTrueStatement
   | HighIRLetDefinitionStatement
   | HighIRStructInitializationStatement
   | HighIRReturnStatement;
@@ -160,6 +166,13 @@ export const HIR_IF_ELSE = ({
   booleanExpression,
   s1,
   s2,
+});
+
+export const HIR_WHILE_TRUE = (
+  statements: readonly HighIRStatement[]
+): HighIRWhileTrueStatement => ({
+  __type__: 'HighIRWhileTrueStatement',
+  statements,
 });
 
 export const HIR_LET = ({

--- a/samlang-core/src/compiler/mir/__tests__/mir-lowering-translator.test.ts
+++ b/samlang-core/src/compiler/mir/__tests__/mir-lowering-translator.test.ts
@@ -11,6 +11,7 @@ import {
   HIR_LET,
   HIR_INDEX_ACCESS,
   HIR_STRUCT_INITIALIZATION,
+  HIR_WHILE_TRUE,
 } from '../../../ast/hir/hir-expressions';
 import { midIRStatementToString } from '../../../ast/mir';
 import midIRTranslateStatementsAndCollectGlobalStrings from '../mir-lowering-translator';
@@ -52,6 +53,13 @@ goto LABEL__2_PURPOSE_IF_ELSE_END;
 LABEL__1_PURPOSE_FALSE_BRANCH:
 return 2;
 LABEL__2_PURPOSE_IF_ELSE_END:`
+  );
+
+  assertCorrectlyLoweredWithPreConfiguredSetup(
+    HIR_WHILE_TRUE([HIR_RETURN(HIR_INT(BigInt(2)))]),
+    `LABEL__0_PURPOSE_WHILE_TRUE_START:
+return 2;
+goto LABEL__0_PURPOSE_WHILE_TRUE_START;`
   );
 
   assertCorrectlyLoweredWithPreConfiguredSetup(

--- a/samlang-core/src/compiler/mir/mir-lowering-translator.ts
+++ b/samlang-core/src/compiler/mir/mir-lowering-translator.ts
@@ -102,6 +102,17 @@ class MidIRLoweringManager {
           MIR_LABEL(endLabel),
         ];
       }
+      case 'HighIRWhileTrueStatement': {
+        const whileTrueStartLabel = this.allocator.allocateLabelWithAnnotation(
+          this.functionName,
+          'WHILE_TRUE_START'
+        );
+        return [
+          MIR_LABEL(whileTrueStartLabel),
+          ...statement.statements.map(this.lowerHIRStatementToMIRNonCanonicalStatements).flat(),
+          MIR_JUMP(whileTrueStartLabel),
+        ];
+      }
       case 'HighIRLetDefinitionStatement':
         return [
           MIR_MOVE_TEMP(

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -12,6 +12,7 @@ import {
   HIR_STRING,
   HIR_INDEX_ACCESS,
   HIR_VARIABLE,
+  HIR_WHILE_TRUE,
 } from '../../ast/hir/hir-expressions';
 import { compileSamlangSourcesToHighIRSources } from '../../compiler';
 import {
@@ -57,6 +58,17 @@ it('HIR statements to JS string test', () => {
       })
     )
   ).toBe(`if ((5 == 5)) {return;} else {return;}`);
+  expect(
+    highIRStatementToString(
+      HIR_WHILE_TRUE([
+        HIR_FUNCTION_CALL({
+          functionArguments: [],
+          functionExpression: HIR_NAME('func'),
+          returnCollector: 'val',
+        }),
+      ])
+    )
+  ).toBe('while (true) { var val = func(); }');
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -16,6 +16,9 @@ export const highIRStatementToString = (highIRStatement: HighIRStatement): strin
       const s2Str = s2.map((s) => highIRStatementToString(s)).join(';');
       return `if (${booleanExpressionStr}) {${s1Str}} else {${s2Str}}`;
     }
+    case 'HighIRWhileTrueStatement': {
+      return `while (true) { ${highIRStatement.statements.map(highIRStatementToString).join('')} }`;
+    }
     case 'HighIRFunctionCallStatement': {
       const { functionArguments, functionExpression, returnCollector } = highIRStatement;
       return `var ${returnCollector} = ${highIRExpressionToString(


### PR DESCRIPTION
## Summary

According to [my roadmap](https://wiki.developersam.com/docs/oss-roadmap-2020-h2#compiler-backend) released yesterday, I plan to move as many optimizations into HIR as possible. One of such optimizations that can be easily moved is tail recursion optimization.

Tail recursion transforms a tail recursive function's body into a while loop. Currently, this is performed in MIR, where the loop in implemented by label and unconditional jumps. Currently HIR doesn't have such expressive power to describe the tail recursive call workflow.

An easy fix for the problem is to introduce while statements in HIR. If we think about it carefully, all we need is `while (true)` statement, because `while (boolExpr)` can be simulated by

```js
while (true) {
  if (!boolExpr) break;
  // body
}
```

I didn't introduce a break statement because it's not necessary for tail recursion optimization.

## Test Plan

Added test on printer and mir lowering translator