### PR TITLE
[compiler][hir] Do not emit wildcard assign statement

### DIFF
--- a/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-expression-lowering.test.ts
@@ -554,7 +554,6 @@ let a__depth_1__block_0: any = ((_t0: _Dummy)[0]: any);
 let _t1: _Dummy = (_this: _Dummy);
 let a__depth_1__block_0: any = ((_t1: _Dummy)[0]: any);
 let c__depth_1__block_0: any = ((_t1: _Dummy)[1]: any);
-let _t2: _Dummy = (_this: _Dummy);
 let a: void = (a__depth_1__block_0: void);
 return 0;`
   );

--- a/samlang-core-compiler/hir-expression-lowering.ts
+++ b/samlang-core-compiler/hir-expression-lowering.ts
@@ -896,13 +896,6 @@ class HighIRExpressionLoweringManager {
           );
           break;
         case 'WildCardPattern':
-          loweredStatements.push(
-            HIR_LET({
-              name: this.allocateTemporaryVariable(),
-              type: this.lowerType(typeAnnotation),
-              assignedExpression: loweredAssignedExpression,
-            })
-          );
           break;
       }
     });


### PR DESCRIPTION
## Summary

The expression is pure and the value is discarded, so there is no point to record this.

## Test Plan

`yarn test`
