### PR TITLE
[ast][compiler] Create typed HIR AST

### DIFF
--- a/samlang-core-analysis/__tests__/used-name-analysis.test.ts
+++ b/samlang-core-analysis/__tests__/used-name-analysis.test.ts
@@ -1,6 +1,7 @@
 import analyzeUsedFunctionNames from '../used-name-analysis';
 
 import { ENCODED_COMPILED_PROGRAM_MAIN } from 'samlang-core-ast/common-names';
+import { unitType } from 'samlang-core-ast/common-nodes';
 import {
   HIR_ZERO,
   HIR_NAME,
@@ -24,7 +25,10 @@ it('analyzeUsedFunctionNames test', () => {
             parameters: [],
             hasReturn: false,
             body: [
-              HIR_FUNCTION_CALL({ functionExpression: HIR_NAME('foo'), functionArguments: [] }),
+              HIR_FUNCTION_CALL({
+                functionExpression: HIR_NAME('foo', unitType),
+                functionArguments: [],
+              }),
             ],
           },
           {
@@ -35,13 +39,19 @@ it('analyzeUsedFunctionNames test', () => {
               HIR_LET({ name: '', assignedExpression: HIR_ZERO }),
               HIR_STRUCT_INITIALIZATION({
                 structVariableName: '',
-                expressionList: [HIR_INDEX_ACCESS({ expression: HIR_NAME('bar'), index: 0 })],
+                expressionList: [
+                  HIR_INDEX_ACCESS({
+                    type: unitType,
+                    expression: HIR_NAME('bar', unitType),
+                    index: 0,
+                  }),
+                ],
               }),
               HIR_FUNCTION_CALL({
-                functionExpression: HIR_NAME('baz'),
-                functionArguments: [HIR_NAME('haha')],
+                functionExpression: HIR_NAME('baz', unitType),
+                functionArguments: [HIR_NAME('haha', unitType)],
               }),
-              HIR_RETURN(HIR_NAME('bar')),
+              HIR_RETURN(HIR_NAME('bar', unitType)),
               HIR_WHILE_TRUE([
                 HIR_IF_ELSE({
                   booleanExpression: HIR_ZERO,
@@ -49,9 +59,10 @@ it('analyzeUsedFunctionNames test', () => {
                     HIR_LET({
                       name: '',
                       assignedExpression: HIR_BINARY({
+                        type: unitType,
                         operator: '+',
-                        e1: HIR_NAME('foo'),
-                        e2: HIR_NAME('bar'),
+                        e1: HIR_NAME('foo', unitType),
+                        e2: HIR_NAME('bar', unitType),
                       }),
                     }),
                   ],
@@ -66,7 +77,7 @@ it('analyzeUsedFunctionNames test', () => {
             hasReturn: false,
             body: [
               HIR_FUNCTION_CALL({
-                functionExpression: HIR_NAME('foo'),
+                functionExpression: HIR_NAME('foo', unitType),
                 functionArguments: [],
               }),
             ],

--- a/samlang-core-ast/hir-expressions.ts
+++ b/samlang-core-ast/hir-expressions.ts
@@ -1,7 +1,9 @@
-import type { IROperator } from 'samlang-core-ast/common-operators';
+import { intType, stringType, Type } from './common-nodes';
+import type { IROperator } from './common-operators';
 
 interface BaseHighIRExpression {
   readonly __type__: string;
+  readonly type: Type;
 }
 
 export interface HighIRIntLiteralExpression extends BaseHighIRExpression {
@@ -105,42 +107,50 @@ type ConstructorArgumentObject<E extends BaseHighIRExpression | BaseHighIRStatem
 
 export const HIR_INT = (value: bigint): HighIRIntLiteralExpression => ({
   __type__: 'HighIRIntLiteralExpression',
+  type: intType,
   value,
 });
 
 export const HIR_STRING = (value: string): HighIRStringLiteralExpression => ({
   __type__: 'HighIRStringLiteralExpression',
+  type: stringType,
   value,
 });
 
 export const HIR_ZERO: HighIRIntLiteralExpression = HIR_INT(BigInt(0));
 export const HIR_ONE: HighIRIntLiteralExpression = HIR_INT(BigInt(1));
 
-export const HIR_NAME = (name: string): HighIRNameExpression => ({
+export const HIR_NAME = (name: string, type: Type): HighIRNameExpression => ({
   __type__: 'HighIRNameExpression',
+  type,
   name,
 });
 
-export const HIR_VARIABLE = (name: string): HighIRVariableExpression => ({
+export const HIR_VARIABLE = (name: string, type: Type): HighIRVariableExpression => ({
   __type__: 'HighIRVariableExpression',
+  type,
   name,
 });
 
 export const HIR_INDEX_ACCESS = ({
+  type,
   expression,
   index,
 }: ConstructorArgumentObject<HighIRIndexAccessExpression>): HighIRIndexAccessExpression => ({
   __type__: 'HighIRIndexAccessExpression',
+  type,
   expression,
   index,
 });
 
 export const HIR_BINARY = ({
+  type,
   operator,
   e1,
   e2,
 }: ConstructorArgumentObject<HighIRBinaryExpression>): HighIRBinaryExpression => ({
   __type__: 'HighIRBinaryExpression',
+  type,
   operator,
   e1,
   e2,

--- a/samlang-core-compiler/__tests__/hir-eliminate-useless-ending-moves.test.ts
+++ b/samlang-core-compiler/__tests__/hir-eliminate-useless-ending-moves.test.ts
@@ -1,5 +1,6 @@
 import eliminateUselessEndingMoveForHighIRStatements from '../hir-eliminate-useless-ending-moves';
 
+import { functionType, intType } from 'samlang-core-ast/common-nodes';
 import {
   HIR_ZERO,
   HIR_ONE,
@@ -20,10 +21,10 @@ it('eliminateUselessEndingMoveForHighIRStatements useless linear sequence test',
   expect(
     eliminateUselessEndingMoveForHighIRStatements([
       HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
+      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
       HIR_STRUCT_INITIALIZATION({ structVariableName: 'useless', expressionList: [] }),
     ])
   ).toEqual([]);
@@ -33,37 +34,73 @@ it('eliminateUselessEndingMoveForHighIRStatements if-else test 1', () => {
   expect(
     eliminateUselessEndingMoveForHighIRStatements([
       HIR_IF_ELSE({
-        booleanExpression: HIR_BINARY({ operator: '==', e1: HIR_VARIABLE('n'), e2: HIR_ZERO }),
+        booleanExpression: HIR_BINARY({
+          type: intType,
+          operator: '==',
+          e1: HIR_VARIABLE('n', intType),
+          e2: HIR_ZERO,
+        }),
         s1: [
           HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
+          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
         ],
         s2: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_module__class_Class1_function_factorial'),
+            functionExpression: HIR_NAME(
+              '_module__class_Class1_function_factorial',
+              functionType([intType], intType)
+            ),
             functionArguments: [
-              HIR_BINARY({ operator: '-', e1: HIR_VARIABLE('n'), e2: HIR_ONE }),
-              HIR_BINARY({ operator: '*', e1: HIR_VARIABLE('n'), e2: HIR_VARIABLE('acc') }),
+              HIR_BINARY({
+                type: intType,
+                operator: '-',
+                e1: HIR_VARIABLE('n', intType),
+                e2: HIR_ONE,
+              }),
+              HIR_BINARY({
+                type: intType,
+                operator: '*',
+                e1: HIR_VARIABLE('n', intType),
+                e2: HIR_VARIABLE('acc', intType),
+              }),
             ],
             returnCollector: '_t0',
           }),
-          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0') }),
+          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0', intType) }),
         ],
       }),
     ])
   ).toEqual([
     HIR_IF_ELSE({
-      booleanExpression: HIR_BINARY({ operator: '==', e1: HIR_VARIABLE('n'), e2: HIR_ZERO }),
+      booleanExpression: HIR_BINARY({
+        type: intType,
+        operator: '==',
+        e1: HIR_VARIABLE('n', intType),
+        e2: HIR_ZERO,
+      }),
       s1: [],
       s2: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME('_module__class_Class1_function_factorial'),
+          functionExpression: HIR_NAME(
+            '_module__class_Class1_function_factorial',
+            functionType([intType], intType)
+          ),
           functionArguments: [
-            HIR_BINARY({ operator: '-', e1: HIR_VARIABLE('n'), e2: HIR_ONE }),
-            HIR_BINARY({ operator: '*', e1: HIR_VARIABLE('n'), e2: HIR_VARIABLE('acc') }),
+            HIR_BINARY({
+              type: intType,
+              operator: '-',
+              e1: HIR_VARIABLE('n', intType),
+              e2: HIR_ONE,
+            }),
+            HIR_BINARY({
+              type: intType,
+              operator: '*',
+              e1: HIR_VARIABLE('n', intType),
+              e2: HIR_VARIABLE('acc', intType),
+            }),
           ],
           returnCollector: '_t0',
         }),
@@ -77,15 +114,20 @@ it('eliminateUselessEndingMoveForHighIRStatements if-else test 2', () => {
     eliminateUselessEndingMoveForHighIRStatements([
       HIR_STRUCT_INITIALIZATION({ structVariableName: 'useless', expressionList: [] }),
       HIR_IF_ELSE({
-        booleanExpression: HIR_BINARY({ operator: '==', e1: HIR_VARIABLE('n'), e2: HIR_ZERO }),
+        booleanExpression: HIR_BINARY({
+          type: intType,
+          operator: '==',
+          e1: HIR_VARIABLE('n', intType),
+          e2: HIR_ZERO,
+        }),
         s1: [
           HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
+          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
         ],
-        s2: [HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0') })],
+        s2: [HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0', intType) })],
       }),
     ])
   ).toEqual([]);

--- a/samlang-core-compiler/__tests__/hir-move-return-coalescing.test.ts
+++ b/samlang-core-compiler/__tests__/hir-move-return-coalescing.test.ts
@@ -1,5 +1,6 @@
 import coalesceMoveAndReturnForHighIRStatements from '../hir-move-return-coalescing';
 
+import { intType, functionType } from 'samlang-core-ast/common-nodes';
 import {
   HIR_ZERO,
   HIR_ONE,
@@ -31,12 +32,12 @@ it('coalesceMoveAndReturnWithForHighIRStatements linear sequence test', () => {
     coalesceMoveAndReturnForHighIRStatements([
       HIR_WHILE_TRUE([]),
       HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
+      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
       HIR_STRUCT_INITIALIZATION({ structVariableName: 'useless', expressionList: [] }),
-      HIR_RETURN(HIR_VARIABLE('_t1')),
+      HIR_RETURN(HIR_VARIABLE('_t1', intType)),
     ])
   ).toEqual([HIR_WHILE_TRUE([]), HIR_RETURN(HIR_ONE)]);
 });
@@ -46,12 +47,12 @@ it('coalesceMoveAndReturnWithForHighIRStatements failed linear sequence test', (
     coalesceMoveAndReturnForHighIRStatements([
       HIR_WHILE_TRUE([]),
       HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
-      HIR_LET({ name: 'garbage', assignedExpression: HIR_VARIABLE('garbage') }),
-      HIR_RETURN(HIR_VARIABLE('_t1')),
+      HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+      HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+      HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+      HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
+      HIR_LET({ name: 'garbage', assignedExpression: HIR_VARIABLE('garbage', intType) }),
+      HIR_RETURN(HIR_VARIABLE('_t1', intType)),
     ])
   ).toBeNull();
 });
@@ -60,42 +61,78 @@ it('coalesceMoveAndReturnWithForHighIRStatements if-else test', () => {
   expect(
     coalesceMoveAndReturnForHighIRStatements([
       HIR_IF_ELSE({
-        booleanExpression: HIR_BINARY({ operator: '==', e1: HIR_VARIABLE('n'), e2: HIR_ZERO }),
+        booleanExpression: HIR_BINARY({
+          type: intType,
+          operator: '==',
+          e1: HIR_VARIABLE('n', intType),
+          e2: HIR_ZERO,
+        }),
         s1: [
           HIR_LET({ name: 'one_const_value', assignedExpression: HIR_ONE }),
-          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value') }),
-          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2') }),
-          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1') }),
-          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one') }),
+          HIR_LET({ name: 'one2', assignedExpression: HIR_VARIABLE('one_const_value', intType) }),
+          HIR_LET({ name: 'one1', assignedExpression: HIR_VARIABLE('one2', intType) }),
+          HIR_LET({ name: 'one', assignedExpression: HIR_VARIABLE('one1', intType) }),
+          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('one', intType) }),
         ],
         s2: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_module__class_Class1_function_factorial'),
+            functionExpression: HIR_NAME(
+              '_module__class_Class1_function_factorial',
+              functionType([intType, intType], intType)
+            ),
             functionArguments: [
-              HIR_BINARY({ operator: '-', e1: HIR_VARIABLE('n'), e2: HIR_ONE }),
-              HIR_BINARY({ operator: '*', e1: HIR_VARIABLE('n'), e2: HIR_VARIABLE('acc') }),
+              HIR_BINARY({
+                type: intType,
+                operator: '-',
+                e1: HIR_VARIABLE('n', intType),
+                e2: HIR_ONE,
+              }),
+              HIR_BINARY({
+                type: intType,
+                operator: '*',
+                e1: HIR_VARIABLE('n', intType),
+                e2: HIR_VARIABLE('acc', intType),
+              }),
             ],
             returnCollector: '_t0',
           }),
-          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0') }),
+          HIR_LET({ name: '_t1', assignedExpression: HIR_VARIABLE('_t0', intType) }),
         ],
       }),
-      HIR_RETURN(HIR_VARIABLE('_t1')),
+      HIR_RETURN(HIR_VARIABLE('_t1', intType)),
     ])
   ).toEqual([
     HIR_IF_ELSE({
-      booleanExpression: HIR_BINARY({ operator: '==', e1: HIR_VARIABLE('n'), e2: HIR_ZERO }),
+      booleanExpression: HIR_BINARY({
+        type: intType,
+        operator: '==',
+        e1: HIR_VARIABLE('n', intType),
+        e2: HIR_ZERO,
+      }),
       s1: [HIR_RETURN(HIR_ONE)],
       s2: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME('_module__class_Class1_function_factorial'),
+          functionExpression: HIR_NAME(
+            '_module__class_Class1_function_factorial',
+            functionType([intType, intType], intType)
+          ),
           functionArguments: [
-            HIR_BINARY({ operator: '-', e1: HIR_VARIABLE('n'), e2: HIR_ONE }),
-            HIR_BINARY({ operator: '*', e1: HIR_VARIABLE('n'), e2: HIR_VARIABLE('acc') }),
+            HIR_BINARY({
+              type: intType,
+              operator: '-',
+              e1: HIR_VARIABLE('n', intType),
+              e2: HIR_ONE,
+            }),
+            HIR_BINARY({
+              type: intType,
+              operator: '*',
+              e1: HIR_VARIABLE('n', intType),
+              e2: HIR_VARIABLE('acc', intType),
+            }),
           ],
           returnCollector: '_t0',
         }),
-        HIR_RETURN(HIR_VARIABLE('_t0')),
+        HIR_RETURN(HIR_VARIABLE('_t0', intType)),
       ],
     }),
   ]);

--- a/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
+++ b/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
@@ -1,5 +1,6 @@
 import performTailRecursiveCallTransformationOnHighIRFunction from '../hir-tail-recursion-transformation-hir';
 
+import { functionType, intType } from 'samlang-core-ast/common-nodes';
 import {
   HIR_ZERO,
   HIR_ONE,
@@ -36,7 +37,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction no tailrec call test'
       hasReturn: true,
       body: [
         HIR_LET({ name: '_t1', assignedExpression: HIR_ONE }),
-        HIR_RETURN(HIR_VARIABLE('_t1')),
+        HIR_RETURN(HIR_VARIABLE('_t1', intType)),
       ],
     })
   ).toEqual({
@@ -55,11 +56,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow test', ()
       hasReturn: true,
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME('tailRec'),
-          functionArguments: [HIR_VARIABLE('n')],
+          functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+          functionArguments: [HIR_VARIABLE('n', intType)],
           returnCollector: 'collector',
         }),
-        HIR_RETURN(HIR_VARIABLE('collector')),
+        HIR_RETURN(HIR_VARIABLE('collector', intType)),
       ],
     })
   ).toEqual({
@@ -68,8 +69,14 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow test', ()
     hasReturn: true,
     body: [
       HIR_WHILE_TRUE([
-        HIR_LET({ name: '_tailRecTransformationArgument0', assignedExpression: HIR_VARIABLE('n') }),
-        HIR_LET({ name: 'n', assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0') }),
+        HIR_LET({
+          name: '_tailRecTransformationArgument0',
+          assignedExpression: HIR_VARIABLE('n', intType),
+        }),
+        HIR_LET({
+          name: 'n',
+          assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
+        }),
       ]),
     ],
   });
@@ -83,11 +90,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
       hasReturn: true,
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME('tailRec1'),
-          functionArguments: [HIR_VARIABLE('n')],
+          functionExpression: HIR_NAME('tailRec1', functionType([intType], intType)),
+          functionArguments: [HIR_VARIABLE('n', intType)],
           returnCollector: 'collector',
         }),
-        HIR_RETURN(HIR_VARIABLE('collector')),
+        HIR_RETURN(HIR_VARIABLE('collector', intType)),
       ],
     })
   ).toEqual({
@@ -96,11 +103,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
     hasReturn: true,
     body: [
       HIR_FUNCTION_CALL({
-        functionExpression: HIR_NAME('tailRec1'),
-        functionArguments: [HIR_VARIABLE('n')],
+        functionExpression: HIR_NAME('tailRec1', functionType([intType], intType)),
+        functionArguments: [HIR_VARIABLE('n', intType)],
         returnCollector: 'collector',
       }),
-      HIR_RETURN(HIR_VARIABLE('collector')),
+      HIR_RETURN(HIR_VARIABLE('collector', intType)),
     ],
   });
 });
@@ -113,11 +120,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
       hasReturn: true,
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME('tailRec'),
-          functionArguments: [HIR_VARIABLE('n')],
+          functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+          functionArguments: [HIR_VARIABLE('n', intType)],
           returnCollector: 'collector1',
         }),
-        HIR_RETURN(HIR_VARIABLE('collector')),
+        HIR_RETURN(HIR_VARIABLE('collector', intType)),
       ],
     })
   ).toEqual({
@@ -126,11 +133,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
     hasReturn: true,
     body: [
       HIR_FUNCTION_CALL({
-        functionExpression: HIR_NAME('tailRec'),
-        functionArguments: [HIR_VARIABLE('n')],
+        functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+        functionArguments: [HIR_VARIABLE('n', intType)],
         returnCollector: 'collector1',
       }),
-      HIR_RETURN(HIR_VARIABLE('collector')),
+      HIR_RETURN(HIR_VARIABLE('collector', intType)),
     ],
   });
 });
