### PR TITLE
[test] Avoid serialize in HIR lowering test

### DIFF
--- a/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
@@ -63,19 +63,13 @@ const expectCorrectlyLowered = (
     expression = HIR_ZERO,
   }: Partial<ReturnType<typeof lowerSamlangExpression>>
 ): void => {
-  const serialize = (json: unknown): string =>
-    JSON.stringify(json, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 4);
   expect(
-    serialize(
-      lowerSamlangExpression(ModuleReference.ROOT, 'ENCODED_FUNCTION_NAME', samlangExpression)
-    )
-  ).toEqual(
-    serialize({
-      statements,
-      expression,
-      syntheticFunctions,
-    })
-  );
+    lowerSamlangExpression(ModuleReference.ROOT, 'ENCODED_FUNCTION_NAME', samlangExpression)
+  ).toEqual({
+    statements,
+    expression,
+    syntheticFunctions,
+  });
 };
 
 it('Literal lowering works.', () => {


### PR DESCRIPTION


## Summary

Since we migrated to the serializable Long instead of bigint, there is no need for that.

## Test Plan

`yarn test`
