### PR TITLE
[compiler][hir] Implement tail recursion transformation

### DIFF
--- a/samlang-core/src/compiler/hir/__tests__/hir-move-return-coalescing.test.ts
+++ b/samlang-core/src/compiler/hir/__tests__/hir-move-return-coalescing.test.ts
@@ -13,19 +13,15 @@ import {
 import coalesceMoveAndReturnWithForHighIRStatements from '../hir-move-return-coalescing';
 
 it('coalesceMoveAndReturnWithForHighIRStatements empty array test', () => {
-  expect(coalesceMoveAndReturnWithForHighIRStatements([])).toEqual([]);
+  expect(coalesceMoveAndReturnWithForHighIRStatements([])).toBeNull();
 });
 
 it('coalesceMoveAndReturnWithForHighIRStatements not end with return test', () => {
-  expect(coalesceMoveAndReturnWithForHighIRStatements([HIR_WHILE_TRUE([])])).toEqual([
-    HIR_WHILE_TRUE([]),
-  ]);
+  expect(coalesceMoveAndReturnWithForHighIRStatements([HIR_WHILE_TRUE([])])).toBeNull();
 });
 
 it('coalesceMoveAndReturnWithForHighIRStatements not end with return variable test', () => {
-  expect(coalesceMoveAndReturnWithForHighIRStatements([HIR_RETURN(HIR_ZERO)])).toEqual([
-    HIR_RETURN(HIR_ZERO),
-  ]);
+  expect(coalesceMoveAndReturnWithForHighIRStatements([HIR_RETURN(HIR_ZERO)])).toBeNull();
 });
 
 it('coalesceMoveAndReturnWithForHighIRStatements linear sequence test', () => {
@@ -54,16 +50,7 @@ it('coalesceMoveAndReturnWithForHighIRStatements failed linear sequence test', (
       HIR_LET({ name: 'garbage', assignedExpression: HIR_VARIABLE('garbage') }),
       HIR_RETURN(HIR_VARIABLE('_t1')),
     ])
-  ).toEqual([
-    HIR_WHILE_TRUE([]),
-    HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-    HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-    HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-    HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-    HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
-    HIR_LET({ name: 'garbage', assignedExpression: HIR_VARIABLE('garbage') }),
-    HIR_RETURN(HIR_VARIABLE('_t1')),
-  ]);
+  ).toBeNull();
 });
 
 it('coalesceMoveAndReturnWithForHighIRStatements if-else test', () => {

--- a/samlang-core/src/compiler/hir/__tests__/hir-tail-recursion-transformation-hir.test.ts
+++ b/samlang-core/src/compiler/hir/__tests__/hir-tail-recursion-transformation-hir.test.ts
@@ -1,0 +1,280 @@
+import {
+  HIR_ZERO,
+  HIR_ONE,
+  HIR_VARIABLE,
+  HIR_FUNCTION_CALL,
+  HIR_IF_ELSE,
+  HIR_WHILE_TRUE,
+  HIR_LET,
+  HIR_NAME,
+  HIR_RETURN,
+} from '../../../ast/hir/hir-expressions';
+import performTailRecursiveCallTransformationOnHighIRFunction from '../hir-tail-recursion-transformation-hir';
+
+it('performTailRecursiveCallTransformationOnHighIRFunction failed coalescing test', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: '',
+      parameters: [],
+      hasReturn: true,
+      body: [],
+    })
+  ).toBeNull();
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction no tailrec call test', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: '',
+      parameters: [],
+      hasReturn: true,
+      body: [
+        HIR_LET({ name: '_t1', assignedExpression: HIR_ONE }),
+        HIR_RETURN(HIR_VARIABLE('_t1')),
+      ],
+    })
+  ).toBeNull();
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction linear flow test', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_FUNCTION_CALL({
+          functionExpression: HIR_NAME('tailRec'),
+          functionArguments: [HIR_VARIABLE('n')],
+          returnCollector: 'collector',
+        }),
+        HIR_RETURN(HIR_VARIABLE('collector')),
+      ],
+    })
+  ).toEqual({
+    name: 'tailRec',
+    parameters: ['n'],
+    hasReturn: true,
+    body: [
+      HIR_WHILE_TRUE([
+        HIR_LET({ name: '_tailRecTransformationArgument0', assignedExpression: HIR_VARIABLE('n') }),
+        HIR_LET({ name: 'n', assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0') }),
+      ]),
+    ],
+  });
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch test 1', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_FUNCTION_CALL({
+          functionExpression: HIR_NAME('tailRec1'),
+          functionArguments: [HIR_VARIABLE('n')],
+          returnCollector: 'collector',
+        }),
+        HIR_RETURN(HIR_VARIABLE('collector')),
+      ],
+    })
+  ).toBeNull();
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch test 2', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_FUNCTION_CALL({
+          functionExpression: HIR_NAME('tailRec'),
+          functionArguments: [HIR_VARIABLE('n')],
+          returnCollector: 'collector1',
+        }),
+        HIR_RETURN(HIR_VARIABLE('collector')),
+      ],
+    })
+  ).toBeNull();
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 1', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [
+            HIR_FUNCTION_CALL({
+              functionExpression: HIR_NAME('tailRec'),
+              functionArguments: [HIR_VARIABLE('n')],
+              returnCollector: 'collector',
+            }),
+            HIR_RETURN(HIR_VARIABLE('collector')),
+          ],
+          s2: [HIR_RETURN(HIR_ZERO)],
+        }),
+      ],
+    })
+  ).toEqual({
+    name: 'tailRec',
+    parameters: ['n'],
+    hasReturn: true,
+    body: [
+      HIR_WHILE_TRUE([
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [
+            HIR_LET({
+              name: '_tailRecTransformationArgument0',
+              assignedExpression: HIR_VARIABLE('n'),
+            }),
+            HIR_LET({
+              name: 'n',
+              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+            }),
+          ],
+          s2: [HIR_RETURN(HIR_ZERO)],
+        }),
+      ]),
+    ],
+  });
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 2', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [HIR_RETURN(HIR_ZERO)],
+          s2: [
+            HIR_FUNCTION_CALL({
+              functionExpression: HIR_NAME('tailRec'),
+              functionArguments: [HIR_VARIABLE('n')],
+              returnCollector: 'collector',
+            }),
+            HIR_RETURN(HIR_VARIABLE('collector')),
+          ],
+        }),
+      ],
+    })
+  ).toEqual({
+    name: 'tailRec',
+    parameters: ['n'],
+    hasReturn: true,
+    body: [
+      HIR_WHILE_TRUE([
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [HIR_RETURN(HIR_ZERO)],
+          s2: [
+            HIR_LET({
+              name: '_tailRecTransformationArgument0',
+              assignedExpression: HIR_VARIABLE('n'),
+            }),
+            HIR_LET({
+              name: 'n',
+              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+            }),
+          ],
+        }),
+      ]),
+    ],
+  });
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction 1-level no transform test', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [HIR_RETURN(HIR_ZERO)],
+          s2: [HIR_RETURN(HIR_ZERO)],
+        }),
+      ],
+    })
+  ).toBeNull();
+});
+
+it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test', () => {
+  expect(
+    performTailRecursiveCallTransformationOnHighIRFunction({
+      name: 'tailRec',
+      parameters: ['n'],
+      hasReturn: true,
+      body: [
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [
+            HIR_IF_ELSE({
+              booleanExpression: HIR_ONE,
+              s1: [
+                HIR_IF_ELSE({
+                  booleanExpression: HIR_ONE,
+                  s1: [
+                    HIR_FUNCTION_CALL({
+                      functionExpression: HIR_NAME('tailRec'),
+                      functionArguments: [HIR_VARIABLE('n')],
+                      returnCollector: 'collector',
+                    }),
+                    HIR_RETURN(HIR_VARIABLE('collector')),
+                  ],
+                  s2: [HIR_RETURN(HIR_ZERO)],
+                }),
+              ],
+              s2: [HIR_RETURN(HIR_ZERO)],
+            }),
+          ],
+          s2: [HIR_RETURN(HIR_ZERO)],
+        }),
+      ],
+    })
+  ).toEqual({
+    name: 'tailRec',
+    parameters: ['n'],
+    hasReturn: true,
+    body: [
+      HIR_WHILE_TRUE([
+        HIR_IF_ELSE({
+          booleanExpression: HIR_ONE,
+          s1: [
+            HIR_IF_ELSE({
+              booleanExpression: HIR_ONE,
+              s1: [
+                HIR_IF_ELSE({
+                  booleanExpression: HIR_ONE,
+                  s1: [
+                    HIR_LET({
+                      name: '_tailRecTransformationArgument0',
+                      assignedExpression: HIR_VARIABLE('n'),
+                    }),
+                    HIR_LET({
+                      name: 'n',
+                      assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+                    }),
+                  ],
+                  s2: [HIR_RETURN(HIR_ZERO)],
+                }),
+              ],
+              s2: [HIR_RETURN(HIR_ZERO)],
+            }),
+          ],
+          s2: [HIR_RETURN(HIR_ZERO)],
+        }),
+      ]),
+    ],
+  });
+});

