### PR TITLE
Avoid printing parenthesis for binary expressions whenever possible

### DIFF
--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -64,7 +64,7 @@ it('HIR statements to JS string test', () => {
         s2: [HIR_RETURN(HIR_ZERO)],
       })
     )
-  ).toBe(`if ((5 == 5)) {return 0;} else {return 0;}`);
+  ).toBe(`if (5 == 5) {return 0;} else {return 0;}`);
   expect(
     highIRStatementToString(
       HIR_WHILE_TRUE([
@@ -177,5 +177,91 @@ it('HIR expression to JS string test', () => {
         e2: HIR_INT(BigInt(7)),
       })
     )
-  ).toBe('(7 != 7)');
+  ).toBe('7 != 7');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '+',
+        e1: HIR_INT(BigInt(7)),
+        e2: HIR_BINARY({
+          operator: '*',
+          e1: HIR_INT(BigInt(4)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('7 + 4 * 4');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '*',
+        e1: HIR_INT(BigInt(7)),
+        e2: HIR_BINARY({
+          operator: '+',
+          e1: HIR_INT(BigInt(4)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('7 * (4 + 4)');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '*',
+        e1: HIR_INT(BigInt(7)),
+        e2: HIR_BINARY({
+          operator: '*',
+          e1: HIR_INT(BigInt(4)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('7 * (4 * 4)');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '*',
+        e1: HIR_BINARY({
+          operator: '*',
+          e1: HIR_INT(BigInt(1)),
+          e2: HIR_INT(BigInt(2)),
+        }),
+        e2: HIR_BINARY({
+          operator: '*',
+          e1: HIR_INT(BigInt(3)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('(1 * 2) * (3 * 4)');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '+',
+        e1: HIR_BINARY({
+          operator: '-',
+          e1: HIR_INT(BigInt(1)),
+          e2: HIR_INT(BigInt(2)),
+        }),
+        e2: HIR_BINARY({
+          operator: '%',
+          e1: HIR_INT(BigInt(3)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('(1 - 2) + 3 % 4');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '+',
+        e1: HIR_NAME('somevar'),
+        e2: HIR_BINARY({
+          operator: '-',
+          e1: HIR_INT(BigInt(3)),
+          e2: HIR_INT(BigInt(4)),
+        }),
+      })
+    )
+  ).toBe('somevar + (3 - 4)');
 });

--- a/samlang-core/src/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/src/printer/__tests__/printer-js.test.ts
@@ -167,6 +167,29 @@ it('HIR expression to JS string test', () => {
       })
     )
   ).toBe(`samlang[3]`);
+  expect(
+    highIRExpressionToString(
+      HIR_INDEX_ACCESS({
+        expression: HIR_INDEX_ACCESS({
+          expression: HIR_VARIABLE('a'),
+          index: 4,
+        }),
+        index: 3,
+      })
+    )
+  ).toBe('a[4][3]');
+  expect(
+    highIRExpressionToString(
+      HIR_INDEX_ACCESS({
+        expression: HIR_BINARY({
+          operator: '+',
+          e1: HIR_STRING('a'),
+          e2: HIR_STRING('b'),
+        }),
+        index: 0,
+      })
+    )
+  ).toBe("('a' + 'b')[0]");
   expect(highIRExpressionToString(HIR_VARIABLE('ts'))).toBe('ts');
   expect(highIRExpressionToString(HIR_NAME('key'))).toBe('key');
   expect(
@@ -264,4 +287,16 @@ it('HIR expression to JS string test', () => {
       })
     )
   ).toBe('somevar + (3 - 4)');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
+        operator: '+',
+        e1: HIR_INDEX_ACCESS({
+          expression: HIR_VARIABLE('a'),
+          index: 2,
+        }),
+        e2: HIR_INT(BigInt(1)),
+      })
+    )
+  ).toBe('a[2] + 1');
 });

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -63,7 +63,13 @@ export const highIRExpressionToString = (highIRExpression: HighIRExpression): st
       return `'${highIRExpression.value}'`;
     case 'HighIRIndexAccessExpression': {
       const { expression, index } = highIRExpression;
-      return `${highIRExpressionToString(expression)}[${index}]`;
+      const addParentheses = (subExpression: HighIRExpression): string => {
+        if (subExpression.__type__ === 'HighIRBinaryExpression') {
+          return `(${highIRExpressionToString(subExpression)})`;
+        }
+        return highIRExpressionToString(subExpression);
+      };
+      return `${addParentheses(expression)}[${index}]`;
     }
     case 'HighIRVariableExpression':
       return (highIRExpression as HighIRVariableExpression).name;

--- a/samlang-core/src/printer/printer-js.ts
+++ b/samlang-core/src/printer/printer-js.ts
@@ -1,4 +1,5 @@
 import { Sources, ModuleReference } from '..';
+import { binaryOperatorSymbolTable } from '../ast/common/binary-operators';
 import {
   ENCODED_FUNCTION_NAME_INT_TO_STRING,
   ENCODED_FUNCTION_NAME_PRINTLN,
@@ -11,10 +12,8 @@ import {
   HighIRExpression,
   HighIRVariableExpression,
   HighIRNameExpression,
-  HighIRBinaryExpression,
 } from '../ast/hir/hir-expressions';
 import { HighIRFunction, HighIRModule } from '../ast/hir/hir-toplevel';
-import { binaryOperatorSymbolTable } from '../ast/common/binary-operators';
 
 export const highIRStatementToString = (highIRStatement: HighIRStatement): string => {
   switch (highIRStatement.__type__) {
@@ -73,7 +72,7 @@ export const highIRExpressionToString = (highIRExpression: HighIRExpression): st
     case 'HighIRBinaryExpression': {
       const { e1, e2, operator } = highIRExpression;
       const addParentheses = (subExpression: HighIRExpression): string => {
-        if (subExpression.__type__ == 'HighIRBinaryExpression') {
+        if (subExpression.__type__ === 'HighIRBinaryExpression') {
           const p1 = binaryOperatorSymbolTable[operator]?.precedence;
           const p2 = binaryOperatorSymbolTable[subExpression.operator]?.precedence;
           if (p1 != null && p2 != null && p2 >= p1) {


### PR DESCRIPTION
## Summary

When we print `(subexpression) + (subexpression)`, we only want to print the parenthesis around the subexpressions if it is a binary expression and the operator for that subexpression has a greater or equal precedence to the operator of the whole outside expression. E.g., `1 * (3 + 4)`.

## Test Plan

👀 , `yarn test`, and review some PEMDAS 🔢

(Aight commit history is a little weird because i tried to do amend commit and things didn't exactly work out 😅)