@@ -146,11 +153,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
           booleanExpression: HIR_ONE,
           s1: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('tailRec'),
-              functionArguments: [HIR_VARIABLE('n')],
+              functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+              functionArguments: [HIR_VARIABLE('n', intType)],
               returnCollector: 'collector',
             }),
-            HIR_RETURN(HIR_VARIABLE('collector')),
+            HIR_RETURN(HIR_VARIABLE('collector', intType)),
           ],
           s2: [HIR_RETURN(HIR_ZERO)],
         }),
@@ -167,11 +174,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
           s1: [
             HIR_LET({
               name: '_tailRecTransformationArgument0',
-              assignedExpression: HIR_VARIABLE('n'),
+              assignedExpression: HIR_VARIABLE('n', intType),
             }),
             HIR_LET({
               name: 'n',
-              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
             }),
           ],
           s2: [HIR_RETURN(HIR_ZERO)],
@@ -193,11 +200,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
           s1: [HIR_RETURN(HIR_ZERO)],
           s2: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('tailRec'),
-              functionArguments: [HIR_VARIABLE('n')],
+              functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+              functionArguments: [HIR_VARIABLE('n', intType)],
               returnCollector: 'collector',
             }),
-            HIR_RETURN(HIR_VARIABLE('collector')),
+            HIR_RETURN(HIR_VARIABLE('collector', intType)),
           ],
         }),
       ],
