### PR TITLE
[printer][js] Use double quote for JS string with better escape

### DIFF
--- a/samlang-core/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/printer/__tests__/printer-js.test.ts
@@ -49,7 +49,7 @@ const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);
 const ${ENCODED_FUNCTION_NAME_THROW} = (v) => { throw Error(v); };
 
 const _module_Test_class_Main_function_main = () => {
-  var _t0 = _builtin_stringConcat('Hello ', 'World!');
+  var _t0 = _builtin_stringConcat("Hello ", "World!");
   var _t1 = _builtin_println(_t0);
 };
 const _compiled_program_main = () => {
@@ -293,7 +293,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}('Hello, world');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}("Hello, world");`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -302,7 +302,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}('5');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}("5");`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -320,7 +320,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'res',
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}('5', '4');`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}("5", "4");`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -329,7 +329,7 @@ it('HIR statements to JS string test', () => {
         returnCollector: 'panik',
       })
     )
-  ).toBe(`var panik = ${ENCODED_FUNCTION_NAME_THROW}('panik');`);
+  ).toBe(`var panik = ${ENCODED_FUNCTION_NAME_THROW}("panik");`);
   expect(
     highIRStatementToString(
       HIR_LET({
@@ -346,7 +346,7 @@ it('HIR statements to JS string test', () => {
         expressionList: [HIR_ZERO, HIR_STRING('bar'), HIR_INT(BigInt(13))],
       })
     )
-  ).toBe(`var st = [0, 'bar', 13];`);
+  ).toBe(`var st = [0, "bar", 13];`);
 });
 
 it('HIR function to JS string test 1', () => {
@@ -384,7 +384,9 @@ it('HIR function to JS string test 2', () => {
 
 it('HIR expression to JS string test', () => {
   expect(highIRExpressionToString(HIR_INT(BigInt(1305)))).toBe('1305');
-  expect(highIRExpressionToString(HIR_STRING('bloop'))).toBe(`'bloop'`);
+  expect(highIRExpressionToString(HIR_STRING('bloop'))).toBe(`"bloop"`);
+  expect(highIRExpressionToString(HIR_STRING('"foo'))).toBe(`"\\"foo"`);
+  expect(highIRExpressionToString(HIR_STRING("'foo"))).toBe(`"'foo"`);
   expect(
     highIRExpressionToString(
       HIR_INDEX_ACCESS({
@@ -415,7 +417,7 @@ it('HIR expression to JS string test', () => {
         index: 0,
       })
     )
-  ).toBe("('a' + 'b')[0]");
+  ).toBe('("a" + "b")[0]');
   expect(highIRExpressionToString(HIR_VARIABLE('ts'))).toBe('ts');
   expect(highIRExpressionToString(HIR_NAME('key'))).toBe('key');
   expect(

--- a/samlang-core/printer/printer-js.ts
+++ b/samlang-core/printer/printer-js.ts
@@ -23,6 +23,9 @@ import {
   createBracesSurroundedBlockDocument,
 } from './printer-prettier-library';
 
+// Thanks https://gist.github.com/getify/3667624
+const escapeDoubleQuotes = (string: string) => string.replace(/\\([\s\S])|(")/g, '\\$1$2');
+
 const createPrettierDocumentFromHighIRExpression = (
   highIRExpression: HighIRExpression
 ): PrettierDocument => {
@@ -30,7 +33,7 @@ const createPrettierDocumentFromHighIRExpression = (
     case 'HighIRIntLiteralExpression':
       return PRETTIER_TEXT(String(highIRExpression.value));
     case 'HighIRStringLiteralExpression':
-      return PRETTIER_TEXT(`'${highIRExpression.value}'`);
+      return PRETTIER_TEXT(`"${escapeDoubleQuotes(highIRExpression.value)}"`);
     case 'HighIRVariableExpression':
     case 'HighIRNameExpression':
       return PRETTIER_TEXT(highIRExpression.name);

--- a/samlang-demo/src/__test__/index.test.ts
+++ b/samlang-demo/src/__test__/index.test.ts
@@ -11,7 +11,7 @@ const _builtin_intToString = (v) => String(v);
 const _builtin_throw = (v) => { throw Error(v); };
 
 const _module_Demo_class_Main_function_main = () => {
-  var _t0 = _builtin_println('hello world');
+  var _t0 = _builtin_println("hello world");
 };
 const _compiled_program_main = () => {
   _module_Demo_class_Main_function_main();


### PR DESCRIPTION
## Summary

The previous implementation will produce code with syntax error when the string contains single quote. This is caught when I'm writing the integration tests for JS compiler output from samlang CLI. This diff fixes that.

## Test Plan

`yarn test`