### PR TITLE
[printer][js] Create two modes for JS printer

### DIFF
--- a/samlang-core/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/printer/__tests__/printer-js.test.ts
@@ -42,10 +42,8 @@ it('compile hello world to JS integration test', () => {
   const hirModule = compileSamlangSourcesToHighIRSources(checkedSources).get(moduleReference);
   assertNotNull(hirModule);
   expect(highIRModuleToJSString(hirModule)).toBe(
-    `let printed = '';
-
-const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;
-const ${ENCODED_FUNCTION_NAME_PRINTLN} = (line) => { printed += line; printed += "\\n" };
+    `const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;
+const ${ENCODED_FUNCTION_NAME_PRINTLN} = (line) => console.log(line);
 const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);
 const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);
 const ${ENCODED_FUNCTION_NAME_THROW} = (v) => { throw Error(v); };
@@ -58,8 +56,7 @@ const _compiled_program_main = () => {
   _module_Test_class_Main_function_main();
 };
 
-_compiled_program_main();
-printed`
+_compiled_program_main();`
   );
 });
 
@@ -70,7 +67,7 @@ const setupIntegration = (sourceCode: string): string => {
   const hirModule = compileSamlangSourcesToHighIRSources(checkedSources).get(moduleReference);
   assertNotNull(hirModule);
   // eslint-disable-next-line no-eval
-  return eval(highIRModuleToJSString(hirModule));
+  return eval(highIRModuleToJSString(hirModule, true));
 };
 
 it('confirm samlang & equivalent JS have same print output', () => {

--- a/samlang-core/printer/printer-js.ts
+++ b/samlang-core/printer/printer-js.ts
@@ -166,15 +166,18 @@ export const highIRFunctionToString = (highIRFunction: HighIRFunction): string =
     createPrettierDocumentFromHighIRFunction(highIRFunction)
   );
 
-const createPrettierDocumentFromHighIRModule = (highIRModule: HighIRModule): PrettierDocument => {
+const createPrettierDocumentFromHighIRModule = (
+  highIRModule: HighIRModule,
+  forInterpreter: boolean
+): PrettierDocument => {
   const segments: PrettierDocument[] = [
-    PRETTIER_TEXT("let printed = '';"),
-    PRETTIER_LINE,
-    PRETTIER_LINE,
+    ...(forInterpreter ? [PRETTIER_TEXT("let printed = '';"), PRETTIER_LINE, PRETTIER_LINE] : []),
     PRETTIER_TEXT(`const ${ENCODED_FUNCTION_NAME_STRING_CONCAT} = (a, b) => a + b;`),
     PRETTIER_LINE,
     PRETTIER_TEXT(
-      `const ${ENCODED_FUNCTION_NAME_PRINTLN} = (line) => { printed += line; printed += "\\n" };`
+      forInterpreter
+        ? `const ${ENCODED_FUNCTION_NAME_PRINTLN} = (line) => { printed += line; printed += "\\n" };`
+        : `const ${ENCODED_FUNCTION_NAME_PRINTLN} = (line) => console.log(line);`
     ),
     PRETTIER_LINE,
     PRETTIER_TEXT(`const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);`),
@@ -192,13 +195,16 @@ const createPrettierDocumentFromHighIRModule = (highIRModule: HighIRModule): Pre
     PRETTIER_LINE,
     PRETTIER_TEXT(`${ENCODED_COMPILED_PROGRAM_MAIN}();`),
     PRETTIER_LINE,
-    PRETTIER_TEXT('printed')
+    ...(forInterpreter ? [PRETTIER_TEXT('printed')] : [])
   );
   return PRETTIER_CONCAT(...segments);
 };
 
-export const highIRModuleToJSString = (highIRModule: HighIRModule): string =>
+export const highIRModuleToJSString = (
+  highIRModule: HighIRModule,
+  forInterpreter = false
+): string =>
   prettyPrintAccordingToPrettierAlgorithm(
     /* availableWidth */ 100,
-    createPrettierDocumentFromHighIRModule(highIRModule)
+    createPrettierDocumentFromHighIRModule(highIRModule, forInterpreter)
   ).trimEnd();

--- a/samlang-demo/src/__test__/index.test.ts
+++ b/samlang-demo/src/__test__/index.test.ts
@@ -4,10 +4,8 @@ it('runSamlangDemo works when given good program.', () => {
   expect(runSamlangDemo('class Main { function main(): unit = println("hello world") }')).toEqual({
     interpreterPrinted: 'hello world\n',
     prettyPrintedProgram: `class Main { function main(): unit = println("hello world")  }\n`,
-    jsString: `let printed = '';
-
-const _builtin_stringConcat = (a, b) => a + b;
-const _builtin_println = (line) => { printed += line; printed += "\\n" };
+    jsString: `const _builtin_stringConcat = (a, b) => a + b;
+const _builtin_println = (line) => console.log(line);
 const _builtin_stringToInt = (v) => BigInt(v);
 const _builtin_intToString = (v) => String(v);
 const _builtin_throw = (v) => { throw Error(v); };
@@ -19,8 +17,7 @@ const _compiled_program_main = () => {
   _module_Demo_class_Main_function_main();
 };
 
-_compiled_program_main();
-printed`,
+_compiled_program_main();`,
     assemblyString: `    .text
     .intel_syntax noprefix
     .p2align 4, 0x90


### PR DESCRIPTION
## Summary

The interpreter mode is mostly used for internal testing. Therefore, it's defaulted to prod mode, where a println is translated to console.log and there is no `printed` accumulator.

## Test Plan

`yarn test`
