### PR TITLE
[ast] Eliminate pointer type from HIR

### DIFF
--- a/samlang-core-ast/__tests__/hir-types.test.ts
+++ b/samlang-core-ast/__tests__/hir-types.test.ts
@@ -2,8 +2,8 @@ import {
   HIR_VOID_TYPE,
   HIR_INT_TYPE,
   HIR_ANY_TYPE,
+  HIR_STRING_TYPE,
   HIR_IDENTIFIER_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
   prettyPrintHighIRType,
@@ -15,37 +15,32 @@ it('prettyPrintHighIRType works', () => {
     prettyPrintHighIRType(
       HIR_FUNCTION_TYPE(
         [HIR_STRUCT_TYPE([HIR_VOID_TYPE, HIR_INT_TYPE])],
-        HIR_FUNCTION_TYPE(
-          [HIR_IDENTIFIER_TYPE('Foo'), HIR_POINTER_TYPE(HIR_ANY_TYPE)],
-          HIR_VOID_TYPE
-        )
+        HIR_FUNCTION_TYPE([HIR_IDENTIFIER_TYPE('Foo'), HIR_ANY_TYPE], HIR_STRING_TYPE)
       )
     )
-  ).toBe('((void, int)) -> (Foo, Boxed<any>) -> void');
+  ).toBe('((void, int)) -> (Foo, any) -> string');
 });
 
 it('isTheSameHighIRType works', () => {
   expect(isTheSameHighIRType(HIR_VOID_TYPE, HIR_VOID_TYPE)).toBeTruthy();
   expect(isTheSameHighIRType(HIR_VOID_TYPE, HIR_ANY_TYPE)).toBeFalsy();
   expect(isTheSameHighIRType(HIR_VOID_TYPE, HIR_INT_TYPE)).toBeFalsy();
-  expect(isTheSameHighIRType(HIR_ANY_TYPE, HIR_VOID_TYPE)).toBeFalsy();
+  expect(isTheSameHighIRType(HIR_STRING_TYPE, HIR_STRING_TYPE)).toBeTruthy();
+  expect(isTheSameHighIRType(HIR_STRING_TYPE, HIR_ANY_TYPE)).toBeFalsy();
+  expect(isTheSameHighIRType(HIR_STRING_TYPE, HIR_INT_TYPE)).toBeFalsy();
+  expect(isTheSameHighIRType(HIR_ANY_TYPE, HIR_STRING_TYPE)).toBeFalsy();
   expect(isTheSameHighIRType(HIR_ANY_TYPE, HIR_ANY_TYPE)).toBeTruthy();
   expect(isTheSameHighIRType(HIR_ANY_TYPE, HIR_INT_TYPE)).toBeFalsy();
-  expect(isTheSameHighIRType(HIR_INT_TYPE, HIR_VOID_TYPE)).toBeFalsy();
+  expect(isTheSameHighIRType(HIR_INT_TYPE, HIR_STRING_TYPE)).toBeFalsy();
   expect(isTheSameHighIRType(HIR_INT_TYPE, HIR_ANY_TYPE)).toBeFalsy();
   expect(isTheSameHighIRType(HIR_INT_TYPE, HIR_INT_TYPE)).toBeTruthy();
 
-  expect(isTheSameHighIRType(HIR_IDENTIFIER_TYPE('A'), HIR_VOID_TYPE)).toBeFalsy();
+  expect(isTheSameHighIRType(HIR_IDENTIFIER_TYPE('A'), HIR_STRING_TYPE)).toBeFalsy();
   expect(isTheSameHighIRType(HIR_IDENTIFIER_TYPE('A'), HIR_IDENTIFIER_TYPE('B'))).toBeFalsy();
   expect(isTheSameHighIRType(HIR_IDENTIFIER_TYPE('A'), HIR_IDENTIFIER_TYPE('A'))).toBeTruthy();
 
-  expect(isTheSameHighIRType(HIR_POINTER_TYPE(HIR_INT_TYPE), HIR_INT_TYPE)).toBeFalsy();
   expect(
-    isTheSameHighIRType(HIR_POINTER_TYPE(HIR_INT_TYPE), HIR_POINTER_TYPE(HIR_INT_TYPE))
-  ).toBeTruthy();
-
-  expect(
-    isTheSameHighIRType(HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_ANY_TYPE]), HIR_VOID_TYPE)
+    isTheSameHighIRType(HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_ANY_TYPE]), HIR_INT_TYPE)
   ).toBeFalsy();
   expect(
     isTheSameHighIRType(HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_ANY_TYPE]), HIR_STRUCT_TYPE([]))