@@ -214,11 +221,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
           s2: [
             HIR_LET({
               name: '_tailRecTransformationArgument0',
-              assignedExpression: HIR_VARIABLE('n'),
+              assignedExpression: HIR_VARIABLE('n', intType),
             }),
             HIR_LET({
               name: 'n',
-              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+              assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
             }),
           ],
         }),
@@ -272,11 +279,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                   booleanExpression: HIR_ONE,
                   s1: [
                     HIR_FUNCTION_CALL({
-                      functionExpression: HIR_NAME('tailRec'),
-                      functionArguments: [HIR_VARIABLE('n')],
+                      functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+                      functionArguments: [HIR_VARIABLE('n', intType)],
                       returnCollector: 'collector',
                     }),
-                    HIR_RETURN(HIR_VARIABLE('collector')),
+                    HIR_RETURN(HIR_VARIABLE('collector', intType)),
                   ],
                   s2: [HIR_RETURN(HIR_ZERO)],
                 }),
@@ -305,11 +312,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                   s1: [
                     HIR_LET({
                       name: '_tailRecTransformationArgument0',
-                      assignedExpression: HIR_VARIABLE('n'),
+                      assignedExpression: HIR_VARIABLE('n', intType),
                     }),
                     HIR_LET({
                       name: 'n',
-                      assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+                      assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
                     }),
                   ],
                   s2: [HIR_RETURN(HIR_ZERO)],
