### PR TITLE
[ast][hir][compiler] Connect string constants during HIR compilation stage

### DIFF
--- a/samlang-core-analysis/used-name-analysis.ts
+++ b/samlang-core-analysis/used-name-analysis.ts
@@ -6,7 +6,6 @@ import { assertNotNull } from 'samlang-core-utils';
 const collectUsedNamesFromExpression = (set: Set<string>, expression: HighIRExpression): void => {
   switch (expression.__type__) {
     case 'HighIRIntLiteralExpression':
-    case 'HighIRStringLiteralExpression':
     case 'HighIRVariableExpression':
       break;
     case 'HighIRNameExpression':

--- a/samlang-core-ast/__tests__/hir-expressions.test.ts
+++ b/samlang-core-ast/__tests__/hir-expressions.test.ts
@@ -9,7 +9,6 @@ import {
   HIR_RETURN,
   HIR_ZERO,
   HIR_INT,
-  HIR_STRING,
   HIR_NAME,
   HIR_VARIABLE,
   HIR_BINARY,
@@ -39,7 +38,7 @@ it('debugPrintHighIRStatement works', () => {
                 type: HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_STRING_TYPE]),
                 expressionList: [
                   HIR_BINARY({ operator: '+', e1: HIR_INT(0), e2: HIR_INT(0) }),
-                  HIR_STRING('meggo'),
+                  HIR_NAME('meggo', HIR_STRING_TYPE),
                 ],
               }),
               HIR_FUNCTION_CALL({
@@ -68,7 +67,7 @@ while true {
     let foo: Bar = (dev: Bar);
     return (foo: Bar);
   } else {
-    let baz: (int, string) = [(0 + 0), 'meggo'];
+    let baz: (int, string) = [(0 + 0), meggo];
     let vibez: int = h(((d: (int, int))[0]: int));
     h((d: int));
   }

--- a/samlang-core-ast/__tests__/hir-toplevel.test.ts
+++ b/samlang-core-ast/__tests__/hir-toplevel.test.ts
@@ -5,6 +5,7 @@ import { HIR_ANY_TYPE, HIR_INT_TYPE, HIR_FUNCTION_TYPE } from '../hir-types';
 it('debugPrintHighIRModule works', () => {
   expect(
     debugPrintHighIRModule({
+      globalVariables: [{ name: 'dev_meggo', content: 'vibez' }],
       typeDefinitions: [{ identifier: 'Foo', mappings: [HIR_INT_TYPE, HIR_ANY_TYPE] }],
       functions: [
         {
@@ -16,7 +17,9 @@ it('debugPrintHighIRModule works', () => {
         },
       ],
     })
-  ).toBe(`type Foo = (int, any);
+  ).toBe(`const dev_meggo = 'vibez';
+
+type Foo = (int, any);
 
 function Bar(f: int): int {
   return 0;

--- a/samlang-core-ast/hir-expressions.ts
+++ b/samlang-core-ast/hir-expressions.ts
@@ -1,11 +1,5 @@
 import type { IROperator } from './common-operators';
-import {
-  HighIRType,
-  HIR_BOOL_TYPE,
-  HIR_INT_TYPE,
-  HIR_STRING_TYPE,
-  prettyPrintHighIRType,
-} from './hir-types';
+import { HighIRType, HIR_BOOL_TYPE, HIR_INT_TYPE, prettyPrintHighIRType } from './hir-types';
 
 import { Long } from 'samlang-core-utils';
 
@@ -49,7 +43,6 @@ export interface HighIRBinaryExpression extends BaseHighIRExpression {
 
 export type HighIRExpression =
   | HighIRIntLiteralExpression
-  | HighIRStringLiteralExpression
   | HighIRNameExpression
   | HighIRVariableExpression
   | HighIRIndexAccessExpression
@@ -133,12 +126,6 @@ export const HIR_INT = (value: number | Long): HighIRIntLiteralExpression => ({
   __type__: 'HighIRIntLiteralExpression',
   type: HIR_INT_TYPE,
   value: typeof value === 'number' ? Long.fromInt(value) : value,
-});
-
-export const HIR_STRING = (value: string): HighIRStringLiteralExpression => ({
-  __type__: 'HighIRStringLiteralExpression',
-  type: HIR_STRING_TYPE,
-  value,
 });
 
 export const HIR_ZERO: HighIRIntLiteralExpression = HIR_INT(0);
@@ -258,8 +245,6 @@ const debugPrintHighIRExpression = (expression: HighIRExpression): string => {
   switch (expression.__type__) {
     case 'HighIRIntLiteralExpression':
       return expression.value.toString();
-    case 'HighIRStringLiteralExpression':
-      return `'${expression.value}'`;
     case 'HighIRVariableExpression':
       return `(${expression.name}: ${prettyPrintHighIRType(expression.type)})`;
     case 'HighIRNameExpression':

--- a/samlang-core-ast/hir-toplevel.ts
+++ b/samlang-core-ast/hir-toplevel.ts
@@ -1,3 +1,4 @@
+import type { GlobalVariable } from './common-nodes';
 import { debugPrintHighIRStatement, HighIRStatement } from './hir-expressions';
 import {
   HighIRType,
@@ -22,6 +23,7 @@ export interface HighIRFunction {
 }
 
 export interface HighIRModule {
+  readonly globalVariables: readonly GlobalVariable[];
   readonly typeDefinitions: readonly HighIRTypeDefinition[];
   readonly functions: readonly HighIRFunction[];
 }
@@ -43,8 +45,13 @@ export const debugPrintHighIRFunction = ({
   return `${header}\n${body}\n}\n`;
 };
 
-export const debugPrintHighIRModule = ({ typeDefinitions, functions }: HighIRModule): string =>
+export const debugPrintHighIRModule = ({
+  globalVariables,
+  typeDefinitions,
+  functions,
+}: HighIRModule): string =>
   [
+    ...globalVariables.map(({ name, content }) => `const ${name} = '${content}';\n`),
     ...typeDefinitions.map(
       ({ identifier, mappings }) =>
         `type ${identifier} = ${prettyPrintHighIRType(HIR_STRUCT_TYPE(mappings))};\n`

--- a/samlang-core-compiler/__tests__/hir-string-manager.test.ts
+++ b/samlang-core-compiler/__tests__/hir-string-manager.test.ts
@@ -1,0 +1,22 @@
+import HighIRStringManager from '../hir-string-manager';
+
+it('allocate string global variable test', () => {
+  const allocator = new HighIRStringManager();
+  expect(allocator.allocateStringArrayGlobalVariable('foobar')).toEqual({
+    name: 'GLOBAL_STRING_0',
+    content: 'foobar',
+  });
+  expect(allocator.allocateStringArrayGlobalVariable('foobar2')).toEqual({
+    name: 'GLOBAL_STRING_1',
+    content: 'foobar2',
+  });
+  expect(allocator.allocateStringArrayGlobalVariable('foobar')).toEqual({
+    name: 'GLOBAL_STRING_0',
+    content: 'foobar',
+  });
+
+  expect(allocator.globalVariables).toEqual([
+    { name: 'GLOBAL_STRING_0', content: 'foobar' },
+    { name: 'GLOBAL_STRING_1', content: 'foobar2' },
+  ]);
+});

--- a/samlang-core-compiler/__tests__/mir-lowering-translator.test.ts
+++ b/samlang-core-compiler/__tests__/mir-lowering-translator.test.ts
@@ -9,7 +9,6 @@ import {
   HIR_IF_ELSE,
   HIR_RETURN,
   HIR_BINARY,
-  HIR_STRING,
   HIR_FUNCTION_CALL,
   HIR_LET,
   HIR_INDEX_ACCESS,
@@ -27,7 +26,7 @@ const assertCorrectlyLoweredWithPreConfiguredSetup = (
 ): void => {
   expect(
     midIRTranslateStatementsAndCollectGlobalStrings(new MidIRResourceAllocator(), '', [statement])
-      .loweredStatements.map(midIRStatementToString)
+      .map(midIRStatementToString)
       .join('\n')
   ).toBe(expectedMirStatementsString);
 };
@@ -36,7 +35,11 @@ it('midIRTranslateStatementsAndCollectGlobalStrings test', () => {
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_FUNCTION_CALL({
       functionExpression: HIR_NAME('foo', HIR_INT_TYPE),
-      functionArguments: [HIR_ONE, HIR_STRING('bar'), HIR_VARIABLE('baz', HIR_INT_TYPE)],
+      functionArguments: [
+        HIR_ONE,
+        HIR_NAME('GLOBAL_STRING_0', HIR_STRING_TYPE),
+        HIR_VARIABLE('baz', HIR_INT_TYPE),
+      ],
       returnCollector: { name: 'bar', type: HIR_STRING_TYPE },
     }),
     `_bar = foo(1, GLOBAL_STRING_0, _baz);`
@@ -44,7 +47,11 @@ it('midIRTranslateStatementsAndCollectGlobalStrings test', () => {
   assertCorrectlyLoweredWithPreConfiguredSetup(
     HIR_FUNCTION_CALL({
       functionExpression: HIR_NAME('foo', HIR_INT_TYPE),
-      functionArguments: [HIR_ONE, HIR_STRING('bar'), HIR_VARIABLE('baz', HIR_INT_TYPE)],
+      functionArguments: [
+        HIR_ONE,
+        HIR_NAME('GLOBAL_STRING_0', HIR_STRING_TYPE),
+        HIR_VARIABLE('baz', HIR_INT_TYPE),
+      ],
     }),
     `foo(1, GLOBAL_STRING_0, _baz);`
   );

--- a/samlang-core-compiler/__tests__/mir-resource-allocator.test.ts
+++ b/samlang-core-compiler/__tests__/mir-resource-allocator.test.ts
@@ -1,21 +1,5 @@
 import MidIRResourceAllocator from '../mir-resource-allocator';
 
-it('allocate string global variable test', () => {
-  const allocator = new MidIRResourceAllocator();
-  expect(allocator.allocateStringArrayGlobalVariable('foobar')).toEqual({
-    name: 'GLOBAL_STRING_0',
-    content: 'foobar',
-  });
-  expect(allocator.allocateStringArrayGlobalVariable('foobar2')).toEqual({
-    name: 'GLOBAL_STRING_1',
-    content: 'foobar2',
-  });
-  expect(allocator.allocateStringArrayGlobalVariable('foobar')).toEqual({
-    name: 'GLOBAL_STRING_0',
-    content: 'foobar',
-  });
-});
-
 it('allocate label test', () => {
   const allocator = new MidIRResourceAllocator();
   expect(allocator.allocateLabel('fooBar')).toBe('LABEL_fooBar_0');

--- a/samlang-core-compiler/__tests__/mir-toplevel-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/mir-toplevel-lowering.test.ts
@@ -1,13 +1,17 @@
 import compileHighIrModuleToMidIRCompilationUnit from '../mir-toplevel-lowering';
 
-import { HIR_RETURN, HIR_STRING } from 'samlang-core-ast/hir-expressions';
+import { HIR_NAME, HIR_RETURN } from 'samlang-core-ast/hir-expressions';
 import { HIR_STRING_TYPE, HIR_VOID_TYPE, HIR_FUNCTION_TYPE } from 'samlang-core-ast/hir-types';
 import { midIRCompilationUnitToString } from 'samlang-core-ast/mir-nodes';
 
 it('compileHighIrModuleToMidIRCompilationUnit dummy source test', () => {
   expect(
     midIRCompilationUnitToString(
-      compileHighIrModuleToMidIRCompilationUnit({ typeDefinitions: [], functions: [] })
+      compileHighIrModuleToMidIRCompilationUnit({
+        globalVariables: [],
+        typeDefinitions: [],
+        functions: [],
+      })
     )
   ).toBe('\n');
 });
@@ -16,6 +20,7 @@ it('compileHighIrModuleToMidIRCompilationUnit full integration test', () => {
   expect(
     midIRCompilationUnitToString(
       compileHighIrModuleToMidIRCompilationUnit({
+        globalVariables: [{ name: 'GLOBAL_STRING_0', content: 'hello world' }],
         typeDefinitions: [],
         functions: [
           {
@@ -23,14 +28,14 @@ it('compileHighIrModuleToMidIRCompilationUnit full integration test', () => {
             parameters: ['foo', 'bar', 'baz'],
             hasReturn: true,
             type: HIR_FUNCTION_TYPE([HIR_VOID_TYPE, HIR_VOID_TYPE, HIR_VOID_TYPE], HIR_STRING_TYPE),
-            body: [HIR_RETURN(HIR_STRING('hello world'))],
+            body: [HIR_RETURN(HIR_NAME('GLOBAL_STRING_0', HIR_STRING_TYPE))],
           },
           {
             name: 'fooBar',
             parameters: ['foo', 'bar', 'baz'],
             hasReturn: true,
             type: HIR_FUNCTION_TYPE([HIR_VOID_TYPE, HIR_VOID_TYPE, HIR_VOID_TYPE], HIR_STRING_TYPE),
-            body: [HIR_RETURN(HIR_STRING('hello world'))],
+            body: [HIR_RETURN(HIR_NAME('GLOBAL_STRING_0', HIR_STRING_TYPE))],
           },
         ],
       })

--- a/samlang-core-compiler/hir-string-manager.ts
+++ b/samlang-core-compiler/hir-string-manager.ts
@@ -1,0 +1,22 @@
+import type { GlobalVariable } from 'samlang-core-ast/common-nodes';
+
+export default class HighIRStringManager {
+  private nextGlobalVariableId = 0;
+
+  private globalVariableReferenceMap: Map<string, GlobalVariable> = new Map();
+
+  get globalVariables(): readonly GlobalVariable[] {
+    return Array.from(this.globalVariableReferenceMap.values());
+  }
+
+  allocateStringArrayGlobalVariable(string: string): GlobalVariable {
+    const existing = this.globalVariableReferenceMap.get(`STRING_CONTENT_${string}`);
+    if (existing != null) {
+      return existing;
+    }
+    const variable = { name: `GLOBAL_STRING_${this.nextGlobalVariableId}`, content: string };
+    this.nextGlobalVariableId += 1;
+    this.globalVariableReferenceMap.set(`STRING_CONTENT_${string}`, variable);
+    return variable;
+  }
+}

--- a/samlang-core-compiler/mir-resource-allocator.ts
+++ b/samlang-core-compiler/mir-resource-allocator.ts
@@ -1,22 +1,5 @@
-import type { GlobalVariable } from 'samlang-core-ast/common-nodes';
-
 export default class MidIRResourceAllocator {
-  private nextGlobalVariableId = 0;
-
   private nextLabelId = 0;
-
-  private globalVariableReferenceMap: Map<string, GlobalVariable> = new Map();
-
-  allocateStringArrayGlobalVariable(string: string): GlobalVariable {
-    const existing = this.globalVariableReferenceMap.get(`STRING_CONTENT_${string}`);
-    if (existing != null) {
-      return existing;
-    }
-    const variable = { name: `GLOBAL_STRING_${this.nextGlobalVariableId}`, content: string };
-    this.nextGlobalVariableId += 1;
-    this.globalVariableReferenceMap.set(`STRING_CONTENT_${string}`, variable);
-    return variable;
-  }
 
   allocateLabel(functionName: string): string {
     const temp = this.nextLabelId;

--- a/samlang-core-compiler/mir-toplevel-lowering.ts
+++ b/samlang-core-compiler/mir-toplevel-lowering.ts
@@ -4,7 +4,6 @@ import reorderMidIRBasicBlocksToMaximizeLongestNoJumpPath from './mir-basic-bloc
 import midIRTranslateStatementsAndCollectGlobalStrings from './mir-lowering-translator';
 import MidIRResourceAllocator from './mir-resource-allocator';
 
-import type { GlobalVariable } from 'samlang-core-ast/common-nodes';
 import type { HighIRModule } from 'samlang-core-ast/hir-toplevel';
 import { MidIRCompilationUnit, MidIRFunction, MIR_RETURN } from 'samlang-core-ast/mir-nodes';
 import { optimizeIrWithSimpleOptimization } from 'samlang-core-optimization/simple-optimizations';
@@ -13,18 +12,13 @@ const compileHighIrModuleToMidIRCompilationUnit = (
   highIRModule: HighIRModule
 ): MidIRCompilationUnit => {
   const allocator = new MidIRResourceAllocator();
-  const globalVariables = new Map<string, GlobalVariable>();
   const functions: MidIRFunction[] = [];
   highIRModule.functions.forEach((highIRFunction) => {
-    const {
-      loweredStatements,
-      stringGlobalVariables,
-    } = midIRTranslateStatementsAndCollectGlobalStrings(
+    const loweredStatements = midIRTranslateStatementsAndCollectGlobalStrings(
       allocator,
       highIRFunction.name,
       highIRFunction.body
     );
-    stringGlobalVariables.forEach((it) => globalVariables.set(it.name, it));
     functions.push({
       functionName: highIRFunction.name,
       argumentNames: highIRFunction.parameters.map((it) => `_${it}`),
@@ -41,7 +35,7 @@ const compileHighIrModuleToMidIRCompilationUnit = (
       hasReturn: highIRFunction.hasReturn,
     });
   });
-  return { globalVariables: Array.from(globalVariables.values()), functions };
+  return { globalVariables: highIRModule.globalVariables, functions };
 };
 
 export default compileHighIrModuleToMidIRCompilationUnit;

--- a/samlang-core-printer/__tests__/printer-js.test.ts
+++ b/samlang-core-printer/__tests__/printer-js.test.ts
@@ -23,7 +23,6 @@ import {
   HIR_RETURN,
   HIR_ZERO,
   HIR_STRUCT_INITIALIZATION,
-  HIR_STRING,
   HIR_INDEX_ACCESS,
   HIR_VARIABLE,
   HIR_WHILE_TRUE,
@@ -64,6 +63,12 @@ const highIRModuleToJSString = (
 
 it('compile hello world to JS integration test', () => {
   const hirModule: HighIRModule = {
+    globalVariables: [
+      { name: 'h', content: 'Hello ' },
+      { name: 'w', content: 'World!' },
+      { name: 'f1', content: '"foo' },
+      { name: 'f2', content: "'foo" },
+    ],
     typeDefinitions: [],
     functions: [
       {
@@ -74,7 +79,7 @@ it('compile hello world to JS integration test', () => {
         body: [
           HIR_FUNCTION_CALL({
             functionExpression: HIR_NAME('_builtin_stringConcat', HIR_VOID_TYPE),
-            functionArguments: [HIR_STRING('Hello '), HIR_STRING('World!')],
+            functionArguments: [HIR_NAME('h', HIR_STRING_TYPE), HIR_NAME('w', HIR_STRING_TYPE)],
             returnCollector: { name: '_t0', type: HIR_STRING_TYPE },
           }),
           HIR_FUNCTION_CALL({
@@ -106,8 +111,12 @@ const ${ENCODED_FUNCTION_NAME_STRING_TO_INT} = (v) => BigInt(v);
 const ${ENCODED_FUNCTION_NAME_INT_TO_STRING} = (v) => String(v);
 const ${ENCODED_FUNCTION_NAME_THROW} = (v) => { throw Error(v); };
 
+const h = "Hello ";
+const w = "World!";
+const f1 = "\\"foo";
+const f2 = "'foo";
 const _module_Test_class_Main_function_main = () => {
-  var _t0 = _builtin_stringConcat("Hello ", "World!");
+  var _t0 = _builtin_stringConcat(h, w);
   var _t1 = _builtin_println(_t0);
 };
 const _compiled_program_main = () => {
@@ -126,6 +135,10 @@ const setupHIRIntegration = (hirModule: HighIRModule): string => {
 it('confirm samlang & equivalent JS have same print output', () => {
   expect(
     setupHIRIntegration({
+      globalVariables: [
+        { name: 'h', content: 'Hello ' },
+        { name: 'w', content: 'World!' },
+      ],
       typeDefinitions: [],
       functions: [
         {
@@ -136,7 +149,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
           body: [
             HIR_FUNCTION_CALL({
               functionExpression: HIR_NAME('_builtin_stringConcat', HIR_VOID_TYPE),
-              functionArguments: [HIR_STRING('Hello '), HIR_STRING('World!')],
+              functionArguments: [HIR_NAME('h', HIR_STRING_TYPE), HIR_NAME('w', HIR_STRING_TYPE)],
               returnCollector: { name: '_t0', type: HIR_STRING_TYPE },
             }),
             HIR_FUNCTION_CALL({
@@ -152,6 +165,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
 
   expect(
     setupHIRIntegration({
+      globalVariables: [],
       typeDefinitions: [],
       functions: [
         {
@@ -167,6 +181,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
 
   expect(
     setupHIRIntegration({
+      globalVariables: [],
       typeDefinitions: [],
       functions: [
         {
@@ -213,6 +228,10 @@ it('confirm samlang & equivalent JS have same print output', () => {
 
   expect(
     setupHIRIntegration({
+      globalVariables: [
+        { name: 'y', content: 'Meaning of life' },
+        { name: 'n', content: 'Not the meaning of life... keep looking' },
+      ],
       typeDefinitions: [],
       functions: [
         {
@@ -227,8 +246,8 @@ it('confirm samlang & equivalent JS have same print output', () => {
                 e1: HIR_VARIABLE('sum', HIR_INT_TYPE),
                 e2: HIR_INT(42),
               }),
-              s1: [HIR_RETURN(HIR_STRING('Meaning of life'))],
-              s2: [HIR_RETURN(HIR_STRING('Not the meaning of life... keep looking'))],
+              s1: [HIR_RETURN(HIR_NAME('y', HIR_STRING_TYPE))],
+              s2: [HIR_RETURN(HIR_NAME('n', HIR_STRING_TYPE))],
             }),
           ],
         },
@@ -276,6 +295,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
 
   expect(
     setupHIRIntegration({
+      globalVariables: [{ name: 'rb', content: 'RANDOM_BABY' }],
       typeDefinitions: [],
       functions: [
         {
@@ -287,7 +307,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
             HIR_STRUCT_INITIALIZATION({
               structVariableName: 't0',
               type: HIR_VOID_TYPE,
-              expressionList: [HIR_STRING('RANDOM_BABY')],
+              expressionList: [HIR_NAME('rb', HIR_STRING_TYPE)],
             }),
             HIR_RETURN(HIR_VARIABLE('t0', HIR_VOID_TYPE)),
           ],
@@ -335,6 +355,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
 
   expect(() =>
     setupHIRIntegration({
+      globalVariables: [{ name: 'illegal', content: 'Division by zero is illegal!' }],
       typeDefinitions: [],
       functions: [
         {
@@ -367,7 +388,7 @@ it('confirm samlang & equivalent JS have same print output', () => {
               s1: [
                 HIR_FUNCTION_CALL({
                   functionExpression: HIR_NAME('_builtin_throw', HIR_VOID_TYPE),
-                  functionArguments: [HIR_STRING('Division by zero is illegal!')],
+                  functionArguments: [HIR_NAME('illegal', HIR_STRING_TYPE)],
                 }),
               ],
               s2: [],
@@ -481,21 +502,21 @@ it('HIR statements to JS string test', () => {
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
-        functionArguments: [HIR_STRING('Hello, world')],
+        functionArguments: [HIR_ZERO],
         functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_PRINTLN, HIR_VOID_TYPE),
         returnCollector: { name: 'res', type: HIR_VOID_TYPE },
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}("Hello, world");`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}(0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
-        functionArguments: [HIR_STRING('5')],
+        functionArguments: [HIR_ZERO],
         functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_TO_INT, HIR_VOID_TYPE),
         returnCollector: { name: 'res', type: HIR_INT_TYPE },
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}("5");`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}(0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -508,21 +529,21 @@ it('HIR statements to JS string test', () => {
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
-        functionArguments: [HIR_STRING('5'), HIR_STRING('4')],
+        functionArguments: [HIR_ZERO, HIR_ZERO],
         functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_STRING_CONCAT, HIR_VOID_TYPE),
         returnCollector: { name: 'res', type: HIR_STRING_TYPE },
       })
     )
-  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}("5", "4");`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}(0, 0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
-        functionArguments: [HIR_STRING('panik')],
+        functionArguments: [HIR_ZERO],
         functionExpression: HIR_NAME(ENCODED_FUNCTION_NAME_THROW, HIR_VOID_TYPE),
         returnCollector: { name: 'panik', type: HIR_VOID_TYPE },
       })
     )
-  ).toBe(`var panik = ${ENCODED_FUNCTION_NAME_THROW}("panik");`);
+  ).toBe(`var panik = ${ENCODED_FUNCTION_NAME_THROW}(0);`);
   expect(
     highIRStatementToString(
       HIR_LET({
@@ -538,10 +559,10 @@ it('HIR statements to JS string test', () => {
       HIR_STRUCT_INITIALIZATION({
         structVariableName: 'st',
         type: HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_STRING_TYPE, HIR_INT_TYPE]),
-        expressionList: [HIR_ZERO, HIR_STRING('bar'), HIR_INT(13)],
+        expressionList: [HIR_ZERO, HIR_ZERO, HIR_INT(13)],
       })
     )
-  ).toBe(`var st = [0, "bar", 13];`);
+  ).toBe(`var st = [0, 0, 13];`);
 });
 
 it('HIR function to JS string test 1', () => {
@@ -588,9 +609,6 @@ it('HIR function to JS string test 2', () => {
 
 it('HIR expression to JS string test', () => {
   expect(highIRExpressionToString(HIR_INT(1305))).toBe('1305');
-  expect(highIRExpressionToString(HIR_STRING('bloop'))).toBe(`"bloop"`);
-  expect(highIRExpressionToString(HIR_STRING('"foo'))).toBe(`"\\"foo"`);
-  expect(highIRExpressionToString(HIR_STRING("'foo"))).toBe(`"'foo"`);
   expect(
     highIRExpressionToString(
       HIR_INDEX_ACCESS({
@@ -619,13 +637,13 @@ it('HIR expression to JS string test', () => {
         type: HIR_VOID_TYPE,
         expression: HIR_BINARY({
           operator: '+',
-          e1: HIR_STRING('a'),
-          e2: HIR_STRING('b'),
+          e1: HIR_ZERO,
+          e2: HIR_ZERO,
         }),
         index: 0,
       })
     )
-  ).toBe('("a" + "b")[0]');
+  ).toBe('(0 + 0)[0]');
   expect(highIRExpressionToString(HIR_VARIABLE('ts', HIR_VOID_TYPE))).toBe('ts');
   expect(highIRExpressionToString(HIR_NAME('key', HIR_VOID_TYPE))).toBe('key');
   expect(

--- a/samlang-core-printer/printer-js.ts
+++ b/samlang-core-printer/printer-js.ts
@@ -32,8 +32,6 @@ export const createPrettierDocumentFromHighIRExpression_EXPOSED_FOR_TESTING = (
   switch (highIRExpression.__type__) {
     case 'HighIRIntLiteralExpression':
       return PRETTIER_TEXT(String(highIRExpression.value));
-    case 'HighIRStringLiteralExpression':
-      return PRETTIER_TEXT(`"${escapeDoubleQuotes(highIRExpression.value)}"`);
     case 'HighIRVariableExpression':
     case 'HighIRNameExpression':
       return PRETTIER_TEXT(highIRExpression.name);
@@ -189,6 +187,12 @@ export const createPrettierDocumentFromHighIRModule = (
     PRETTIER_LINE,
     PRETTIER_LINE,
   ];
+  highIRModule.globalVariables.forEach(({ name, content }) => {
+    segments.push(
+      PRETTIER_TEXT(`const ${name} = "${escapeDoubleQuotes(content)}";`),
+      PRETTIER_LINE
+    );
+  });
   highIRModule.functions.forEach((highIRFunction) =>
     segments.push(
       createPrettierDocumentFromHighIRFunction_EXPOSED_FOR_TESTING(highIRFunction),

--- a/samlang-demo/src/__test__/index.test.ts
+++ b/samlang-demo/src/__test__/index.test.ts
@@ -10,8 +10,9 @@ const _builtin_stringToInt = (v) => BigInt(v);
 const _builtin_intToString = (v) => String(v);
 const _builtin_throw = (v) => { throw Error(v); };
 
+const GLOBAL_STRING_0 = "hello world";
 const _module_Demo_class_Main_function_main = () => {
-  _builtin_println("hello world");
+  _builtin_println(GLOBAL_STRING_0);
 };
 const _compiled_program_main = () => {
   _module_Demo_class_Main_function_main();


### PR DESCRIPTION
## Summary

Further reduce the work in MIR stage and prevent duplicated code for LLVM transform.

## Test Plan

`yarn test`