@@ -70,7 +65,7 @@ it('isTheSameHighIRType works', () => {
   ).toBeTruthy();
 
   expect(
-    isTheSameHighIRType(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_ANY_TYPE), HIR_VOID_TYPE)
+    isTheSameHighIRType(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_ANY_TYPE), HIR_INT_TYPE)
   ).toBeFalsy();
   expect(
     isTheSameHighIRType(

--- a/samlang-core-ast/hir-expressions.ts
+++ b/samlang-core-ast/hir-expressions.ts
@@ -1,5 +1,5 @@
 import type { IROperator } from './common-operators';
-import { HighIRType, HIR_INT_TYPE, HIR_POINTER_TYPE } from './hir-types';
+import { HighIRType, HIR_INT_TYPE, HIR_STRING_TYPE } from './hir-types';
 
 import { Long } from 'samlang-core-utils';
 
@@ -117,7 +117,7 @@ export const HIR_INT = (value: number | Long): HighIRIntLiteralExpression => ({
 
 export const HIR_STRING = (value: string): HighIRStringLiteralExpression => ({
   __type__: 'HighIRStringLiteralExpression',
-  type: HIR_POINTER_TYPE(HIR_INT_TYPE),
+  type: HIR_STRING_TYPE,
   value,
 });
 

--- a/samlang-core-ast/hir-types.ts
+++ b/samlang-core-ast/hir-types.ts
@@ -2,15 +2,13 @@ import { checkNotNull } from 'samlang-core-utils';
 
 export type HighIRPrimitiveType = {
   readonly __type__: 'PrimitiveType';
-  readonly type: 'void' | 'int' | 'any';
+  readonly type: 'void' | 'int' | 'any' | 'string';
 };
 
 export type HighIRIdentifierType = {
   readonly __type__: 'IdentifierType';
   readonly name: string;
 };
-
-export type HighIRPointerType = { readonly __type__: 'PointerType'; readonly boxed: HighIRType };
 
 export type HighIRStructType = {
   readonly __type__: 'StructType';
@@ -26,18 +24,13 @@ export type HighIRFunctionType = {
 export type HighIRType =
   | HighIRPrimitiveType
   | HighIRIdentifierType
-  | HighIRPointerType
   | HighIRStructType
   | HighIRFunctionType;
 
 export const HIR_VOID_TYPE: HighIRPrimitiveType = { __type__: 'PrimitiveType', type: 'void' };
 export const HIR_INT_TYPE: HighIRPrimitiveType = { __type__: 'PrimitiveType', type: 'int' };
 export const HIR_ANY_TYPE: HighIRPrimitiveType = { __type__: 'PrimitiveType', type: 'any' };
-
-export const HIR_POINTER_TYPE = (boxed: HighIRType): HighIRPointerType => ({
-  __type__: 'PointerType',
-  boxed,
-});
+export const HIR_STRING_TYPE: HighIRPrimitiveType = { __type__: 'PrimitiveType', type: 'string' };
 
 export const HIR_IDENTIFIER_TYPE = (name: string): HighIRIdentifierType => ({
   __type__: 'IdentifierType',
@@ -54,11 +47,7 @@ export const HIR_FUNCTION_TYPE = (
   returnType: HighIRType
 ): HighIRFunctionType => ({ __type__: 'FunctionType', argumentTypes, returnType });
 
-export const HIR_STRING_TYPE: HighIRPointerType = HIR_POINTER_TYPE(HIR_INT_TYPE);
-
-export const HIR_CLOSURE_TYPE: HighIRPointerType = HIR_POINTER_TYPE(
-  HIR_STRUCT_TYPE([HIR_ANY_TYPE, HIR_ANY_TYPE])
-);
+export const HIR_CLOSURE_TYPE: HighIRStructType = HIR_STRUCT_TYPE([HIR_ANY_TYPE, HIR_ANY_TYPE]);
 
 export const prettyPrintHighIRType = (type: HighIRType): string => {
   switch (type.__type__) {
@@ -66,8 +55,6 @@ export const prettyPrintHighIRType = (type: HighIRType): string => {
       return type.type;
     case 'IdentifierType':
       return type.name;
-    case 'PointerType':
-      return `Boxed<${prettyPrintHighIRType(type.boxed)}>`;
     case 'StructType':
       return `(${type.mappings.map(prettyPrintHighIRType).join(', ')})`;
     case 'FunctionType':
@@ -83,8 +70,6 @@ export const isTheSameHighIRType = (t1: HighIRType, t2: HighIRType): boolean => 
       return t2.__type__ === 'PrimitiveType' && t1.type === t2.type;
     case 'IdentifierType':
       return t2.__type__ === 'IdentifierType' && t1.name === t2.name;
-    case 'PointerType':
-      return t2.__type__ === 'PointerType' && isTheSameHighIRType(t1.boxed, t2.boxed);
     case 'StructType':
       return (
         t2.__type__ === 'StructType' &&

--- a/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
@@ -31,7 +31,6 @@ import {
   HIR_INT_TYPE,
   HIR_ANY_TYPE,
   HIR_VOID_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
   HIR_STRING_TYPE,
@@ -143,14 +142,11 @@ it('Lowering to StructConstructor works.', () => {
       statements: [
         HIR_STRUCT_INITIALIZATION({
           structVariableName: '_t0',
-          type: HIR_POINTER_TYPE(HIR_STRUCT_TYPE([IR_DUMMY_IDENTIFIER_TYPE])),
+          type: HIR_STRUCT_TYPE([IR_DUMMY_IDENTIFIER_TYPE]),
           expressionList: [IR_THIS],
         }),
       ],
-      expression: HIR_VARIABLE(
-        '_t0',
-        HIR_POINTER_TYPE(HIR_STRUCT_TYPE([IR_DUMMY_IDENTIFIER_TYPE]))
-      ),
+      expression: HIR_VARIABLE('_t0', HIR_STRUCT_TYPE([IR_DUMMY_IDENTIFIER_TYPE])),
     }
   );
 
@@ -223,10 +219,7 @@ it('MethodAccess lowering works.', () => {
           structVariableName: '_t0',
           type: HIR_CLOSURE_TYPE,
           expressionList: [
-            HIR_NAME(
-              '_module__class_Dummy_function_foo',
-              HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([], HIR_VOID_TYPE))
-            ),
+            HIR_NAME('_module__class_Dummy_function_foo', HIR_FUNCTION_TYPE([], HIR_VOID_TYPE)),
             IR_THIS,
           ],
         }),
@@ -249,7 +242,7 @@ it('Unary lowering works.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_throw',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -275,7 +268,7 @@ it('Unary lowering works.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_throw',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -303,7 +296,7 @@ it('FunctionCall family lowering works 1/n.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_intToString',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_STRING_TYPE))
+            HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_STRING_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -327,7 +320,7 @@ it('FunctionCall family lowering works 2/n.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_stringToInt',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_INT_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_INT_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -351,7 +344,7 @@ it('FunctionCall family lowering works 3/n.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_println',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -384,9 +377,7 @@ it('FunctionCall family lowering works 4/n.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_module_ModuleModule_class_ImportedClass_function_bar',
-            HIR_POINTER_TYPE(
-              HIR_FUNCTION_TYPE([IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE], HIR_INT_TYPE)
-            )
+            HIR_FUNCTION_TYPE([IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE], HIR_INT_TYPE)
           ),
           functionArguments: [IR_THIS, IR_THIS],
           returnCollector: '_t0',
@@ -415,11 +406,9 @@ it('FunctionCall family lowering works 5/n.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_module__class_Dummy_function_fooBar',
-            HIR_POINTER_TYPE(
-              HIR_FUNCTION_TYPE(
-                [IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE],
-                HIR_INT_TYPE
-              )
+            HIR_FUNCTION_TYPE(
+              [IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE, IR_DUMMY_IDENTIFIER_TYPE],
+              HIR_INT_TYPE
             )
           ),
           functionArguments: [IR_THIS, IR_THIS, IR_THIS],
@@ -562,7 +551,7 @@ it('String concat binary lowering works.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_stringConcat',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE, HIR_STRING_TYPE], HIR_STRING_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE, HIR_STRING_TYPE], HIR_STRING_TYPE)
           ),
           functionArguments: [IR_THIS, IR_THIS],
           returnCollector: '_t0',
@@ -636,20 +625,14 @@ it('Lambda lowering works (1/n).', () => {
           name: '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
           parameters: ['_context', 'a'],
           hasReturn: false,
-          type: HIR_FUNCTION_TYPE(
-            [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
-            HIR_VOID_TYPE
-          ),
+          type: HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE], HIR_VOID_TYPE),
           body: [
             HIR_LET({
               name: 'a',
               type: HIR_VOID_TYPE,
               assignedExpression: HIR_INDEX_ACCESS({
                 type: HIR_VOID_TYPE,
-                expression: HIR_VARIABLE(
-                  '_context',
-                  HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))
-                ),
+                expression: HIR_VARIABLE('_context', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
                 index: 0,
               }),
             }),
@@ -659,7 +642,7 @@ it('Lambda lowering works (1/n).', () => {
       statements: [
         HIR_STRUCT_INITIALIZATION({
           structVariableName: '_t1',
-          type: HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
+          type: HIR_STRUCT_TYPE([HIR_VOID_TYPE]),
           expressionList: [HIR_VARIABLE('a', HIR_VOID_TYPE)],
         }),
         HIR_STRUCT_INITIALIZATION({
@@ -668,14 +651,9 @@ it('Lambda lowering works (1/n).', () => {
           expressionList: [
             HIR_NAME(
               '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
-              HIR_POINTER_TYPE(
-                HIR_FUNCTION_TYPE(
-                  [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
-                  HIR_VOID_TYPE
-                )
-              )
+              HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE], HIR_VOID_TYPE)
             ),
-            HIR_VARIABLE('_t1', HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))),
+            HIR_VARIABLE('_t1', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
           ],
         }),
       ],
@@ -699,20 +677,14 @@ it('Lambda lowering works (2/n).', () => {
           name: '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
           parameters: ['_context', 'a'],
           hasReturn: true,
-          type: HIR_FUNCTION_TYPE(
-            [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
-            HIR_INT_TYPE
-          ),
+          type: HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE], HIR_INT_TYPE),
           body: [
             HIR_LET({
               name: 'a',
               type: HIR_VOID_TYPE,
               assignedExpression: HIR_INDEX_ACCESS({
                 type: HIR_VOID_TYPE,
-                expression: HIR_VARIABLE(
-                  '_context',
-                  HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))
-                ),
+                expression: HIR_VARIABLE('_context', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
                 index: 0,
               }),
             }),
@@ -723,7 +695,7 @@ it('Lambda lowering works (2/n).', () => {
       statements: [
         HIR_STRUCT_INITIALIZATION({
           structVariableName: '_t1',
-          type: HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
+          type: HIR_STRUCT_TYPE([HIR_VOID_TYPE]),
           expressionList: [HIR_VARIABLE('a', HIR_VOID_TYPE)],
         }),
         HIR_STRUCT_INITIALIZATION({
@@ -732,14 +704,9 @@ it('Lambda lowering works (2/n).', () => {
           expressionList: [
             HIR_NAME(
               '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
-              HIR_POINTER_TYPE(
-                HIR_FUNCTION_TYPE(
-                  [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
-                  HIR_INT_TYPE
-                )
-              )
+              HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE], HIR_INT_TYPE)
             ),
-            HIR_VARIABLE('_t1', HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))),
+            HIR_VARIABLE('_t1', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
           ],
         }),
       ],
@@ -764,7 +731,7 @@ it('Lambda lowering works (3/n).', () => {
           parameters: ['_context', 'a'],
           hasReturn: true,
           type: HIR_FUNCTION_TYPE(
-            [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
+            [HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE],
             IR_DUMMY_IDENTIFIER_TYPE
           ),
           body: [
@@ -773,10 +740,7 @@ it('Lambda lowering works (3/n).', () => {
               type: HIR_VOID_TYPE,
               assignedExpression: HIR_INDEX_ACCESS({
                 type: HIR_VOID_TYPE,
-                expression: HIR_VARIABLE(
-                  '_context',
-                  HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))
-                ),
+                expression: HIR_VARIABLE('_context', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
                 index: 0,
               }),
             }),
@@ -787,7 +751,7 @@ it('Lambda lowering works (3/n).', () => {
       statements: [
         HIR_STRUCT_INITIALIZATION({
           structVariableName: '_t1',
-          type: HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
+          type: HIR_STRUCT_TYPE([HIR_VOID_TYPE]),
           expressionList: [HIR_VARIABLE('a', HIR_VOID_TYPE)],
         }),
         HIR_STRUCT_INITIALIZATION({
@@ -796,14 +760,12 @@ it('Lambda lowering works (3/n).', () => {
           expressionList: [
             HIR_NAME(
               '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
-              HIR_POINTER_TYPE(
-                HIR_FUNCTION_TYPE(
-                  [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE])), HIR_VOID_TYPE],
-                  IR_DUMMY_IDENTIFIER_TYPE
-                )
+              HIR_FUNCTION_TYPE(
+                [HIR_STRUCT_TYPE([HIR_VOID_TYPE]), HIR_VOID_TYPE],
+                IR_DUMMY_IDENTIFIER_TYPE
               )
             ),
-            HIR_VARIABLE('_t1', HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_VOID_TYPE]))),
+            HIR_VARIABLE('_t1', HIR_STRUCT_TYPE([HIR_VOID_TYPE])),
           ],
         }),
       ],
@@ -827,10 +789,7 @@ it('Lambda lowering works (4/n).', () => {
           name: '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
           parameters: ['_context', 'a'],
           hasReturn: true,
-          type: HIR_FUNCTION_TYPE(
-            [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([])), HIR_VOID_TYPE],
-            IR_DUMMY_IDENTIFIER_TYPE
-          ),
+          type: HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([]), HIR_VOID_TYPE], IR_DUMMY_IDENTIFIER_TYPE),
           body: [HIR_RETURN(IR_THIS)],
         },
       ],
@@ -841,12 +800,7 @@ it('Lambda lowering works (4/n).', () => {
           expressionList: [
             HIR_NAME(
               '_module__class_ENCODED_FUNCTION_NAME_function__SYNTHETIC_0',
-              HIR_POINTER_TYPE(
-                HIR_FUNCTION_TYPE(
-                  [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([])), HIR_VOID_TYPE],
-                  IR_DUMMY_IDENTIFIER_TYPE
-                )
-              )
+              HIR_FUNCTION_TYPE([HIR_STRUCT_TYPE([]), HIR_VOID_TYPE], IR_DUMMY_IDENTIFIER_TYPE)
             ),
             HIR_ONE,
           ],
@@ -865,7 +819,7 @@ it('Panic lowering works.', () => {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             '_builtin_throw',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
           ),
           functionArguments: [IR_THIS],
           returnCollector: '_t0',
@@ -892,7 +846,7 @@ it('IfElse lowering works.', () => {
             HIR_FUNCTION_CALL({
               functionExpression: HIR_NAME(
                 '_builtin_throw',
-                HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+                HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
               ),
               functionArguments: [IR_THIS],
               returnCollector: '_t0',
@@ -976,7 +930,7 @@ it('Match lowering works.', () => {
                 HIR_FUNCTION_CALL({
                   functionExpression: HIR_NAME(
                     '_builtin_throw',
-                    HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+                    HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
                   ),
                   functionArguments: [IR_THIS],
                   returnCollector: '_t3',

--- a/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
+++ b/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
@@ -11,7 +11,7 @@ import {
   HIR_NAME,
   HIR_RETURN,
 } from 'samlang-core-ast/hir-expressions';
-import { HIR_FUNCTION_TYPE, HIR_INT_TYPE, HIR_POINTER_TYPE } from 'samlang-core-ast/hir-types';
+import { HIR_FUNCTION_TYPE, HIR_INT_TYPE } from 'samlang-core-ast/hir-types';
 
 it('performTailRecursiveCallTransformationOnHighIRFunction failed coalescing test', () => {
   expect(
@@ -61,10 +61,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow test', ()
       type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME(
-            'tailRec',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
-          ),
+          functionExpression: HIR_NAME('tailRec', HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)),
           functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
           returnCollector: 'collector',
         }),
@@ -102,10 +99,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
       type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME(
-            'tailRec1',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
-          ),
+          functionExpression: HIR_NAME('tailRec1', HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)),
           functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
           returnCollector: 'collector',
         }),
@@ -119,10 +113,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
     type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
     body: [
       HIR_FUNCTION_CALL({
-        functionExpression: HIR_NAME(
-          'tailRec1',
-          HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
-        ),
+        functionExpression: HIR_NAME('tailRec1', HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)),
         functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
         returnCollector: 'collector',
       }),
@@ -140,10 +131,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
       type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
       body: [
         HIR_FUNCTION_CALL({
-          functionExpression: HIR_NAME(
-            'tailRec',
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
-          ),
+          functionExpression: HIR_NAME('tailRec', HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)),
           functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
           returnCollector: 'collector1',
         }),
@@ -157,10 +145,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction linear flow mismatch 
     type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
     body: [
       HIR_FUNCTION_CALL({
-        functionExpression: HIR_NAME(
-          'tailRec',
-          HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
-        ),
+        functionExpression: HIR_NAME('tailRec', HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)),
         functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
         returnCollector: 'collector1',
       }),
@@ -183,7 +168,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
             HIR_FUNCTION_CALL({
               functionExpression: HIR_NAME(
                 'tailRec',
-                HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
               ),
               functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
               returnCollector: 'collector',
@@ -237,7 +222,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 1-level if-else test 
             HIR_FUNCTION_CALL({
               functionExpression: HIR_NAME(
                 'tailRec',
-                HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
               ),
               functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
               returnCollector: 'collector',
@@ -325,7 +310,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                     HIR_FUNCTION_CALL({
                       functionExpression: HIR_NAME(
                         'tailRec',
-                        HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                        HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
                       ),
                       functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
                       returnCollector: 'collector',
@@ -405,7 +390,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                     HIR_FUNCTION_CALL({
                       functionExpression: HIR_NAME(
                         'tailRec',
-                        HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                        HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
                       ),
                       functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
                       returnCollector: 'collector',
@@ -415,7 +400,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                     HIR_FUNCTION_CALL({
                       functionExpression: HIR_NAME(
                         'tailRec1',
-                        HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                        HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
                       ),
                       functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
                       returnCollector: 'collector',
@@ -434,7 +419,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                 HIR_FUNCTION_CALL({
                   functionExpression: HIR_NAME(
                     'tailRec',
-                    HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                    HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
                   ),
                   functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
                   returnCollector: 'collector',
@@ -479,7 +464,7 @@ it('performTailRecursiveCallTransformationOnHighIRFunction 3-level if-else test 
                     HIR_FUNCTION_CALL({
                       functionExpression: HIR_NAME(
                         'tailRec1',
-                        HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE))
+                        HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE)
                       ),
                       functionArguments: [HIR_VARIABLE('n', HIR_INT_TYPE)],
                       returnCollector: 'collector',

--- a/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
@@ -17,7 +17,6 @@ import {
   HIR_INT_TYPE,
   HIR_ANY_TYPE,
   HIR_IDENTIFIER_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
   HIR_VOID_TYPE,
@@ -239,11 +238,9 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
       {
         identifier: '_Class3',
         mappings: [
-          HIR_POINTER_TYPE(
-            HIR_FUNCTION_TYPE(
-              [HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_IDENTIFIER_TYPE('_A'), HIR_ANY_TYPE]))],
-              HIR_INT_TYPE
-            )
+          HIR_FUNCTION_TYPE(
+            [HIR_STRUCT_TYPE([HIR_IDENTIFIER_TYPE('_A'), HIR_ANY_TYPE])],
+            HIR_INT_TYPE
           ),
         ],
       },
@@ -258,7 +255,7 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
           HIR_FUNCTION_CALL({
             functionExpression: HIR_NAME(
               '_module__class_Class1_function_infiniteLoop',
-              HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([], HIR_INT_TYPE))
+              HIR_FUNCTION_TYPE([], HIR_INT_TYPE)
             ),
             functionArguments: [],
             returnCollector: '_t0',
@@ -281,7 +278,7 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
           HIR_FUNCTION_CALL({
             functionExpression: HIR_NAME(
               '_module__class_Main_function_main',
-              HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([], HIR_VOID_TYPE))
+              HIR_FUNCTION_TYPE([], HIR_VOID_TYPE)
             ),
             functionArguments: [],
           }),

--- a/samlang-core-compiler/__tests__/hir-type-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-type-lowering.test.ts
@@ -14,8 +14,8 @@ import {
   HIR_INT_TYPE,
   HIR_VOID_TYPE,
   HIR_ANY_TYPE,
+  HIR_STRING_TYPE,
   HIR_IDENTIFIER_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
 } from 'samlang-core-ast/hir-types';
@@ -24,7 +24,7 @@ it('lowerSamlangType works', () => {
   expect(lowerSamlangType(intType, new Set())).toEqual(HIR_INT_TYPE);
   expect(lowerSamlangType(boolType, new Set())).toEqual(HIR_INT_TYPE);
   expect(lowerSamlangType(unitType, new Set())).toEqual(HIR_VOID_TYPE);
-  expect(lowerSamlangType(stringType, new Set([]))).toEqual(HIR_POINTER_TYPE(HIR_INT_TYPE));
+  expect(lowerSamlangType(stringType, new Set([]))).toEqual(HIR_STRING_TYPE);
 
   expect(lowerSamlangType(identifierType(ModuleReference.ROOT, 'A'), new Set())).toEqual(
     HIR_IDENTIFIER_TYPE('_A')
@@ -34,10 +34,10 @@ it('lowerSamlangType works', () => {
   );
 
   expect(lowerSamlangType(tupleType([intType, boolType]), new Set())).toEqual(
-    HIR_POINTER_TYPE(HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_INT_TYPE]))
+    HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_INT_TYPE])
   );
   expect(lowerSamlangType(functionType([intType, boolType], unitType), new Set())).toEqual(
-    HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_INT_TYPE, HIR_INT_TYPE], HIR_VOID_TYPE))
+    HIR_FUNCTION_TYPE([HIR_INT_TYPE, HIR_INT_TYPE], HIR_VOID_TYPE)
   );
 
   expect(() => lowerSamlangType({ type: 'UndecidedType', index: 0 }, new Set())).toThrow();

--- a/samlang-core-compiler/hir-expression-lowering.ts
+++ b/samlang-core-compiler/hir-expression-lowering.ts
@@ -33,7 +33,6 @@ import {
   HIR_INT_TYPE,
   HIR_ANY_TYPE,
   HIR_VOID_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
   HIR_STRING_TYPE,
@@ -327,7 +326,7 @@ class HighIRExpressionLoweringManager {
         HIR_FUNCTION_CALL({
           functionExpression: HIR_NAME(
             ENCODED_FUNCTION_NAME_THROW,
-            HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE))
+            HIR_FUNCTION_TYPE([HIR_STRING_TYPE], HIR_VOID_TYPE)
           ),
           functionArguments: [result.expression],
           returnCollector: this.allocateTemporaryVariable(),
@@ -364,7 +363,7 @@ class HighIRExpressionLoweringManager {
     }
     loweredStatements.push(
       HIR_FUNCTION_CALL({
-        functionExpression: HIR_NAME(functionName, HIR_POINTER_TYPE(calledFunctionType)),
+        functionExpression: HIR_NAME(functionName, calledFunctionType),
         functionArguments: [loweredArgument],
         returnCollector,
       })
@@ -409,14 +408,12 @@ class HighIRExpressionLoweringManager {
               (functionExpression.expression.type as IdentifierType).identifier,
               functionExpression.methodName
             ),
-            HIR_POINTER_TYPE(
-              HIR_FUNCTION_TYPE(
-                [
-                  this.lowerType(functionExpression.expression.type),
-                  ...expression.functionArguments.map((it) => this.lowerType(it.type)),
-                ],
-                this.lowerType(expression.type)
-              )
+            HIR_FUNCTION_TYPE(
+              [
+                this.lowerType(functionExpression.expression.type),
+                ...expression.functionArguments.map((it) => this.lowerType(it.type)),
+              ],
+              this.lowerType(expression.type)
             )
           ),
           functionArguments: [
@@ -583,9 +580,7 @@ class HighIRExpressionLoweringManager {
           HIR_FUNCTION_CALL({
             functionExpression: HIR_NAME(
               ENCODED_FUNCTION_NAME_STRING_CONCAT,
-              HIR_POINTER_TYPE(
-                HIR_FUNCTION_TYPE([HIR_STRING_TYPE, HIR_STRING_TYPE], HIR_STRING_TYPE)
-              )
+              HIR_FUNCTION_TYPE([HIR_STRING_TYPE, HIR_STRING_TYPE], HIR_STRING_TYPE)
             ),
             functionArguments: [loweredE1, loweredE2],
             returnCollector,
@@ -754,7 +749,7 @@ class HighIRExpressionLoweringManager {
       const expressionList = captured.map(([variableName, variableType]) =>
         HIR_VARIABLE(variableName, this.lowerType(variableType))
       );
-      const contextType = HIR_POINTER_TYPE(HIR_STRUCT_TYPE(expressionList.map((it) => it.type)));
+      const contextType = HIR_STRUCT_TYPE(expressionList.map((it) => it.type));
       loweredStatements.push(
         HIR_STRUCT_INITIALIZATION({
           structVariableName: contextName,
@@ -768,10 +763,7 @@ class HighIRExpressionLoweringManager {
       HIR_STRUCT_INITIALIZATION({
         structVariableName,
         type: HIR_CLOSURE_TYPE,
-        expressionList: [
-          HIR_NAME(syntheticLambda.name, HIR_POINTER_TYPE(syntheticLambda.type)),
-          context,
-        ],
+        expressionList: [HIR_NAME(syntheticLambda.name, syntheticLambda.type), context],
       })
     );
     return {
@@ -783,8 +775,8 @@ class HighIRExpressionLoweringManager {
   private createSyntheticLambdaFunction(expression: LambdaExpression): HighIRFunction {
     const loweringResult = this.lower(expression.body);
     const lambdaStatements: HighIRStatement[] = [];
-    const contextType = HIR_POINTER_TYPE(
-      HIR_STRUCT_TYPE(Object.values(expression.captured).map((it) => this.lowerType(it)))
+    const contextType = HIR_STRUCT_TYPE(
+      Object.values(expression.captured).map((it) => this.lowerType(it))
     );
     Object.entries(expression.captured).forEach(([variable, variableType], index) => {
       lambdaStatements.push(

--- a/samlang-core-compiler/hir-toplevel-lowering.ts
+++ b/samlang-core-compiler/hir-toplevel-lowering.ts
@@ -19,7 +19,6 @@ import {
   HIR_INT_TYPE,
   HIR_ANY_TYPE,
   HIR_VOID_TYPE,
-  HIR_POINTER_TYPE,
   HIR_FUNCTION_TYPE,
   HIR_IDENTIFIER_TYPE,
 } from 'samlang-core-ast/hir-types';
@@ -138,7 +137,7 @@ const compileSamlangSourcesToHighIRSources = (
           HIR_FUNCTION_CALL({
             functionExpression: HIR_NAME(
               entryPointFunctionName,
-              HIR_POINTER_TYPE(HIR_FUNCTION_TYPE([], HIR_VOID_TYPE))
+              HIR_FUNCTION_TYPE([], HIR_VOID_TYPE)
             ),
             functionArguments: [],
           }),

--- a/samlang-core-compiler/hir-types-lowering.ts
+++ b/samlang-core-compiler/hir-types-lowering.ts
@@ -1,11 +1,11 @@
 import type { Type } from 'samlang-core-ast/common-nodes';
 import {
   HighIRType,
-  HIR_INT_TYPE,
   HIR_VOID_TYPE,
+  HIR_INT_TYPE,
+  HIR_STRING_TYPE,
   HIR_ANY_TYPE,
   HIR_IDENTIFIER_TYPE,
-  HIR_POINTER_TYPE,
   HIR_STRUCT_TYPE,
   HIR_FUNCTION_TYPE,
 } from 'samlang-core-ast/hir-types';
@@ -22,7 +22,7 @@ const lowerSamlangType = (type: Type, genericTypes: ReadonlySet<string>): HighIR
         case 'unit':
           return HIR_VOID_TYPE;
         case 'string':
-          return HIR_POINTER_TYPE(HIR_INT_TYPE);
+          return HIR_STRING_TYPE;
       }
     // eslint-disable-next-line no-fallthrough
     case 'IdentifierType': {
@@ -30,15 +30,11 @@ const lowerSamlangType = (type: Type, genericTypes: ReadonlySet<string>): HighIR
       return HIR_IDENTIFIER_TYPE(`${type.moduleReference.parts.join('_')}_${type.identifier}`);
     }
     case 'TupleType':
-      return HIR_POINTER_TYPE(
-        HIR_STRUCT_TYPE(type.mappings.map((it) => lowerSamlangType(it, genericTypes)))
-      );
+      return HIR_STRUCT_TYPE(type.mappings.map((it) => lowerSamlangType(it, genericTypes)));
     case 'FunctionType':
-      return HIR_POINTER_TYPE(
-        HIR_FUNCTION_TYPE(
-          type.argumentTypes.map((it) => lowerSamlangType(it, genericTypes)),
-          lowerSamlangType(type.returnType, genericTypes)
-        )
+      return HIR_FUNCTION_TYPE(
+        type.argumentTypes.map((it) => lowerSamlangType(it, genericTypes)),
+        lowerSamlangType(type.returnType, genericTypes)
       );
   }
 };


### PR DESCRIPTION
## Summary

HIR should be able to be compiled to TS directly. Therefore, a pointer type there doesn't make sense. In addition, we know for sure that only function type and tuple type needs to be wrapped by pointer type, so we can only start to do that at LLVM transformation phase.

## Test Plan

`yarn test`
