### PR TITLE
[printer][js] Wrap div binary expression with `Math.floor` to preserve integer division semantics

### DIFF
--- a/samlang-core/printer/__tests__/printer-js.test.ts
+++ b/samlang-core/printer/__tests__/printer-js.test.ts
@@ -432,6 +432,15 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        operator: '/',
+        e1: HIR_INT(BigInt(7)),
+        e2: HIR_INT(BigInt(8)),
+      })
+    )
+  ).toBe('Math.floor(7 / 8)');
+  expect(
+    highIRExpressionToString(
+      HIR_BINARY({
         operator: '+',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_BINARY({

--- a/samlang-core/printer/printer-js.ts
+++ b/samlang-core/printer/printer-js.ts
@@ -58,11 +58,17 @@ const createPrettierDocumentFromHighIRExpression = (
         }
         return subExpressionDocument;
       };
-      return PRETTIER_CONCAT(
+      const binaryExpressionDocument = PRETTIER_CONCAT(
         withParenthesisWhenNecesasry(e1),
         PRETTIER_TEXT(` ${operator} `),
         withParenthesisWhenNecesasry(e2)
       );
+      return operator === '/'
+        ? PRETTIER_CONCAT(
+            PRETTIER_TEXT('Math.floor'),
+            createParenthesisSurroundedDocument(binaryExpressionDocument)
+          )
+        : binaryExpressionDocument;
     }
   }
 };

--- a/scripts/compile-repository.js
+++ b/scripts/compile-repository.js
@@ -55,6 +55,15 @@ const interpretPrograms = (programs) =>
   programs.map((program) => `#${program}\n${runWithErrorCheck(program)}`).join('\n');
 
 /**
+ * @param {string[]} programs
+ * @returns {string}
+ */
+const interpretJSPrograms = (programs) =>
+  programs
+    .map((program) => `#${program}\n${runWithErrorCheck('node', [`${program}.js`])}`)
+    .join('\n');
+
+/**
  * @param {string} expected
  * @param {string} actual
  * @returns {boolean}
@@ -76,3 +85,8 @@ if (!compare(read('./scripts/snapshot.txt'), interpretPrograms(getX86Programs())
   process.exit(1);
 }
 console.error('Generated X86 code is good.');
+console.error('Checking generated JS code...');
+if (!compare(read('./scripts/snapshot.txt'), interpretJSPrograms(getX86Programs()))) {
+  process.exit(1);
+}
+console.error('Generated JS code is good.');


### PR DESCRIPTION
## Summary

Caught this problem when I'm finishing the integration test in `scripts/compile-repository.js`.

## Test Plan

CI