### PR TITLE
[ast][hir] Eliminate support for empty return

### DIFF
--- a/samlang-core/src/ast/hir/hir-expressions.ts
+++ b/samlang-core/src/ast/hir/hir-expressions.ts
@@ -87,7 +87,7 @@ export interface HighIRStructInitializationStatement extends BaseHighIRStatement
 
 export interface HighIRReturnStatement extends BaseHighIRStatement {
   readonly __type__: 'HighIRReturnStatement';
-  readonly expression?: HighIRExpression;
+  readonly expression: HighIRExpression;
 }
 
 export type HighIRStatement =
@@ -195,7 +195,7 @@ export const HIR_STRUCT_INITIALIZATION = ({
   expressionList,
 });
 
-export const HIR_RETURN = (expression?: HighIRExpression): HighIRReturnStatement => ({
+export const HIR_RETURN = (expression: HighIRExpression): HighIRReturnStatement => ({
   __type__: 'HighIRReturnStatement',
   expression,
 });

--- a/samlang-core/src/compiler/mir/__tests__/mir-lowering-translator.test.ts
+++ b/samlang-core/src/compiler/mir/__tests__/mir-lowering-translator.test.ts
@@ -12,8 +12,9 @@ import {
   HIR_INDEX_ACCESS,
   HIR_STRUCT_INITIALIZATION,
   HIR_WHILE_TRUE,
+  HIR_ZERO,
 } from '../../../ast/hir/hir-expressions';
-import { midIRStatementToString } from '../../../ast/mir';
+import { midIRStatementToString, MIR_ZERO } from '../../../ast/mir';
 import midIRTranslateStatementsAndCollectGlobalStrings from '../mir-lowering-translator';
 import MidIRResourceAllocator from '../mir-resource-allocator';
 
@@ -80,5 +81,5 @@ MEM[(_struct + 0)] = _this;
 MEM[(_struct + 8)] = _that;`
   );
 
-  assertCorrectlyLoweredWithPreConfiguredSetup(HIR_RETURN(), 'return;');
+  assertCorrectlyLoweredWithPreConfiguredSetup(HIR_RETURN(HIR_ZERO), 'return 0;');
 });

--- a/samlang-core/src/compiler/mir/mir-lowering-translator.ts
+++ b/samlang-core/src/compiler/mir/mir-lowering-translator.ts
@@ -143,13 +143,7 @@ class MidIRLoweringManager {
         return statements;
       }
       case 'HighIRReturnStatement':
-        return [
-          MIR_RETURN(
-            statement.expression == null
-              ? undefined
-              : this.lowerHIRExpressionToMIRExpression(statement.expression)
-          ),
-        ];
+        return [MIR_RETURN(this.lowerHIRExpressionToMIRExpression(statement.expression))];
     }
   };
 }

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -45,19 +45,11 @@ it('HIR statements to JS string test', () => {
           e1: HIR_INT(BigInt(5)),
           e2: HIR_INT(BigInt(5)),
         }),
-        s1: [
-          {
-            __type__: 'HighIRReturnStatement',
-          },
-        ],
-        s2: [
-          {
-            __type__: 'HighIRReturnStatement',
-          },
-        ],
+        s1: [HIR_RETURN(HIR_ZERO)],
+        s2: [HIR_RETURN(HIR_ZERO)],
       })
     )
-  ).toBe(`if ((5 == 5)) {return;} else {return;}`);
+  ).toBe(`if ((5 == 5)) {return 0;} else {return 0;}`);
   expect(
     highIRStatementToString(
       HIR_WHILE_TRUE([
@@ -86,7 +78,6 @@ it('HIR statements to JS string test', () => {
       })
     )
   ).toBe(`var foo = 19815;`);
-  expect(highIRStatementToString(HIR_RETURN())).toBe('return;');
   expect(highIRStatementToString(HIR_RETURN(HIR_ZERO))).toBe('return 0;');
   expect(
     highIRStatementToString(

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -30,11 +30,7 @@ export const highIRStatementToString = (highIRStatement: HighIRStatement): strin
       return `var ${name} = ${highIRExpressionToString(assignedExpression)};`;
     }
     case 'HighIRReturnStatement':
-      return `return${
-        highIRStatement.expression
-          ? ` ${highIRExpressionToString(highIRStatement.expression)};`
-          : ';'
-      }`;
+      return `return ${highIRExpressionToString(highIRStatement.expression)};`;
     case 'HighIRStructInitializationStatement': {
       const { structVariableName, expressionList } = highIRStatement;
       return `${structVariableName} = [${expressionList


### PR DESCRIPTION
## Summary

The HIR compiler will never generate code with `return;`. So let's remove the support and make later stages consider fewer cases.

## Test Plan

`yarn test`