@@ -342,15 +349,15 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                   booleanExpression: HIR_ONE,
                   s1: [
                     HIR_FUNCTION_CALL({
-                      functionExpression: HIR_NAME('tailRec'),
-                      functionArguments: [HIR_VARIABLE('n')],
+                      functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+                      functionArguments: [HIR_VARIABLE('n', intType)],
                       returnCollector: 'collector',
                     }),
                   ],
                   s2: [
                     HIR_FUNCTION_CALL({
-                      functionExpression: HIR_NAME('tailRec1'),
-                      functionArguments: [HIR_VARIABLE('n')],
+                      functionExpression: HIR_NAME('tailRec1', functionType([intType], intType)),
+                      functionArguments: [HIR_VARIABLE('n', intType)],
                       returnCollector: 'collector',
                     }),
                   ],
@@ -365,8 +372,8 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
               s1: [],
               s2: [
                 HIR_FUNCTION_CALL({
-                  functionExpression: HIR_NAME('tailRec'),
-                  functionArguments: [HIR_VARIABLE('n')],
+                  functionExpression: HIR_NAME('tailRec', functionType([intType], intType)),
+                  functionArguments: [HIR_VARIABLE('n', intType)],
                   returnCollector: 'collector',
                 }),
               ],
@@ -392,17 +399,17 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                   s1: [
                     HIR_LET({
                       name: '_tailRecTransformationArgument0',
-                      assignedExpression: HIR_VARIABLE('n'),
+                      assignedExpression: HIR_VARIABLE('n', intType),
                     }),
                     HIR_LET({
                       name: 'n',
-                      assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+                      assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
                     }),
                   ],
                   s2: [
                     HIR_FUNCTION_CALL({
-                      functionExpression: HIR_NAME('tailRec1'),
-                      functionArguments: [HIR_VARIABLE('n')],
+                      functionExpression: HIR_NAME('tailRec1', functionType([intType], intType)),
+                      functionArguments: [HIR_VARIABLE('n', intType)],
                       returnCollector: 'collector',
                     }),
                     HIR_RETURN(HIR_ZERO),
@@ -419,11 +426,11 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
               s2: [
                 HIR_LET({
                   name: '_tailRecTransformationArgument0',
-                  assignedExpression: HIR_VARIABLE('n'),
+                  assignedExpression: HIR_VARIABLE('n', intType),
                 }),
                 HIR_LET({
                   name: 'n',
-                  assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0'),
+                  assignedExpression: HIR_VARIABLE('_tailRecTransformationArgument0', intType),
                 }),
               ],
             }),

