### PR TITLE
Support for builtin functions and entry module for JS printer

### DIFF
--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -35,6 +35,9 @@ it('compile hello world to JS integration test', () => {
   expect(highIRSourcesToJSString(hirSources)).toBe(
     `const _module_Test_class_Main_function_main = () => {var _t0 = ''.concat('Hello ', 'World!');;var _t1 = console.log(_t0); };`
   );
+  expect(highIRSourcesToJSString(hirSources, moduleReference)).toBe(
+    `const _module_Test_class_Main_function_main = () => {var _t0 = ''.concat('Hello ', 'World!');;var _t1 = console.log(_t0); };\n_module_Test_class_Main_function_main();`
+  );
 });
 
 it('HIR statements to JS string test', () => {

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -1,5 +1,10 @@
 import { ModuleReference, checkSources } from '../..';
-import { encodeBuiltinName } from '../../ast/common/name-encoder';
+import {
+  ENCODED_FUNCTION_NAME_STRING_CONCAT,
+  ENCODED_FUNCTION_NAME_PRINTLN,
+  ENCODED_FUNCTION_NAME_STRING_TO_INT,
+  ENCODED_FUNCTION_NAME_INT_TO_STRING,
+} from '../../ast/common/name-encoder';
 import {
   HIR_IF_ELSE,
   HIR_BINARY,
@@ -33,10 +38,16 @@ it('compile hello world to JS integration test', () => {
   const { checkedSources } = checkSources([[moduleReference, sourceCode]]);
   const hirSources = compileSamlangSourcesToHighIRSources(checkedSources);
   expect(highIRSourcesToJSString(hirSources)).toBe(
-    `const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };`
+    `const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;
+  const ${ENCODED_FUNCTION_NAME_PRINTLN} = (v) => console.log(v);
+  const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);
+  const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };`
   );
   expect(highIRSourcesToJSString(hirSources, moduleReference)).toBe(
-    `const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };\n_module_Test_class_Main_function_main();`
+    `const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;
+  const ${ENCODED_FUNCTION_NAME_PRINTLN} = (v) => console.log(v);
+  const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);
+  const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };\n_module_Test_class_Main_function_main();`
   );
 });
 
@@ -78,38 +89,38 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('Hello, world')],
-        functionExpression: HIR_NAME(encodeBuiltinName('println')),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_PRINTLN),
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = _builtin_println('Hello, world');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}('Hello, world');`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('5')],
-        functionExpression: HIR_NAME(encodeBuiltinName('stringToInt')),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_TO_INT),
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = BigInt('5');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}('5');`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_INT(BigInt(5))],
-        functionExpression: HIR_NAME(encodeBuiltinName('intToString')),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_INT_TO_STRING),
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = String(5);`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_INT_TO_STRING}(5);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('5'), HIR_STRING('4')],
-        functionExpression: HIR_NAME(encodeBuiltinName('stringConcat')),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_CONCAT),
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = _builtin_stringConcat('5', '4');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}('5', '4');`);
   expect(
     highIRStatementToString(
       HIR_LET({

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -33,10 +33,10 @@ it('compile hello world to JS integration test', () => {
   const { checkedSources } = checkSources([[moduleReference, sourceCode]]);
   const hirSources = compileSamlangSourcesToHighIRSources(checkedSources);
   expect(highIRSourcesToJSString(hirSources)).toBe(
-    `const _module_Test_class_Main_function_main = () => {var _t0 = ''.concat('Hello ', 'World!');;var _t1 = console.log(_t0); };`
+    `const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };`
   );
   expect(highIRSourcesToJSString(hirSources, moduleReference)).toBe(
-    `const _module_Test_class_Main_function_main = () => {var _t0 = ''.concat('Hello ', 'World!');;var _t1 = console.log(_t0); };\n_module_Test_class_Main_function_main();`
+    `const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\nconst _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };\n_module_Test_class_Main_function_main();`
   );
 });
 
@@ -77,12 +77,12 @@ it('HIR statements to JS string test', () => {
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
-        functionArguments: [HIR_STRING('Hello, '), HIR_STRING('world')],
+        functionArguments: [HIR_STRING('Hello, world')],
         functionExpression: HIR_NAME(encodeBuiltinName('println')),
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = console.log('Hello, ', 'world');`);
+  ).toBe(`var res = _builtin_println('Hello, world');`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -91,7 +91,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = parseInt('5');`);
+  ).toBe(`var res = BigInt('5');`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -109,7 +109,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = ''.concat('5', '4');`);
+  ).toBe(`var res = _builtin_stringConcat('5', '4');`);
   expect(
     highIRStatementToString(
       HIR_LET({

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -1,4 +1,5 @@
 import { ModuleReference, checkSources } from '../..';
+import { encodeBuiltinName } from '../../ast/common/name-encoder';
 import {
   HIR_IF_ELSE,
   HIR_BINARY,
@@ -32,7 +33,7 @@ it('compile hello world to JS integration test', () => {
   const { checkedSources } = checkSources([[moduleReference, sourceCode]]);
   const hirSources = compileSamlangSourcesToHighIRSources(checkedSources);
   expect(highIRSourcesToJSString(hirSources)).toBe(
-    `const _module_Test_class_Main_function_main = () => {var _t0 = _builtin_stringConcat('Hello ', 'World!');;var _t1 = _builtin_println(_t0); };`
+    `const _module_Test_class_Main_function_main = () => {var _t0 = ''.concat('Hello ', 'World!');;var _t1 = console.log(_t0); };`
   );
 });
 
@@ -70,6 +71,42 @@ it('HIR statements to JS string test', () => {
       })
     )
   ).toBe('var val = func();');
+  expect(
+    highIRStatementToString(
+      HIR_FUNCTION_CALL({
+        functionArguments: [HIR_STRING('Hello, '), HIR_STRING('world')],
+        functionExpression: HIR_NAME(encodeBuiltinName('println')),
+        returnCollector: 'res',
+      })
+    )
+  ).toBe(`var res = console.log('Hello, ', 'world');`);
+  expect(
+    highIRStatementToString(
+      HIR_FUNCTION_CALL({
+        functionArguments: [HIR_STRING('5')],
+        functionExpression: HIR_NAME(encodeBuiltinName('stringToInt')),
+        returnCollector: 'res',
+      })
+    )
+  ).toBe(`var res = parseInt('5');`);
+  expect(
+    highIRStatementToString(
+      HIR_FUNCTION_CALL({
+        functionArguments: [HIR_INT(BigInt(5))],
+        functionExpression: HIR_NAME(encodeBuiltinName('intToString')),
+        returnCollector: 'res',
+      })
+    )
+  ).toBe(`var res = String(5);`);
+  expect(
+    highIRStatementToString(
+      HIR_FUNCTION_CALL({
+        functionArguments: [HIR_STRING('5'), HIR_STRING('4')],
+        functionExpression: HIR_NAME(encodeBuiltinName('stringConcat')),
+        returnCollector: 'res',
+      })
+    )
+  ).toBe(`var res = ''.concat('5', '4');`);
   expect(
     highIRStatementToString(
       HIR_LET({

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -1,9 +1,10 @@
-import { Sources } from '..';
+import { Sources, ModuleReference } from '..';
 import {
   ENCODED_FUNCTION_NAME_INT_TO_STRING,
   ENCODED_FUNCTION_NAME_PRINTLN,
   ENCODED_FUNCTION_NAME_STRING_TO_INT,
   ENCODED_FUNCTION_NAME_STRING_CONCAT,
+  encodeMainFunctionName,
 } from '../ast/common/name-encoder';
 import {
   HighIRStatement,
@@ -95,10 +96,16 @@ export const highIRExpressionToString = (highIRExpression: HighIRExpression): st
   }
 };
 
-export const highIRSourcesToJSString = (sources: Sources<HighIRModule>): string => {
+export const highIRSourcesToJSString = (
+  sources: Sources<HighIRModule>,
+  entryModule?: ModuleReference
+): string => {
   let finalStr = '';
   sources.forEach((module) => {
     finalStr += `${module.functions.map((f) => highIRFunctionToString(f)).join(';\n')}`;
   });
+  if (entryModule) {
+    finalStr += `\n${encodeMainFunctionName(entryModule)}();`;
+  }
   return finalStr;
 };

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -28,30 +28,9 @@ export const highIRStatementToString = (highIRStatement: HighIRStatement): strin
     }
     case 'HighIRFunctionCallStatement': {
       const { functionArguments, functionExpression, returnCollector } = highIRStatement;
-      let functionName = highIRExpressionToString(functionExpression);
-      switch (functionName) {
-        case ENCODED_FUNCTION_NAME_INT_TO_STRING: {
-          functionName = 'String';
-          break;
-        }
-        case ENCODED_FUNCTION_NAME_PRINTLN: {
-          functionName = '_builtin_println';
-          break;
-        }
-        case ENCODED_FUNCTION_NAME_STRING_TO_INT: {
-          functionName = 'BigInt';
-          break;
-        }
-        case ENCODED_FUNCTION_NAME_STRING_CONCAT: {
-          functionName = '_builtin_stringConcat';
-          break;
-        }
-        default:
-          break;
-      }
-      return `var ${returnCollector} = ${functionName}(${functionArguments
-        .map((arg) => highIRExpressionToString(arg))
-        .join(', ')});`;
+      return `var ${returnCollector} = ${highIRExpressionToString(
+        functionExpression
+      )}(${functionArguments.map((arg) => highIRExpressionToString(arg)).join(', ')});`;
     }
     case 'HighIRLetDefinitionStatement': {
       const { name, assignedExpression } = highIRStatement;
@@ -100,8 +79,10 @@ export const highIRSourcesToJSString = (
   sources: Sources<HighIRModule>,
   entryModule?: ModuleReference
 ): string => {
-  let finalStr =
-    'const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\n';
+  let finalStr = `const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;
+  const ${ENCODED_FUNCTION_NAME_PRINTLN} = (v) => console.log(v);
+  const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);
+  const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);\n`;
   sources.forEach((module) => {
     finalStr += `${module.functions.map((f) => highIRFunctionToString(f)).join(';\n')}`;
   });

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -35,15 +35,15 @@ export const highIRStatementToString = (highIRStatement: HighIRStatement): strin
           break;
         }
         case ENCODED_FUNCTION_NAME_PRINTLN: {
-          functionName = 'console.log';
+          functionName = '_builtin_println';
           break;
         }
         case ENCODED_FUNCTION_NAME_STRING_TO_INT: {
-          functionName = 'parseInt';
+          functionName = 'BigInt';
           break;
         }
         case ENCODED_FUNCTION_NAME_STRING_CONCAT: {
-          functionName = "''.concat";
+          functionName = '_builtin_stringConcat';
           break;
         }
         default:
@@ -100,7 +100,8 @@ export const highIRSourcesToJSString = (
   sources: Sources<HighIRModule>,
   entryModule?: ModuleReference
 ): string => {
-  let finalStr = '';
+  let finalStr =
+    'const _builtin_stringConcat = (a, b) => a + b;\nconst _builtin_println = (v) => console.log(v);\n';
   sources.forEach((module) => {
     finalStr += `${module.functions.map((f) => highIRFunctionToString(f)).join(';\n')}`;
   });

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -1,5 +1,11 @@
 import { Sources } from '..';
 import {
+  ENCODED_FUNCTION_NAME_INT_TO_STRING,
+  ENCODED_FUNCTION_NAME_PRINTLN,
+  ENCODED_FUNCTION_NAME_STRING_TO_INT,
+  ENCODED_FUNCTION_NAME_STRING_CONCAT,
+} from '../ast/common/name-encoder';
+import {
   HighIRStatement,
   HighIRExpression,
   HighIRVariableExpression,
@@ -21,9 +27,30 @@ export const highIRStatementToString = (highIRStatement: HighIRStatement): strin
     }
     case 'HighIRFunctionCallStatement': {
       const { functionArguments, functionExpression, returnCollector } = highIRStatement;
-      return `var ${returnCollector} = ${highIRExpressionToString(
-        functionExpression
-      )}(${functionArguments.map((arg) => highIRExpressionToString(arg)).join(', ')});`;
+      let functionName = highIRExpressionToString(functionExpression);
+      switch (functionName) {
+        case ENCODED_FUNCTION_NAME_INT_TO_STRING: {
+          functionName = 'String';
+          break;
+        }
+        case ENCODED_FUNCTION_NAME_PRINTLN: {
+          functionName = 'console.log';
+          break;
+        }
+        case ENCODED_FUNCTION_NAME_STRING_TO_INT: {
+          functionName = 'parseInt';
+          break;
+        }
+        case ENCODED_FUNCTION_NAME_STRING_CONCAT: {
+          functionName = "''.concat";
+          break;
+        }
+        default:
+          break;
+      }
+      return `var ${returnCollector} = ${functionName}(${functionArguments
+        .map((arg) => highIRExpressionToString(arg))
+        .join(', ')});`;
     }
     case 'HighIRLetDefinitionStatement': {
       const { name, assignedExpression } = highIRStatement;


### PR DESCRIPTION
## Summary

This PR improves on the previous JS printer in #39 by adding support for outputing code for builtin functions like `stringConcat`, `println`, etc as well as adding support for an entry module so the outputted code is actually runnable. These are the first two tasks in #44 .

## Test Plan

👀 , `yarn test`, and potentially try running the outputted JS code to see that it works as expected.