### PR TITLE
[printer][js] Do not expose toString methods in JS printer

### DIFF
--- a/samlang-core-printer/__tests__/printer-js.test.ts
+++ b/samlang-core-printer/__tests__/printer-js.test.ts
@@ -1,9 +1,10 @@
 import {
-  highIRModuleToJSString,
-  highIRStatementToString,
-  highIRFunctionToString,
-  highIRExpressionToString,
+  createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING,
+  createPrettierDocumentFromHighIRStatement_EXPOSED_FOR_TESTING,
+  createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING,
+  createPrettierDocumentFromHighIRModule,
 } from '../printer-js';
+import { prettyPrintAccordingToPrettierAlgorithm } from '../printer-prettier-core';
 
 import {
   ENCODED_FUNCTION_NAME_STRING_CONCAT,
@@ -26,9 +27,33 @@ import {
   HIR_INDEX_ACCESS,
   HIR_VARIABLE,
   HIR_WHILE_TRUE,
+  HighIRExpression,
+  HighIRStatement,
 } from 'samlang-core-ast/hir-expressions';
 import type { HighIRModule } from 'samlang-core-ast/hir-toplevel';
 import { assertNotNull } from 'samlang-core-utils';
+
+const highIRExpressionToString = (highIRExpression: HighIRExpression): string =>
+  prettyPrintAccordingToPrettierAlgorithm(
+    /* availableWidth */ 100,
+    createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(highIRExpression)
+  ).trimEnd();
+
+const highIRStatementToString = (highIRStatement: HighIRStatement): string =>
+  prettyPrintAccordingToPrettierAlgorithm(
+    /* availableWidth */ 100,
+    createPrettierDocumentFromHighIRStatement_EXPOSED_FOR_TESTING(highIRStatement)
+  ).trimEnd();
+
+const highIRModuleToJSString = (
+  availableWidth: number,
+  highIRModule: HighIRModule,
+  forInterpreter = false
+): string =>
+  prettyPrintAccordingToPrettierAlgorithm(
+    availableWidth,
+    createPrettierDocumentFromHighIRModule(highIRModule, forInterpreter)
+  ).trimEnd();
 
 it('compile hello world to JS integration test', () => {
   const hirModule: HighIRModule = {
@@ -469,17 +494,20 @@ it('HIR statements to JS string test', () => {
 
 it('HIR function to JS string test 1', () => {
   expect(
-    highIRFunctionToString({
-      name: 'baz',
-      parameters: ['d', 't', 'i'],
-      hasReturn: true,
-      body: [
-        HIR_LET({
-          name: 'b',
-          assignedExpression: HIR_INT(BigInt(1857)),
-        }),
-      ],
-    })
+    prettyPrintAccordingToPrettierAlgorithm(
+      100,
+      createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING({
+        name: 'baz',
+        parameters: ['d', 't', 'i'],
+        hasReturn: true,
+        body: [
+          HIR_LET({
+            name: 'b',
+            assignedExpression: HIR_INT(BigInt(1857)),
+          }),
+        ],
+      })
+    )
   ).toBe(`const baz = (d, t, i) => {
   var b = 1857;
 };
@@ -488,12 +516,15 @@ it('HIR function to JS string test 1', () => {
 
 it('HIR function to JS string test 2', () => {
   expect(
-    highIRFunctionToString({
-      name: 'baz',
-      parameters: ['d', 't', 'i'],
-      hasReturn: true,
-      body: [HIR_RETURN(HIR_INT(BigInt(42)))],
-    })
+    prettyPrintAccordingToPrettierAlgorithm(
+      100,
+      createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING({
+        name: 'baz',
+        parameters: ['d', 't', 'i'],
+        hasReturn: true,
+        body: [HIR_RETURN(HIR_INT(BigInt(42)))],
+      })
+    )
   ).toBe(`const baz = (d, t, i) => {
   return 42;
 };

--- a/samlang-core-printer/index.ts
+++ b/samlang-core-printer/index.ts
@@ -1,11 +1,10 @@
-import { highIRModuleToJSString } from './printer-js';
+import { createPrettierDocumentFromHighIRModule } from './printer-js';
 import { prettyPrintAccordingToPrettierAlgorithm } from './printer-prettier-core';
 import createPrettierDocumentForSamlangModule from './printer-source-level';
 
 import type { HighIRModule } from 'samlang-core-ast/hir-toplevel';
 import type { SamlangModule } from 'samlang-core-ast/samlang-toplevel';
 
-// eslint-disable-next-line import/prefer-default-export
 export const prettyPrintSamlangModule = (
   availableWidth: number,
   samlangModule: SamlangModule
@@ -15,7 +14,11 @@ export const prettyPrintSamlangModule = (
     createPrettierDocumentForSamlangModule(samlangModule)
   ).trimEnd()}\n`;
 
-export const prettyPrintHighIRModuleAsJS: (
+export const prettyPrintHighIRModuleAsJS = (
   availableWidth: number,
   highIRModule: HighIRModule
-) => string = highIRModuleToJSString;
+): string =>
+  prettyPrintAccordingToPrettierAlgorithm(
+    availableWidth,
+    createPrettierDocumentFromHighIRModule(highIRModule, /* forInterpreter */ false)
+  ).trimEnd();

--- a/samlang-core-printer/printer-js.ts
+++ b/samlang-core-printer/printer-js.ts
@@ -3,7 +3,6 @@ import {
   PRETTIER_CONCAT,
   PRETTIER_TEXT,
   PRETTIER_LINE,
-  prettyPrintAccordingToPrettierAlgorithm,
 } from './printer-prettier-core';
 import {
   createCommaSeparatedList,
@@ -27,7 +26,7 @@ import type { HighIRFunction, HighIRModule } from 'samlang-core-ast/hir-toplevel
 // Thanks https://gist.github.com/getify/3667624
 const escapeDoubleQuotes = (string: string) => string.replace(/\\([\s\S])|(")/g, '\\$1$2');
 
-const createPrettierDocumentFromHighIRExpression = (
+export const createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING = (
   highIRExpression: HighIRExpression
 ): PrettierDocument => {
   switch (highIRExpression.__type__) {
@@ -40,7 +39,9 @@ const createPrettierDocumentFromHighIRExpression = (
       return PRETTIER_TEXT(highIRExpression.name);
     case 'HighIRIndexAccessExpression': {
       const { expression: subExpression, index } = highIRExpression;
-      let subExpressionDocument = createPrettierDocumentFromHighIRExpression(subExpression);
+      let subExpressionDocument = createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(
+        subExpression
+      );
       if (subExpression.__type__ === 'HighIRBinaryExpression') {
         subExpressionDocument = createParenthesisSurroundedDocument(subExpressionDocument);
       }
@@ -49,7 +50,9 @@ const createPrettierDocumentFromHighIRExpression = (
     case 'HighIRBinaryExpression': {
       const { e1, e2, operator } = highIRExpression;
       const withParenthesisWhenNecesasry = (subExpression: HighIRExpression): PrettierDocument => {
-        const subExpressionDocument = createPrettierDocumentFromHighIRExpression(subExpression);
+        const subExpressionDocument = createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(
+          subExpression
+        );
         if (subExpression.__type__ === 'HighIRBinaryExpression') {
           const p1 = binaryOperatorSymbolTable[operator]?.precedence;
           const p2 = binaryOperatorSymbolTable[subExpression.operator]?.precedence;
@@ -74,21 +77,15 @@ const createPrettierDocumentFromHighIRExpression = (
   }
 };
 
-export const highIRExpressionToString = (highIRExpression: HighIRExpression): string =>
-  prettyPrintAccordingToPrettierAlgorithm(
-    /* availableWidth */ 100,
-    createPrettierDocumentFromHighIRExpression(highIRExpression)
-  ).trimEnd();
-
 const concatStatements = (statements: readonly HighIRStatement[]) => {
   const documents = statements
-    .map((it) => [createPrettierDocumentFromHighIRStatement(it), PRETTIER_LINE])
+    .map((it) => [createPrettierDocumentFromHighIRStatement_EXPOSED_FOR_TESTING(it), PRETTIER_LINE])
     .flat();
   if (documents.length === 0) return documents;
   return documents.slice(0, documents.length - 1);
 };
 
-const createPrettierDocumentFromHighIRStatement = (
+export const createPrettierDocumentFromHighIRStatement_EXPOSED_FOR_TESTING = (
   highIRStatement: HighIRStatement
 ): PrettierDocument => {
   switch (highIRStatement.__type__) {
@@ -98,11 +95,13 @@ const createPrettierDocumentFromHighIRStatement = (
         segments.push(PRETTIER_TEXT(`var ${highIRStatement.returnCollector} = `));
       }
       segments.push(
-        createPrettierDocumentFromHighIRExpression(highIRStatement.functionExpression),
+        createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(
+          highIRStatement.functionExpression
+        ),
         createParenthesisSurroundedDocument(
           createCommaSeparatedList(
             highIRStatement.functionArguments,
-            createPrettierDocumentFromHighIRExpression
+            createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING
           )
         ),
         PRETTIER_TEXT(';')
@@ -113,7 +112,9 @@ const createPrettierDocumentFromHighIRStatement = (
       return PRETTIER_CONCAT(
         PRETTIER_TEXT('if '),
         createParenthesisSurroundedDocument(
-          createPrettierDocumentFromHighIRExpression(highIRStatement.booleanExpression)
+          createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(
+            highIRStatement.booleanExpression
+          )
         ),
         PRETTIER_TEXT(' '),
         createBracesSurroundedBlockDocument(concatStatements(highIRStatement.s1)),
@@ -128,7 +129,9 @@ const createPrettierDocumentFromHighIRStatement = (
     case 'HighIRLetDefinitionStatement':
       return PRETTIER_CONCAT(
         PRETTIER_TEXT(`var ${highIRStatement.name} = `),
-        createPrettierDocumentFromHighIRExpression(highIRStatement.assignedExpression),
+        createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(
+          highIRStatement.assignedExpression
+        ),
         PRETTIER_TEXT(';')
       );
     case 'HighIRStructInitializationStatement':
@@ -137,7 +140,7 @@ const createPrettierDocumentFromHighIRStatement = (
         createBracketSurroundedDocument(
           createCommaSeparatedList(
             highIRStatement.expressionList,
-            createPrettierDocumentFromHighIRExpression
+            createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING
           )
         ),
         PRETTIER_TEXT(';')
@@ -145,19 +148,13 @@ const createPrettierDocumentFromHighIRStatement = (
     case 'HighIRReturnStatement':
       return PRETTIER_CONCAT(
         PRETTIER_TEXT('return '),
-        createPrettierDocumentFromHighIRExpression(highIRStatement.expression),
+        createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING(highIRStatement.expression),
         PRETTIER_TEXT(';')
       );
   }
 };
 
-export const highIRStatementToString = (highIRStatement: HighIRStatement): string =>
-  prettyPrintAccordingToPrettierAlgorithm(
-    /* availableWidth */ 100,
-    createPrettierDocumentFromHighIRStatement(highIRStatement)
-  ).trimEnd();
-
-const createPrettierDocumentFromHighIRFunction = (
+export const createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING = (
   highIRFunction: HighIRFunction
 ): PrettierDocument =>
   PRETTIER_CONCAT(
@@ -170,13 +167,7 @@ const createPrettierDocumentFromHighIRFunction = (
     PRETTIER_TEXT(';')
   );
 
-export const highIRFunctionToString = (highIRFunction: HighIRFunction): string =>
-  prettyPrintAccordingToPrettierAlgorithm(
-    /* availableWidth */ 100,
-    createPrettierDocumentFromHighIRFunction(highIRFunction)
-  );
-
-const createPrettierDocumentFromHighIRModule = (
+export const createPrettierDocumentFromHighIRModule = (
   highIRModule: HighIRModule,
   forInterpreter: boolean
 ): PrettierDocument => {
@@ -199,7 +190,10 @@ const createPrettierDocumentFromHighIRModule = (
     PRETTIER_LINE,
   ];
   highIRModule.functions.forEach((highIRFunction) =>
-    segments.push(createPrettierDocumentFromHighIRFunction(highIRFunction), PRETTIER_LINE)
+    segments.push(
+      createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING(highIRFunction),
+      PRETTIER_LINE
+    )
   );
   segments.push(
     PRETTIER_LINE,
@@ -209,13 +203,3 @@ const createPrettierDocumentFromHighIRModule = (
   );
   return PRETTIER_CONCAT(...segments);
 };
-
-export const highIRModuleToJSString = (
-  availableWidth: number,
-  highIRModule: HighIRModule,
-  forInterpreter = false
-): string =>
-  prettyPrintAccordingToPrettierAlgorithm(
-    availableWidth,
-    createPrettierDocumentFromHighIRModule(highIRModule, forInterpreter)
-  ).trimEnd();


### PR DESCRIPTION
## Summary

To be consistent with source level printer, only exposing the toString functions at `index.ts`.

## Test Plan

`yarn test`
