### PR TITLE
[ci] Separate out compile job to speed up CI for average cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,23 @@ jobs:
         run: yarn lint
       - name: Check Format
         run: yarn format:check
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v2-beta
+      - uses: actions/cache@v2
+        with:
+          path: |
+            .yarn/cache
+            .pnp.js
+          key: yarn-berry-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-berry-
+      - name: Yarn Install
+        run: yarn
+      - name: Compile
+        run: yarn compile
   test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
     "lint": "eslint . --cache",
     "format": "prettier --write '**/*.{ts,js}'",
     "format:check": "prettier --check '**/*.{ts,js}'",
-    "build": "yarn workspaces foreach -t run build",
-    "codegen": "yarn workspaces foreach -t run codegen",
+    "compile": "yarn workspaces foreach -t run compile",
     "bundle": "yarn workspaces foreach -t run bundle",
     "test": "jest --coverage",
     "test:single": "jest -t",
-    "postinstall": "yarn codegen && yarn build"
+    "postinstall": "yarn workspaces foreach -t run codegen"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",

--- a/samlang-cli/package.json
+++ b/samlang-cli/package.json
@@ -2,10 +2,8 @@
   "name": "@dev-sam/samlang-cli",
   "version": "0.0.1",
   "license": "AGPLv3",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc --incremental",
+    "compile": "tsc --incremental",
     "bundle": "pnpify ncc build src/index.ts -o build -m --transpile-only"
   },
   "bin": {

--- a/samlang-core/package.json
+++ b/samlang-core/package.json
@@ -2,10 +2,8 @@
   "name": "@dev-sam/samlang-core",
   "version": "0.0.1",
   "license": "AGPLv3",
-  "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsc --incremental --noEmit",
+    "compile": "tsc --incremental --noEmit",
     "codegen": "yarn antlr4ts -o parser/generated -visitor -no-listener PL.g4 && node suppress-type-errors.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

After changes in the last diff, type checking becomes slightly longer, but it's no longer a prereq for any other jobs. This diff completes the job separation to speed up CI.

## Test Plan

CI