### PR TITLE
[printer][source-level] Omit undediced type printing in optional annotations

### DIFF
--- a/samlang-core-printer/__tests__/printer-source-level.test.ts
+++ b/samlang-core-printer/__tests__/printer-source-level.test.ts
@@ -134,15 +134,16 @@ it('prettyPrintSamlangExpression test', () => {
 
   expect(reprintExpression('() -> 1')).toBe('() -> 1');
   expect(reprintExpression('(a: int) -> 1')).toBe('(a: int) -> 1');
+  expect(reprintExpression('(a) -> 1')).toBe('(a) -> 1');
   expect(reprintExpression('(a: int) -> 1 + 1')).toBe('(a: int) -> 1 + 1');
   expect(reprintExpression('(() -> 1)()')).toBe('(() -> 1)()');
 
   expect(reprintExpression('{}')).toBe('{  }');
   expect(reprintExpression('{3}')).toBe('{ 3 }');
-  expect(reprintExpression('{ val _:int=0;val _:int=0; }')).toBe(
+  expect(reprintExpression('{ val _:int=0;val _=0; }')).toBe(
     `{
   val _: int = 0;
-  val _: int = 0;
+  val _ = 0;
 }`
   );
   expect(reprintExpression('{ val a:int=1;val [b,_]:[int*int]=2; 3 }')).toBe(`{

--- a/samlang-core-printer/printer-source-level.ts
+++ b/samlang-core-printer/printer-source-level.ts
@@ -151,7 +151,9 @@ const createPrettierDocumentFromSamlangExpression = (
       return PRETTIER_CONCAT(
         createParenthesisSurroundedDocument(
           createCommaSeparatedList(expression.parameters, ([name, type]) =>
-            PRETTIER_TEXT(`${name}: ${prettyPrintType(type)}`)
+            PRETTIER_TEXT(
+              type.type === 'UndecidedType' ? name : `${name}: ${prettyPrintType(type)}`
+            )
           )
         ),
         PRETTIER_TEXT(' -> '),
@@ -187,7 +189,10 @@ const createPrettierDocumentFromSamlangExpression = (
           return [
             PRETTIER_TEXT('val '),
             patternDocument,
-            PRETTIER_TEXT(`: ${prettyPrintType(typeAnnotation)} = `),
+            typeAnnotation.type === 'UndecidedType'
+              ? PRETTIER_NIL
+              : PRETTIER_TEXT(`: ${prettyPrintType(typeAnnotation)}`),
+            PRETTIER_TEXT(' = '),
             createPrettierDocumentFromSamlangExpression(assignedExpression),
             PRETTIER_TEXT(';'),
             PRETTIER_LINE,


### PR DESCRIPTION
## Summary

Due to type inference, type annotation is not always required. In those places where it's not required, we current still print the type during pretty printing. This is bad because now pretty printing can only be done after type checking.

This diff removes this restriction by avoid printing the type annotation when they are optional and the type in the AST is undecided.

## Test Plan

`yarn test`