--- a/samlang-core/src/compiler/hir/hir-move-return-coalescing.ts
+++ b/samlang-core/src/compiler/hir/hir-move-return-coalescing.ts
@@ -116,20 +116,18 @@ const coalesceMoveAndReturnWithForHighIRStatementsWithKnownReturnedVariable = (
  */
 const coalesceMoveAndReturnWithForHighIRStatements = (
   statements: readonly HighIRStatement[]
-): readonly HighIRStatement[] => {
-  if (statements.length === 0) return statements;
+): readonly HighIRStatement[] | null => {
+  if (statements.length === 0) return null;
   const lastStatement = statements[statements.length - 1];
-  if (lastStatement.__type__ !== 'HighIRReturnStatement') return statements;
+  if (lastStatement.__type__ !== 'HighIRReturnStatement') return null;
   // If the last statement is return, then it must be the only return.
   // This is guaranteed by the implementation of HIR compiler.
   const returnedExpression = lastStatement.expression;
-  if (returnedExpression.__type__ !== 'HighIRVariableExpression') return statements;
-  return (
-    coalesceMoveAndReturnWithForHighIRStatementsWithKnownReturnedVariable(
-      statements,
-      statements.length - 1,
-      [returnedExpression.name]
-    ) ?? statements
+  if (returnedExpression.__type__ !== 'HighIRVariableExpression') return null;
+  return coalesceMoveAndReturnWithForHighIRStatementsWithKnownReturnedVariable(
+    statements,
+    statements.length - 1,
+    [returnedExpression.name]
   );
 };
 

--- a/samlang-core/src/compiler/hir/hir-tail-recursion-transformation-hir.ts
+++ b/samlang-core/src/compiler/hir/hir-tail-recursion-transformation-hir.ts
@@ -1,0 +1,91 @@
+import {
+  HighIRStatement,
+  HIR_VARIABLE,
+  HIR_LET,
+  HIR_IF_ELSE,
+  HIR_WHILE_TRUE,
+} from '../../ast/hir/hir-expressions';
+import type { HighIRFunction } from '../../ast/hir/hir-toplevel';
+import coalesceMoveAndReturnWithForHighIRStatements from './hir-move-return-coalescing';
+
+const performTailRecursiveCallTransformationOnLinearStatements = (
+  highIRFunction: HighIRFunction,
+  statements: readonly HighIRStatement[]
+): readonly HighIRStatement[] | null => {
+  const returnStatement = statements[statements.length - 1];
+  const functionCallStatement = statements[statements.length - 2];
+  if (
+    returnStatement == null ||
+    functionCallStatement == null ||
+    returnStatement.__type__ !== 'HighIRReturnStatement' ||
+    functionCallStatement.__type__ !== 'HighIRFunctionCallStatement'
+  ) {
+    return null;
+  }
+  const { functionExpression, functionArguments, returnCollector } = functionCallStatement;
+  if (
+    functionExpression.__type__ !== 'HighIRNameExpression' ||
+    returnStatement.expression.__type__ !== 'HighIRVariableExpression' ||
+    returnCollector !== returnStatement.expression.name ||
+    functionExpression.name !== highIRFunction.name
+  ) {
+    return null;
+  }
+  return [
+    ...statements.slice(0, statements.length - 2),
+    ...functionArguments.map((functionArgument, i) =>
+      HIR_LET({ name: `_tailRecTransformationArgument${i}`, assignedExpression: functionArgument })
+    ),
+    ...highIRFunction.parameters.map((name, i) =>
+      HIR_LET({ name, assignedExpression: HIR_VARIABLE(`_tailRecTransformationArgument${i}`) })
+    ),
+  ];
+};
+
+const performTailRecursiveCallTransformationOnIfElseEndedStatements = (
+  highIRFunction: HighIRFunction,
+  statements: readonly HighIRStatement[]
+): readonly HighIRStatement[] | null => {
+  const lastStatement = statements[statements.length - 1];
+  if (lastStatement == null || lastStatement.__type__ !== 'HighIRIfElseStatement') return null;
+
+  const s1 = recursivelyPerformTailRecursiveCallTransformationOnStatements(
+    highIRFunction,
+    lastStatement.s1
+  );
+  const s2 = recursivelyPerformTailRecursiveCallTransformationOnStatements(
+    highIRFunction,
+    lastStatement.s2
+  );
+  if (s1 == null && s2 == null) return null;
+  return [
+    ...statements.slice(0, statements.length - 1),
+    HIR_IF_ELSE({
+      booleanExpression: lastStatement.booleanExpression,
+      s1: s1 ?? lastStatement.s1,
+      s2: s2 ?? lastStatement.s2,
+    }),
+  ];
+};
+
+const recursivelyPerformTailRecursiveCallTransformationOnStatements = (
+  highIRFunction: HighIRFunction,
+  statements: readonly HighIRStatement[]
+): readonly HighIRStatement[] | null =>
+  performTailRecursiveCallTransformationOnLinearStatements(highIRFunction, statements) ??
+  performTailRecursiveCallTransformationOnIfElseEndedStatements(highIRFunction, statements);
+
+const performTailRecursiveCallTransformationOnHighIRFunction = (
+  highIRFunction: HighIRFunction
+): HighIRFunction | null => {
+  const moveReturnCoalescedStatements =
+    coalesceMoveAndReturnWithForHighIRStatements(highIRFunction.body) ?? highIRFunction.body;
+  const potentialRewrittenStatements = recursivelyPerformTailRecursiveCallTransformationOnStatements(
+    highIRFunction,
+    moveReturnCoalescedStatements
+  );
+  if (potentialRewrittenStatements == null) return null;
+  return { ...highIRFunction, body: [HIR_WHILE_TRUE(potentialRewrittenStatements)] };
+};
+
+export default performTailRecursiveCallTransformationOnHighIRFunction;


### PR DESCRIPTION
## Summary

Implement the tranformation with the help of coalesceMoveAndReturnWithForHighIRStatements. It's a strict improvement over the old tailrec optimization which can't handle deep if-else blocks.

## Test Plan

Added tests for linear flow, if-else and deep if-else test cases to test this transformation.