### PR TITLE
[compiler] Move dead function elimination to source->hir compiler

### DIFF
--- a/samlang-core/__tests__/compiler-integration-test.test.ts
+++ b/samlang-core/__tests__/compiler-integration-test.test.ts
@@ -3,7 +3,7 @@ import { ModuleReference } from '../ast/common-nodes';
 import { MidIRCompilationUnit, midIRCompilationUnitToString } from '../ast/mir-nodes';
 import {
   compileSamlangSourcesToHighIRSources,
-  compileHighIrSourcesToMidIRCompilationUnits,
+  compileHighIrModuleToMidIRCompilationUnit,
   generateAssemblyInstructionsFromMidIRCompilationUnit,
 } from '../compiler';
 import interpretAssemblyProgram from '../interpreter/assembly-interpreter';
@@ -41,13 +41,12 @@ if (process.env.CI) {
 const mirBaseTestCases: readonly MidIRTestCase[] = (() => {
   expect(compileTimeErrors).toEqual([]);
 
-  const mirSources = compileHighIrSourcesToMidIRCompilationUnits(
-    compileSamlangSourcesToHighIRSources(checkedSources)
-  );
+  const hirSources = compileSamlangSourcesToHighIRSources(checkedSources);
 
   return runnableSamlangProgramTestCases.map(({ testCaseName, expectedStandardOut }) => {
-    const compilationUnit = mirSources.get(new ModuleReference([testCaseName]));
-    assertNotNull(compilationUnit);
+    const highIRModule = hirSources.get(new ModuleReference([testCaseName]));
+    assertNotNull(highIRModule);
+    const compilationUnit = compileHighIrModuleToMidIRCompilationUnit(highIRModule);
     return {
       testCaseName,
       expectedStandardOut,

--- a/samlang-core/analysis/__tests__/used-name-analysis.test.ts
+++ b/samlang-core/analysis/__tests__/used-name-analysis.test.ts
@@ -1,59 +1,80 @@
 import { ENCODED_COMPILED_PROGRAM_MAIN } from '../../ast/common-names';
 import {
-  MIR_ZERO,
-  MIR_NAME,
-  MIR_TEMP,
-  MIR_OP,
-  MIR_IMMUTABLE_MEM,
-  MIR_MOVE_TEMP,
-  MIR_CALL_FUNCTION,
-  MIR_MOVE_IMMUTABLE_MEM,
-  MIR_JUMP,
-  MIR_RETURN,
-  MIR_CJUMP_FALLTHROUGH,
-} from '../../ast/mir-nodes';
+  HIR_ZERO,
+  HIR_NAME,
+  HIR_FUNCTION_CALL,
+  HIR_LET,
+  HIR_STRUCT_INITIALIZATION,
+  HIR_INDEX_ACCESS,
+  HIR_RETURN,
+  HIR_WHILE_TRUE,
+  HIR_IF_ELSE,
+  HIR_BINARY,
+} from '../../ast/hir-expressions';
 import analyzeUsedFunctionNames from '../used-name-analysis';
 
 it('analyzeUsedFunctionNames test', () => {
   expect(
     Array.from(
       analyzeUsedFunctionNames({
-        globalVariables: [],
         functions: [
           {
-            functionName: ENCODED_COMPILED_PROGRAM_MAIN,
-            argumentNames: [],
+            name: ENCODED_COMPILED_PROGRAM_MAIN,
+            parameters: [],
             hasReturn: false,
-            mainBodyStatements: [MIR_CALL_FUNCTION('foo', [])],
-          },
-          {
-            functionName: 'foo',
-            argumentNames: [],
-            hasReturn: false,
-            mainBodyStatements: [
-              MIR_MOVE_TEMP(MIR_TEMP(''), MIR_ZERO),
-              MIR_MOVE_IMMUTABLE_MEM(
-                MIR_IMMUTABLE_MEM(MIR_NAME('bar')),
-                MIR_IMMUTABLE_MEM(MIR_NAME('bar'))
-              ),
-              MIR_JUMP(''),
-              MIR_CALL_FUNCTION('baz', [MIR_NAME('haha')]),
-              MIR_RETURN(MIR_NAME('bar')),
-              MIR_RETURN(),
-              MIR_CJUMP_FALLTHROUGH(MIR_OP('+', MIR_NAME('foo'), MIR_NAME('bar')), ''),
+            body: [
+              HIR_FUNCTION_CALL({ functionExpression: HIR_NAME('foo'), functionArguments: [] }),
             ],
           },
           {
-            functionName: 'bar',
-            argumentNames: [],
+            name: 'foo',
+            parameters: [],
             hasReturn: false,
-            mainBodyStatements: [MIR_CALL_FUNCTION('foo', [])],
+            body: [
+              HIR_LET({ name: '', assignedExpression: HIR_ZERO }),
+              HIR_STRUCT_INITIALIZATION({
+                structVariableName: '',
+                expressionList: [HIR_INDEX_ACCESS({ expression: HIR_NAME('bar'), index: 0 })],
+              }),
+              HIR_FUNCTION_CALL({
+                functionExpression: HIR_NAME('baz'),
+                functionArguments: [HIR_NAME('haha')],
+              }),
+              HIR_RETURN(HIR_NAME('bar')),
+              HIR_WHILE_TRUE([
+                HIR_IF_ELSE({
+                  booleanExpression: HIR_ZERO,
+                  s1: [
+                    HIR_LET({
+                      name: '',
+                      assignedExpression: HIR_BINARY({
+                        operator: '+',
+                        e1: HIR_NAME('foo'),
+                        e2: HIR_NAME('bar'),
+                      }),
+                    }),
+                  ],
+                  s2: [HIR_LET({ name: '', assignedExpression: HIR_ZERO })],
+                }),
+              ]),
+            ],
           },
           {
-            functionName: 'baz',
-            argumentNames: [],
+            name: 'bar',
+            parameters: [],
             hasReturn: false,
-            mainBodyStatements: [],
+            body: [
+              HIR_FUNCTION_CALL({
+                functionExpression: HIR_NAME('foo'),
+                functionArguments: [],
+              }),
+            ],
+          },
+          {
+            name: 'baz',
+            parameters: [],
+            hasReturn: false,
+            body: [],
           },
         ],
       }).values()

--- a/samlang-core/compiler/__tests__/mir-toplevel-lowering.test.ts
+++ b/samlang-core/compiler/__tests__/mir-toplevel-lowering.test.ts
@@ -1,59 +1,34 @@
-import { ModuleReference } from '../../ast/common-nodes';
 import { HIR_RETURN, HIR_STRING } from '../../ast/hir-expressions';
 import { midIRCompilationUnitToString } from '../../ast/mir-nodes';
-import { mapOf } from '../../util/collections';
-import { assertNotNull } from '../../util/type-assertions';
-import {
-  compileHighIrSourcesToMidIRCompilationUnits,
-  compileHighIrSourcesToMidIRCompilationUnit,
-} from '../mir-toplevel-lowering';
+import compileHighIrModuleToMidIRCompilationUnit from '../mir-toplevel-lowering';
 
-it('compileHighIrSourcesToMidIRCompilationUnit empty sources test', () => {
-  expect(midIRCompilationUnitToString(compileHighIrSourcesToMidIRCompilationUnit(mapOf()))).toBe(
-    '\n'
-  );
-});
-
-it('compileHighIrSourcesToMidIRCompilationUnit dummy source test', () => {
+it('compileHighIrModuleToMidIRCompilationUnit dummy source test', () => {
   expect(
-    midIRCompilationUnitToString(
-      compileHighIrSourcesToMidIRCompilationUnit(mapOf([ModuleReference.ROOT, { functions: [] }]))
-    )
+    midIRCompilationUnitToString(compileHighIrModuleToMidIRCompilationUnit({ functions: [] }))
   ).toBe('\n');
 });
 
-const commonSources = mapOf(
-  [
-    ModuleReference.ROOT,
-    {
-      functions: [
-        {
-          name: '_module__class_Main_function_main',
-          parameters: ['foo', 'bar', 'baz'],
-          hasReturn: true,
-          body: [HIR_RETURN(HIR_STRING('hello world'))],
-        },
-      ],
-    },
-  ],
-  [
-    new ModuleReference(['foo']),
-    {
-      functions: [
-        {
-          name: 'fooBar',
-          parameters: ['foo', 'bar', 'baz'],
-          hasReturn: true,
-          body: [HIR_RETURN(HIR_STRING('hello world'))],
-        },
-      ],
-    },
-  ]
-);
-
-it('compileHighIrSourcesToMidIRCompilationUnit full integration test', () => {
-  expect(midIRCompilationUnitToString(compileHighIrSourcesToMidIRCompilationUnit(commonSources)))
-    .toBe(`const GLOBAL_STRING_0 = "hello world";
+it('compileHighIrModuleToMidIRCompilationUnit full integration test', () => {
+  expect(
+    midIRCompilationUnitToString(
+      compileHighIrModuleToMidIRCompilationUnit({
+        functions: [
+          {
+            name: '_module__class_Main_function_main',
+            parameters: ['foo', 'bar', 'baz'],
+            hasReturn: true,
+            body: [HIR_RETURN(HIR_STRING('hello world'))],
+          },
+          {
+            name: 'fooBar',
+            parameters: ['foo', 'bar', 'baz'],
+            hasReturn: true,
+            body: [HIR_RETURN(HIR_STRING('hello world'))],
+          },
+        ],
+      })
+    )
+  ).toBe(`const GLOBAL_STRING_0 = "hello world";
 
 function _module__class_Main_function_main {
   let _foo = _ARG0;
@@ -69,29 +44,6 @@ function fooBar {
   let _baz = _ARG2;
 
   return (GLOBAL_STRING_0 + 8);
-}
-`);
-});
-
-it('compileHighIrSourcesToMidIRCompilationUnits test', () => {
-  const result = compileHighIrSourcesToMidIRCompilationUnits(commonSources);
-  expect(result.size).toBe(1);
-  const root = result.get(ModuleReference.ROOT);
-  assertNotNull(root);
-  expect(midIRCompilationUnitToString(root)).toBe(`const GLOBAL_STRING_0 = "hello world";
-
-function _module__class_Main_function_main {
-  let _foo = _ARG0;
-  let _bar = _ARG1;
-  let _baz = _ARG2;
-
-  return (GLOBAL_STRING_0 + 8);
-}
-
-function _compiled_program_main {
-
-  _module__class_Main_function_main();
-  return;
 }
 `);
 });

--- a/samlang-core/compiler/index.ts
+++ b/samlang-core/compiler/index.ts
@@ -1,9 +1,9 @@
 import generateAssemblyInstructionsFromMidIRCompilationUnit from './asm-toplevel-generator';
 import compileSamlangSourcesToHighIRSources from './hir-toplevel-lowering';
-import { compileHighIrSourcesToMidIRCompilationUnits } from './mir-toplevel-lowering';
+import compileHighIrModuleToMidIRCompilationUnit from './mir-toplevel-lowering';
 
 export {
   compileSamlangSourcesToHighIRSources,
-  compileHighIrSourcesToMidIRCompilationUnits,
+  compileHighIrModuleToMidIRCompilationUnit,
   generateAssemblyInstructionsFromMidIRCompilationUnit,
 };

--- a/samlang-core/compiler/mir-toplevel-lowering.ts
+++ b/samlang-core/compiler/mir-toplevel-lowering.ts
@@ -1,87 +1,46 @@
-import { ENCODED_COMPILED_PROGRAM_MAIN, encodeMainFunctionName } from '../ast/common-names';
-import type { ModuleReference, GlobalVariable, Sources } from '../ast/common-nodes';
+import type { GlobalVariable } from '../ast/common-nodes';
 import type { HighIRModule } from '../ast/hir-toplevel';
-import {
-  MidIRCompilationUnit,
-  MidIRFunction,
-  MIR_CALL_FUNCTION,
-  MIR_RETURN,
-} from '../ast/mir-nodes';
-import {
-  optimizeIrWithSimpleOptimization,
-  optimizeIRWithUnusedNameElimination,
-} from '../optimization/simple-optimizations';
-import { hashMapOf } from '../util/collections';
+import { MidIRCompilationUnit, MidIRFunction, MIR_RETURN } from '../ast/mir-nodes';
+import { optimizeIrWithSimpleOptimization } from '../optimization/simple-optimizations';
 import createMidIRBasicBlocks from './mir-basic-block';
 import emitCanonicalMidIRStatementsFromReorderedBasicBlocks from './mir-basic-block-optimized-emitter';
 import reorderMidIRBasicBlocksToMaximizeLongestNoJumpPath from './mir-basic-block-reorder';
 import midIRTranslateStatementsAndCollectGlobalStrings from './mir-lowering-translator';
 import MidIRResourceAllocator from './mir-resource-allocator';
 
-export const compileHighIrSourcesToMidIRCompilationUnit = (
-  sources: Sources<HighIRModule>
+const compileHighIrModuleToMidIRCompilationUnit = (
+  highIRModule: HighIRModule
 ): MidIRCompilationUnit => {
   const allocator = new MidIRResourceAllocator();
   const globalVariables = new Map<string, GlobalVariable>();
   const functions: MidIRFunction[] = [];
-  sources.forEach(({ functions: highIRFunctions }) =>
-    highIRFunctions.forEach((highIRFunction) => {
-      const {
-        loweredStatements,
-        stringGlobalVariables,
-      } = midIRTranslateStatementsAndCollectGlobalStrings(
-        allocator,
-        highIRFunction.name,
-        highIRFunction.body
-      );
-      stringGlobalVariables.forEach((it) => globalVariables.set(it.name, it));
-      functions.push({
-        functionName: highIRFunction.name,
-        argumentNames: highIRFunction.parameters.map((it) => `_${it}`),
-        mainBodyStatements: optimizeIrWithSimpleOptimization(
-          emitCanonicalMidIRStatementsFromReorderedBasicBlocks(
-            reorderMidIRBasicBlocksToMaximizeLongestNoJumpPath(
-              createMidIRBasicBlocks(allocator, highIRFunction.name, [
-                ...loweredStatements,
-                MIR_RETURN(),
-              ])
-            )
+  highIRModule.functions.forEach((highIRFunction) => {
+    const {
+      loweredStatements,
+      stringGlobalVariables,
+    } = midIRTranslateStatementsAndCollectGlobalStrings(
+      allocator,
+      highIRFunction.name,
+      highIRFunction.body
+    );
+    stringGlobalVariables.forEach((it) => globalVariables.set(it.name, it));
+    functions.push({
+      functionName: highIRFunction.name,
+      argumentNames: highIRFunction.parameters.map((it) => `_${it}`),
+      mainBodyStatements: optimizeIrWithSimpleOptimization(
+        emitCanonicalMidIRStatementsFromReorderedBasicBlocks(
+          reorderMidIRBasicBlocksToMaximizeLongestNoJumpPath(
+            createMidIRBasicBlocks(allocator, highIRFunction.name, [
+              ...loweredStatements,
+              MIR_RETURN(),
+            ])
           )
-        ),
-        hasReturn: highIRFunction.hasReturn,
-      });
-    })
-  );
+        )
+      ),
+      hasReturn: highIRFunction.hasReturn,
+    });
+  });
   return { globalVariables: Array.from(globalVariables.values()), functions };
 };
 
-const getMidIRMainFunction = (entryModuleReference: ModuleReference): MidIRFunction => ({
-  functionName: ENCODED_COMPILED_PROGRAM_MAIN,
-  argumentNames: [],
-  hasReturn: false,
-  mainBodyStatements: [
-    MIR_CALL_FUNCTION(encodeMainFunctionName(entryModuleReference), []),
-    MIR_RETURN(),
-  ],
-});
-
-export const compileHighIrSourcesToMidIRCompilationUnits = (
-  sources: Sources<HighIRModule>
-): Sources<MidIRCompilationUnit> => {
-  const compilationUnitWithoutMain = compileHighIrSourcesToMidIRCompilationUnit(sources);
-  const midIRCompilationUnitSources = hashMapOf<ModuleReference, MidIRCompilationUnit>();
-  sources.forEach((highIRModule, moduleReference) => {
-    const entryPointFunctionName = encodeMainFunctionName(moduleReference);
-    if (!highIRModule.functions.some(({ name }) => name === entryPointFunctionName)) {
-      return;
-    }
-    midIRCompilationUnitSources.set(
-      moduleReference,
-      optimizeIRWithUnusedNameElimination({
-        ...compilationUnitWithoutMain,
-        functions: [...compilationUnitWithoutMain.functions, getMidIRMainFunction(moduleReference)],
-      })
-    );
-  });
-  return midIRCompilationUnitSources;
-};
+export default compileHighIrModuleToMidIRCompilationUnit;

--- a/samlang-core/optimization/__tests__/simple-optimizations.test.ts
+++ b/samlang-core/optimization/__tests__/simple-optimizations.test.ts
@@ -21,7 +21,6 @@ import {
 import {
   optimizeIrWithSimpleOptimization,
   optimizeAssemblyWithSimpleOptimization,
-  optimizeIRWithUnusedNameElimination,
 } from '../simple-optimizations';
 
 const optimizeIRAndConvertToString = (midIRStatements: readonly MidIRStatement[]): string =>
@@ -136,24 +135,6 @@ c = d;`);
 a = b;
 c = d;
 goto C;`);
-});
-
-it('optimizeIRWithUnusedNameElimination test', () => {
-  expect(
-    optimizeIRWithUnusedNameElimination({
-      globalVariables: [
-        { name: 'v1', content: '' },
-        { name: 'v2', content: 'v2' },
-      ],
-      functions: [
-        { functionName: 'f1', argumentNames: [], hasReturn: false, mainBodyStatements: [] },
-        { functionName: 'f2', argumentNames: [], hasReturn: false, mainBodyStatements: [] },
-      ],
-    })
-  ).toEqual({
-    globalVariables: [],
-    functions: [],
-  });
 });
 
 it('optimizeAssemblyWithSimpleOptimization test', () => {

--- a/samlang-core/optimization/simple-optimizations.ts
+++ b/samlang-core/optimization/simple-optimizations.ts
@@ -1,12 +1,6 @@
 import ControlFlowGraph from '../analysis/control-flow-graph';
-import analyzeUsedFunctionNames from '../analysis/used-name-analysis';
 import type { AssemblyInstruction } from '../ast/asm-instructions';
-import {
-  MidIRCompilationUnit,
-  MidIRStatement,
-  MIR_JUMP,
-  MIR_CJUMP_FALLTHROUGH,
-} from '../ast/mir-nodes';
+import { MidIRStatement, MIR_JUMP, MIR_CJUMP_FALLTHROUGH } from '../ast/mir-nodes';
 import { isNotNull } from '../util/type-assertions';
 
 const pipe = <E>(element: E, ...functions: readonly ((element: E) => E)[]): E =>
@@ -199,16 +193,6 @@ export const optimizeIrWithSimpleOptimization = (
     withoutImmediateJumpInIr,
     withoutUnusedLabelInIr
   );
-
-export const optimizeIRWithUnusedNameElimination = (
-  compilationUnit: MidIRCompilationUnit
-): MidIRCompilationUnit => {
-  const usedNames = analyzeUsedFunctionNames(compilationUnit);
-  return {
-    globalVariables: compilationUnit.globalVariables.filter((it) => usedNames.has(it.name)),
-    functions: compilationUnit.functions.filter((it) => usedNames.has(it.functionName)),
-  };
-};
 
 const withoutUnreachableAssemblyCode = (
   instructions: readonly AssemblyInstruction[]

--- a/samlang-core/printer/printer-js.ts
+++ b/samlang-core/printer/printer-js.ts
@@ -1,11 +1,10 @@
-import { Sources, ModuleReference } from '..';
 import {
   ENCODED_FUNCTION_NAME_INT_TO_STRING,
   ENCODED_FUNCTION_NAME_PRINTLN,
   ENCODED_FUNCTION_NAME_STRING_TO_INT,
   ENCODED_FUNCTION_NAME_STRING_CONCAT,
-  encodeMainFunctionName,
   ENCODED_FUNCTION_NAME_THROW,
+  ENCODED_COMPILED_PROGRAM_MAIN,
 } from '../ast/common-names';
 import { binaryOperatorSymbolTable } from '../ast/common-operators';
 import { HighIRStatement, HighIRExpression } from '../ast/hir-expressions';
@@ -167,10 +166,7 @@ export const highIRFunctionToString = (highIRFunction: HighIRFunction): string =
     createPrettierDocumentFromHighIRFunction(highIRFunction)
   );
 
-const createPrettierDocumentFromHighIRSources = (
-  sources: Sources<HighIRModule>,
-  entryModule: ModuleReference | undefined
-): PrettierDocument => {
+const createPrettierDocumentFromHighIRModule = (highIRModule: HighIRModule): PrettierDocument => {
   const segments: PrettierDocument[] = [
     PRETTIER_TEXT("let printed = '';"),
     PRETTIER_LINE,
@@ -189,29 +185,20 @@ const createPrettierDocumentFromHighIRSources = (
     PRETTIER_LINE,
     PRETTIER_LINE,
   ];
-  sources.forEach((samlangModule) =>
-    samlangModule.functions.forEach((highIRFunction) =>
-      segments.push(createPrettierDocumentFromHighIRFunction(highIRFunction), PRETTIER_LINE)
-    )
+  highIRModule.functions.forEach((highIRFunction) =>
+    segments.push(createPrettierDocumentFromHighIRFunction(highIRFunction), PRETTIER_LINE)
   );
-  if (entryModule != null) {
-    segments.push(
-      PRETTIER_LINE,
-      PRETTIER_TEXT(`${encodeMainFunctionName(entryModule)}();`),
-      PRETTIER_LINE,
-      PRETTIER_TEXT('printed')
-    );
-  } else {
-    segments.push(PRETTIER_LINE, PRETTIER_TEXT('printed'));
-  }
+  segments.push(
+    PRETTIER_LINE,
+    PRETTIER_TEXT(`${ENCODED_COMPILED_PROGRAM_MAIN}();`),
+    PRETTIER_LINE,
+    PRETTIER_TEXT('printed')
+  );
   return PRETTIER_CONCAT(...segments);
 };
 
-export const highIRSourcesToJSString = (
-  sources: Sources<HighIRModule>,
-  entryModule?: ModuleReference
-): string =>
+export const highIRModuleToJSString = (highIRModule: HighIRModule): string =>
   prettyPrintAccordingToPrettierAlgorithm(
     /* availableWidth */ 100,
-    createPrettierDocumentFromHighIRSources(sources, entryModule)
+    createPrettierDocumentFromHighIRModule(highIRModule)
   ).trimEnd();

--- a/samlang-core/services/source-processor.ts
+++ b/samlang-core/services/source-processor.ts
@@ -4,7 +4,7 @@ import type { SamlangModule } from '../ast/samlang-toplevel';
 import { typeCheckSources, GlobalTypingContext } from '../checker';
 import {
   compileSamlangSourcesToHighIRSources,
-  compileHighIrSourcesToMidIRCompilationUnits,
+  compileHighIrModuleToMidIRCompilationUnit,
   generateAssemblyInstructionsFromMidIRCompilationUnit,
 } from '../compiler';
 import { CompileTimeError, createGlobalErrorCollector } from '../errors';
@@ -39,14 +39,14 @@ export const lowerSourcesToAssemblyPrograms = (
   sources: Sources<SamlangModule>
 ): Sources<AssemblyProgram> =>
   hashMapOf(
-    ...compileHighIrSourcesToMidIRCompilationUnits(compileSamlangSourcesToHighIRSources(sources))
+    ...compileSamlangSourcesToHighIRSources(sources)
       .entries()
       .map(
-        ([moduleReference, unoptimizedCompilationUnit]) =>
+        ([moduleReference, highIRModule]) =>
           [
             moduleReference,
             generateAssemblyInstructionsFromMidIRCompilationUnit(
-              optimizeIRCompilationUnit(unoptimizedCompilationUnit)
+              optimizeIRCompilationUnit(compileHighIrModuleToMidIRCompilationUnit(highIRModule))
             ),
           ] as const
       )


### PR DESCRIPTION
## Summary

Necessary to reduce the JS bundle size.

## Test Plan

`yarn test`