--- a/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
@@ -1,11 +1,11 @@
 import compileSamlangSourcesToHighIRSources from '../hir-toplevel-lowering';
 
 import {
+  unitType,
   boolType,
   intType,
   identifierType,
   functionType,
-  unitType,
   Range,
   ModuleReference,
 } from 'samlang-core-ast/common-nodes';
@@ -191,7 +191,10 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
         hasReturn: false,
         body: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_module__class_Class1_function_infiniteLoop'),
+            functionExpression: HIR_NAME(
+              '_module__class_Class1_function_infiniteLoop',
+              functionType([], intType)
+            ),
             functionArguments: [],
             returnCollector: '_t0',
           }),
@@ -209,7 +212,10 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
         hasReturn: false,
         body: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_module__class_Main_function_main'),
+            functionExpression: HIR_NAME(
+              '_module__class_Main_function_main',
+              functionType([], unitType)
+            ),
             functionArguments: [],
           }),
         ],

--- a/samlang-core-compiler/__tests__/mir-lowering-translator.test.ts
+++ b/samlang-core-compiler/__tests__/mir-lowering-translator.test.ts
@@ -1,6 +1,7 @@
 import midIRTranslateStatementsAndCollectGlobalStrings from '../mir-lowering-translator';
 import MidIRResourceAllocator from '../mir-resource-allocator';
 
