### PR TITLE
[parser] Only support parsing public methods in interfaces

### DIFF
--- a/samlang-core/PL.g4
+++ b/samlang-core/PL.g4
@@ -25,7 +25,7 @@ classMemberDefinition
       ASSIGN expression
     ;
 classMemberDeclaration
-    : PRIVATE? (FUNCTION | METHOD) typeParametersDeclaration? LowerId LPAREN
+    : METHOD typeParametersDeclaration? LowerId LPAREN
         (annotatedVariable (COMMA annotatedVariable)* COMMA?)?
       RPAREN (COLON typeExpr)?
     ;

--- a/samlang-core/parser/__tests__/index.test.ts
+++ b/samlang-core/parser/__tests__/index.test.ts
@@ -209,7 +209,7 @@ it('Can handle bad programs.', () => {
     }
 
     interface FooBar {
-      function baz(haha: string): int
+      method baz(haha: string): int
     }
 
     interface Parameterized<T> {
@@ -239,7 +239,7 @@ it('Can handle really bad programs.', () => {
     interface {}
 
     interface Ahhh {
-      function notAnnotated(bad: , : int):
+      method notAnnotated(bad: , : int):
     }
 
     class TypeInference(val : string, val foo: ) {

--- a/samlang-core/parser/parser-class-builder.ts
+++ b/samlang-core/parser/parser-class-builder.ts
@@ -181,8 +181,8 @@ class ClassInterfaceBuilder
     const typeParametersDeclaration = ctx.typeParametersDeclaration();
     return {
       range: contextRange(ctx),
-      isPublic: ctx.PRIVATE() == null,
-      isMethod: ctx.METHOD() != null,
+      isPublic: true,
+      isMethod: true,
       nameRange: tokenRange(nameSymbol),
       name,
       typeParameters:


### PR DESCRIPTION
## Summary

- private stuff in interfaces don't make sense because interfaces define public APIs
- functions in interface don't make sense because interfaces are used for dynamic dispatch, and functions can only be statically dispatched.

## Test Plan

`yarn test`