### PR TITLE
Feature: [lsp] Add folding rangs

### DIFF
--- a/samlang-cli/src/lsp.ts
+++ b/samlang-cli/src/lsp.ts
@@ -119,6 +119,7 @@ const startSamlangLanguageServer = (configuration: SamlangProjectConfiguration):
     const moduleReference = uriToModuleReference(foldingrangeParameters.textDocument.uri);
     if (moduleReference == null) return null;
     const foldingRangeResult = service.queryFoldingRanges(moduleReference);
+    if (foldingRangeResult == null) return null;
     return foldingRangeResult.map((foldingRange) => samlangRangeToLspFoldingRange(foldingRange));
   });
 

--- a/samlang-core-services/__tests__/language-service.test.ts
+++ b/samlang-core-services/__tests__/language-service.test.ts
@@ -269,6 +269,7 @@ class Main {
     new Range(new Position(23, 2), new Position(23, 46)).toString(),
     new Range(new Position(22, 0), new Position(24, 1)).toString(),
   ]);
+  expect(service.queryFoldingRanges(new ModuleReference(['dsafadfasd']))).toBe(null);
 });
 
 it('LanguageServices autocompletion test', () => {

--- a/samlang-core-services/__tests__/language-service.test.ts
+++ b/samlang-core-services/__tests__/language-service.test.ts
@@ -224,6 +224,53 @@ class Test1(val a: int) {
   );
 });
 
+it('LanguageServices.queryFoldingRanges test', () => {
+  const testModuleReference = new ModuleReference(['Test']);
+  const state = new LanguageServiceState([
+    [
+      testModuleReference,
+      `
+class List<T>(Nil(unit), Cons([T * List<T>])) {
+  function <T> of(t: T): List<T> =
+    Cons([t, Nil({})])
+  method cons(t: T): List<T> =
+    Cons([t, this])
+}
+class Developer(
+  val name: string, val github: string,
+  val projects: List<string>,
+) {
+  function sam(): Developer = {
+    val l = List.of("SAMLANG").cons("...")
+    val github = "SamChou19815"
+    { name: "Sam Zhou", github, projects: l }.
+    function sam(): Developer = {
+      val l = List.of("SAMLANG").cons("...")
+      val github = "SamChou19815"
+      { name: "Sam Zhou", github, projects: l }.
+    }
+  }
+}
+class Main {
+  function main(): Developer = Developer.sam()
+}
+`,
+    ],
+  ]);
+  const service = new LanguageServices(state, () => 'foo bar');
+  expect(
+    service.queryFoldingRanges(testModuleReference)?.map((module) => module.toString())
+  ).toMatchObject([
+    new Range(new Position(2, 2), new Position(3, 22)).toString(),
+    new Range(new Position(4, 2), new Position(5, 19)).toString(),
+    new Range(new Position(1, 0), new Position(6, 1)).toString(),
+    new Range(new Position(11, 2), new Position(16, 44)).toString(),
+    new Range(new Position(7, 0), new Position(18, 47)).toString(),
+    new Range(new Position(23, 2), new Position(23, 46)).toString(),
+    new Range(new Position(22, 0), new Position(24, 1)).toString(),
+  ]);
+});
+
 it('LanguageServices autocompletion test', () => {
   const testModuleReference = new ModuleReference(['Test']);
   const state = new LanguageServiceState([

--- a/samlang-core-services/language-service.ts
+++ b/samlang-core-services/language-service.ts
@@ -242,6 +242,18 @@ export class LanguageServices {
     return [expression.type, expression.range];
   }
 
+  queryFoldingRanges(moduleReference: ModuleReference): readonly Range[] | null {
+    const module = this.state.getCheckedModule(moduleReference);
+    if (module == null) return null;
+    const ranges = module.classes.flatMap((moduleClass) => {
+      const range = moduleClass.range;
+      const members = moduleClass.members;
+      const memberRanges = members.flatMap((member) => member.range);
+      return [...memberRanges, range];
+    });
+    return ranges;
+  }
+
   queryDefinitionLocation(moduleReference: ModuleReference, position: Position): Location | null {
     const expression = this.state.expressionLocationLookup.get(moduleReference, position);
     if (expression == null) return null;


### PR DESCRIPTION
## Summary

Related to #82 

@SamChou19815 I am a little bit struggling implementing the feature.

This is what I did:
- `samlang-cli/src/lsp.ts`: added the `connection.onFoldingRanges` handler.
- `samlang-core-services/language-service.ts`: added the `queryFoldingRange` method which should return the list of FoldingRanges.

I feel like I'm lacking in understanding of the existing codebase and my IDE doesn't feel like helping me ...
Can you give me some tips on how I can get this done ? Or some links (docs/articles...) that might help me ?
In fact, I would like to have a more general understanding of the codebase to continue contributing in the future !

I thank you in advance for your time 👍

## Test Plan

`yarn test`