+import { intType } from 'samlang-core-ast/common-nodes';
 import {
   HighIRStatement,
   HIR_INT,
@@ -33,16 +34,16 @@ const assertCorrectlyLoweredWithPreConfiguredSetup = (
 it('midIRTranslateStatementsAndCollectGlobalStrings test', () => {
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_FUNCTION_CALL({
-      functionExpression: HIR_NAME('foo'),
-      functionArguments: [HIR_INT(BigInt(1)), HIR_STRING('bar'), HIR_VARIABLE('baz')],
+      functionExpression: HIR_NAME('foo', intType),
+      functionArguments: [HIR_INT(BigInt(1)), HIR_STRING('bar'), HIR_VARIABLE('baz', intType)],
       returnCollector: 'bar',
     }),
     `_bar = foo(1, (GLOBAL_STRING_0 + 8), _baz);`
   );
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_FUNCTION_CALL({
-      functionExpression: HIR_NAME('foo'),
-      functionArguments: [HIR_INT(BigInt(1)), HIR_STRING('bar'), HIR_VARIABLE('baz')],
+      functionExpression: HIR_NAME('foo', intType),
+      functionArguments: [HIR_INT(BigInt(1)), HIR_STRING('bar'), HIR_VARIABLE('baz', intType)],
     }),
     `foo(1, (GLOBAL_STRING_0 + 8), _baz);`
   );
@@ -51,7 +52,14 @@ it('midIRTranslateStatementsAndCollectGlobalStrings test', () => {
     HIR_IF_ELSE({
       booleanExpression: HIR_INT(BigInt(1)),
       s1: [
-        HIR_RETURN(HIR_BINARY({ operator: '+', e1: HIR_INT(BigInt(2)), e2: HIR_INT(BigInt(2)) })),
+        HIR_RETURN(
+          HIR_BINARY({
+            type: intType,
+            operator: '+',
+            e1: HIR_INT(BigInt(2)),
+            e2: HIR_INT(BigInt(2)),
+          })
+        ),
       ],
       s2: [HIR_RETURN(HIR_INT(BigInt(2)))],
     }),
@@ -74,7 +82,11 @@ goto LABEL__0_PURPOSE_WHILE_TRUE_START;`
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_LET({
       name: 'foo',
-      assignedExpression: HIR_INDEX_ACCESS({ expression: HIR_VARIABLE('this'), index: 2 }),
+      assignedExpression: HIR_INDEX_ACCESS({
+        type: intType,
+        expression: HIR_VARIABLE('this', intType),
+        index: 2,
+      }),
     }),
     '_foo = MEM[(_this + 16)];'
   );
@@ -82,7 +94,7 @@ goto LABEL__0_PURPOSE_WHILE_TRUE_START;`
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_STRUCT_INITIALIZATION({
       structVariableName: 'struct',
-      expressionList: [HIR_VARIABLE('this'), HIR_VARIABLE('that')],
+      expressionList: [HIR_VARIABLE('this', intType), HIR_VARIABLE('that', intType)],
     }),
     `_struct = _builtin_malloc(16);
 MEM[(_struct + 0)] = _this;

--- a/samlang-core-compiler/hir-tail-recursion-transformation-hir.ts
+++ b/samlang-core-compiler/hir-tail-recursion-transformation-hir.ts
@@ -11,6 +11,7 @@ import {
   HIR_RETURN,
 } from 'samlang-core-ast/hir-expressions';
 import type { HighIRFunction } from 'samlang-core-ast/hir-toplevel';
+import { checkNotNull } from 'samlang-core-utils';
 
 const performTailRecursiveCallTransformationOnLinearStatementsWithFinalReturn = (
   highIRFunction: HighIRFunction,
@@ -41,7 +42,13 @@ const performTailRecursiveCallTransformationOnLinearStatementsWithFinalReturn = 
       HIR_LET({ name: `_tailRecTransformationArgument${i}`, assignedExpression: functionArgument })
     ),
     ...highIRFunction.parameters.map((name, i) =>
-      HIR_LET({ name, assignedExpression: HIR_VARIABLE(`_tailRecTransformationArgument${i}`) })
+      HIR_LET({
+        name,
+        assignedExpression: HIR_VARIABLE(
+          `_tailRecTransformationArgument${i}`,
+          checkNotNull(functionArguments[i]).type
+        ),
+      })
     ),
   ];
 };
@@ -70,7 +77,13 @@ const performTailRecursiveCallTransformationOnLinearStatementsWithoutFinalReturn
       HIR_LET({ name: `_tailRecTransformationArgument${i}`, assignedExpression: functionArgument })
     ),
     ...highIRFunction.parameters.map((name, i) =>
-      HIR_LET({ name, assignedExpression: HIR_VARIABLE(`_tailRecTransformationArgument${i}`) })
+      HIR_LET({
+        name,
+        assignedExpression: HIR_VARIABLE(
+          `_tailRecTransformationArgument${i}`,
+          checkNotNull(functionArguments[i]).type
+        ),
+      })
     ),
   ];
 };

--- a/samlang-core-compiler/hir-toplevel-lowering.ts
+++ b/samlang-core-compiler/hir-toplevel-lowering.ts
@@ -7,7 +7,7 @@ import {
   encodeFunctionNameGlobally,
   encodeMainFunctionName,
 } from 'samlang-core-ast/common-names';
-import type { ModuleReference, Sources } from 'samlang-core-ast/common-nodes';
+import { ModuleReference, unitType, functionType, Sources } from 'samlang-core-ast/common-nodes';
 import { HIR_FUNCTION_CALL, HIR_NAME, HIR_RETURN } from 'samlang-core-ast/hir-expressions';
 import type { HighIRFunction, HighIRModule } from 'samlang-core-ast/hir-toplevel';
 import type { ClassMemberDefinition, SamlangModule } from 'samlang-core-ast/samlang-toplevel';
@@ -66,7 +66,7 @@ const compileSamlangSourcesToHighIRSources = (
         hasReturn: false,
         body: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME(entryPointFunctionName),
+            functionExpression: HIR_NAME(entryPointFunctionName, functionType([], unitType)),
             functionArguments: [],
           }),
         ],

--- a/samlang-core-printer/__tests__/printer-js.test.ts
+++ b/samlang-core-printer/__tests__/printer-js.test.ts
@@ -13,6 +13,7 @@ import {
   ENCODED_FUNCTION_NAME_INT_TO_STRING,
   ENCODED_FUNCTION_NAME_THROW,
 } from 'samlang-core-ast/common-names';
+import { intType, unitType } from 'samlang-core-ast/common-nodes';
 import {
   HIR_IF_ELSE,
   HIR_BINARY,
@@ -64,13 +65,13 @@ it('compile hello world to JS integration test', () => {
         hasReturn: false,
         body: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_builtin_stringConcat'),
+            functionExpression: HIR_NAME('_builtin_stringConcat', unitType),
             functionArguments: [HIR_STRING('Hello '), HIR_STRING('World!')],
             returnCollector: '_t0',
           }),
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_builtin_println'),
-            functionArguments: [HIR_VARIABLE('_t0')],
+            functionExpression: HIR_NAME('_builtin_println', unitType),
+            functionArguments: [HIR_VARIABLE('_t0', unitType)],
             returnCollector: '_t1',
           }),
         ],
@@ -81,7 +82,7 @@ it('compile hello world to JS integration test', () => {
         hasReturn: false,
         body: [
           HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('_module_Test_class_Main_function_main'),
+            functionExpression: HIR_NAME('_module_Test_class_Main_function_main', unitType),
             functionArguments: [],
           }),
         ],
@@ -123,13 +124,13 @@ it('confirm samlang & equivalent JS have same print output', () => {
           hasReturn: false,
           body: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_stringConcat'),
+              functionExpression: HIR_NAME('_builtin_stringConcat', unitType),
               functionArguments: [HIR_STRING('Hello '), HIR_STRING('World!')],
               returnCollector: '_t0',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_println'),
-              functionArguments: [HIR_VARIABLE('_t0')],
+              functionExpression: HIR_NAME('_builtin_println', unitType),
+              functionArguments: [HIR_VARIABLE('_t0', unitType)],
               returnCollector: '_t1',
             }),
           ],
@@ -159,7 +160,14 @@ it('confirm samlang & equivalent JS have same print output', () => {
           parameters: ['a', 'b'],
           hasReturn: true,
           body: [
-            HIR_RETURN(HIR_BINARY({ operator: '+', e1: HIR_VARIABLE('a'), e2: HIR_VARIABLE('b') })),
+            HIR_RETURN(
+              HIR_BINARY({
+                type: unitType,
+                operator: '+',
+                e1: HIR_VARIABLE('a', unitType),
+                e2: HIR_VARIABLE('b', unitType),
+              })
+            ),
           ],
         },
         {
@@ -168,18 +176,18 @@ it('confirm samlang & equivalent JS have same print output', () => {
           hasReturn: false,
           body: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('sum'),
+              functionExpression: HIR_NAME('sum', unitType),
               functionArguments: [HIR_INT(BigInt(42)), HIR_INT(BigInt(7))],
               returnCollector: '_t0',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_intToString'),
-              functionArguments: [HIR_VARIABLE('_t0')],
+              functionExpression: HIR_NAME('_builtin_intToString', unitType),
+              functionArguments: [HIR_VARIABLE('_t0', unitType)],
               returnCollector: '_t1',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_println'),
-              functionArguments: [HIR_VARIABLE('_t1')],
+              functionExpression: HIR_NAME('_builtin_println', unitType),
+              functionArguments: [HIR_VARIABLE('_t1', unitType)],
               returnCollector: '_t2',
             }),
           ],
@@ -198,8 +206,9 @@ it('confirm samlang & equivalent JS have same print output', () => {
           body: [
             HIR_IF_ELSE({
               booleanExpression: HIR_BINARY({
+                type: unitType,
                 operator: '==',
-                e1: HIR_VARIABLE('sum'),
+                e1: HIR_VARIABLE('sum', unitType),
                 e2: HIR_INT(BigInt(42)),
               }),
               s1: [HIR_RETURN(HIR_STRING('Meaning of life'))],
@@ -212,7 +221,14 @@ it('confirm samlang & equivalent JS have same print output', () => {
           parameters: ['a', 'b'],
           hasReturn: true,
           body: [
-            HIR_RETURN(HIR_BINARY({ operator: '+', e1: HIR_VARIABLE('a'), e2: HIR_VARIABLE('b') })),
+            HIR_RETURN(
+              HIR_BINARY({
+                type: intType,
+                operator: '+',
+                e1: HIR_VARIABLE('a', unitType),
+                e2: HIR_VARIABLE('b', unitType),
+              })
+            ),
           ],
         },
         {
@@ -221,18 +237,18 @@ it('confirm samlang & equivalent JS have same print output', () => {
           hasReturn: false,
           body: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('sum'),
+              functionExpression: HIR_NAME('sum', unitType),
               functionArguments: [HIR_INT(BigInt(42)), HIR_INT(BigInt(7))],
               returnCollector: '_t0',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('MeaningOfLifeConditional'),
-              functionArguments: [HIR_VARIABLE('_t0')],
+              functionExpression: HIR_NAME('MeaningOfLifeConditional', unitType),
+              functionArguments: [HIR_VARIABLE('_t0', unitType)],
               returnCollector: '_t1',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_println'),
-              functionArguments: [HIR_VARIABLE('_t1')],
+              functionExpression: HIR_NAME('_builtin_println', unitType),
+              functionArguments: [HIR_VARIABLE('_t1', unitType)],
               returnCollector: '_t2',
             }),
           ],
@@ -253,7 +269,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
               structVariableName: 't0',
               expressionList: [HIR_STRING('RANDOM_BABY')],
             }),
-            HIR_RETURN(HIR_VARIABLE('t0')),
+            HIR_RETURN(HIR_VARIABLE('t0', unitType)),
           ],
         },
         {
@@ -263,7 +279,8 @@ it('confirm samlang & equivalent JS have same print output', () => {
           body: [
             HIR_RETURN(
               HIR_INDEX_ACCESS({
-                expression: HIR_VARIABLE('s'),
+                type: unitType,
+                expression: HIR_VARIABLE('s', unitType),
                 index: 0,
               })
             ),
@@ -275,18 +292,18 @@ it('confirm samlang & equivalent JS have same print output', () => {
           hasReturn: false,
           body: [
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('dummyStudent'),
+              functionExpression: HIR_NAME('dummyStudent', unitType),
               functionArguments: [],
               returnCollector: '_t0',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('getName'),
-              functionArguments: [HIR_VARIABLE('_t0')],
+              functionExpression: HIR_NAME('getName', unitType),
+              functionArguments: [HIR_VARIABLE('_t0', unitType)],
               returnCollector: '_t1',
             }),
             HIR_FUNCTION_CALL({
-              functionExpression: HIR_NAME('_builtin_println'),
-              functionArguments: [HIR_VARIABLE('_t1')],
+              functionExpression: HIR_NAME('_builtin_println', unitType),
+              functionArguments: [HIR_VARIABLE('_t1', unitType)],
               returnCollector: '_t2',
             }),
           ],
@@ -303,7 +320,14 @@ it('confirm samlang & equivalent JS have same print output', () => {
           parameters: ['a', 'b'],
           hasReturn: true,
           body: [
-            HIR_RETURN(HIR_BINARY({ operator: '+', e1: HIR_VARIABLE('a'), e2: HIR_VARIABLE('b') })),
+            HIR_RETURN(
+              HIR_BINARY({
+                type: unitType,
+                operator: '+',
+                e1: HIR_VARIABLE('a', unitType),
+                e2: HIR_VARIABLE('b', unitType),
+              })
+            ),
           ],
         },
         {
@@ -313,13 +337,14 @@ it('confirm samlang & equivalent JS have same print output', () => {
           body: [
             HIR_IF_ELSE({
               booleanExpression: HIR_BINARY({
+                type: unitType,
                 operator: '==',
                 e1: HIR_INT(BigInt(0)),
                 e2: HIR_INT(BigInt(0)),
               }),
               s1: [
                 HIR_FUNCTION_CALL({
-                  functionExpression: HIR_NAME('_builtin_throw'),
+                  functionExpression: HIR_NAME('_builtin_throw', unitType),
                   functionArguments: [HIR_STRING('Division by zero is illegal!')],
                 }),
               ],
@@ -337,6 +362,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_IF_ELSE({
         booleanExpression: HIR_BINARY({
+          type: unitType,
           operator: '==',
           e1: HIR_INT(BigInt(5)),
           e2: HIR_INT(BigInt(5)),
@@ -354,6 +380,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_IF_ELSE({
         booleanExpression: HIR_BINARY({
+          type: unitType,
           operator: '==',
           e1: HIR_INT(BigInt(5)),
           e2: HIR_INT(BigInt(5)),
@@ -371,6 +398,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_IF_ELSE({
         booleanExpression: HIR_BINARY({
+          type: unitType,
           operator: '==',
           e1: HIR_INT(BigInt(5)),
           e2: HIR_INT(BigInt(5)),
@@ -379,6 +407,7 @@ it('HIR statements to JS string test', () => {
         s2: [
           HIR_IF_ELSE({
             booleanExpression: HIR_BINARY({
+              type: unitType,
               operator: '==',
               e1: HIR_INT(BigInt(5)),
               e2: HIR_INT(BigInt(5)),
@@ -403,7 +432,7 @@ it('HIR statements to JS string test', () => {
       HIR_WHILE_TRUE([
         HIR_FUNCTION_CALL({
           functionArguments: [],
-          functionExpression: HIR_NAME('func'),
+          functionExpression: HIR_NAME('func', unitType),
           returnCollector: 'val',
         }),
       ])
@@ -415,7 +444,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [],
-        functionExpression: HIR_NAME('func'),
+        functionExpression: HIR_NAME('func', unitType),
         returnCollector: 'val',
       })
     )
@@ -424,7 +453,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [],
-        functionExpression: HIR_NAME('func'),
+        functionExpression: HIR_NAME('func', unitType),
       })
     )
   ).toBe('func();');
@@ -432,7 +461,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('Hello, world')],
-        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_PRINTLN),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_PRINTLN, unitType),
         returnCollector: 'res',
       })
     )
@@ -441,7 +470,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('5')],
-        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_TO_INT),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_TO_INT, unitType),
         returnCollector: 'res',
       })
     )
@@ -450,7 +479,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_INT(BigInt(5))],
-        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_INT_TO_STRING),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_INT_TO_STRING, unitType),
         returnCollector: 'res',
       })
     )
@@ -459,7 +488,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('5'), HIR_STRING('4')],
-        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_CONCAT),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_CONCAT, unitType),
         returnCollector: 'res',
       })
     )
@@ -468,7 +497,7 @@ it('HIR statements to JS string test', () => {
     highIRStatementToString(
       HIR_FUNCTION_CALL({
         functionArguments: [HIR_STRING('panik')],
-        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_THROW),
+        functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_THROW, unitType),
         returnCollector: 'panik',
       })
     )
@@ -539,7 +568,8 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_INDEX_ACCESS({
-        expression: HIR_VARIABLE('samlang'),
+        type: unitType,
+        expression: HIR_VARIABLE('samlang', unitType),
         index: 3,
       })
     )
@@ -547,8 +577,10 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_INDEX_ACCESS({
+        type: unitType,
         expression: HIR_INDEX_ACCESS({
-          expression: HIR_VARIABLE('a'),
+          type: unitType,
+          expression: HIR_VARIABLE('a', unitType),
           index: 4,
         }),
         index: 3,
@@ -558,7 +590,9 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_INDEX_ACCESS({
+        type: unitType,
         expression: HIR_BINARY({
+          type: unitType,
           operator: '+',
           e1: HIR_STRING('a'),
           e2: HIR_STRING('b'),
@@ -567,11 +601,12 @@ it('HIR expression to JS string test', () => {
       })
     )
   ).toBe('("a" + "b")[0]');
-  expect(highIRExpressionToString(HIR_VARIABLE('ts'))).toBe('ts');
-  expect(highIRExpressionToString(HIR_NAME('key'))).toBe('key');
+  expect(highIRExpressionToString(HIR_VARIABLE('ts', unitType))).toBe('ts');
+  expect(highIRExpressionToString(HIR_NAME('key', unitType))).toBe('key');
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '!=',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_INT(BigInt(7)),
@@ -581,6 +616,7 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '/',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_INT(BigInt(8)),
@@ -590,9 +626,11 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '+',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '*',
           e1: HIR_INT(BigInt(4)),
           e2: HIR_INT(BigInt(4)),
@@ -603,9 +641,11 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '*',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '+',
           e1: HIR_INT(BigInt(4)),
           e2: HIR_INT(BigInt(4)),
@@ -616,9 +656,11 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '*',
         e1: HIR_INT(BigInt(7)),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '*',
           e1: HIR_INT(BigInt(4)),
           e2: HIR_INT(BigInt(4)),
@@ -629,13 +671,16 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '*',
         e1: HIR_BINARY({
+          type: unitType,
           operator: '*',
           e1: HIR_INT(BigInt(1)),
           e2: HIR_INT(BigInt(2)),
         }),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '*',
           e1: HIR_INT(BigInt(3)),
           e2: HIR_INT(BigInt(4)),
@@ -646,13 +691,16 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '+',
         e1: HIR_BINARY({
+          type: unitType,
           operator: '-',
           e1: HIR_INT(BigInt(1)),
           e2: HIR_INT(BigInt(2)),
         }),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '%',
           e1: HIR_INT(BigInt(3)),
           e2: HIR_INT(BigInt(4)),
@@ -663,9 +711,11 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '+',
-        e1: HIR_NAME('somevar'),
+        e1: HIR_NAME('somevar', unitType),
         e2: HIR_BINARY({
+          type: unitType,
           operator: '-',
           e1: HIR_INT(BigInt(3)),
           e2: HIR_INT(BigInt(4)),
@@ -676,9 +726,11 @@ it('HIR expression to JS string test', () => {
   expect(
     highIRExpressionToString(
       HIR_BINARY({
+        type: unitType,
         operator: '+',
         e1: HIR_INDEX_ACCESS({
-          expression: HIR_VARIABLE('a'),
+          type: unitType,
+          expression: HIR_VARIABLE('a', unitType),
           index: 2,
         }),
         e2: HIR_INT(BigInt(1)),


### PR DESCRIPTION
## Summary

Create typed HIR for the purpose of supporting LLVM eventually.

The current types sticked into the slots are far from accurate. However, the infra is not ready yet to make them accurate. Since we don't use the types for any serious stuff, it's OK for now.

## Test Plan

`yarn test`
