### PR TITLE
[compiler][hir] Do not call coalesceMoveAndReturnForHighIRStatements inside performTailRecursiveCallTransformationOnHighIRFunction

### DIFF
--- a/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
+++ b/samlang-core-compiler/__tests__/hir-tail-recursion-transformation-hir.test.ts
@@ -43,7 +43,8 @@ it('performTailRecursiveCallTransformationOnHighIRFunction no tailrec call test'
       })
     )
   ).toBe(`function (): int {
-  return 1;
+  let _t1: int = 1;
+  return (_t1: int);
 }
 `);
 });

--- a/samlang-core-compiler/hir-tail-recursion-transformation-hir.ts
+++ b/samlang-core-compiler/hir-tail-recursion-transformation-hir.ts
@@ -1,5 +1,3 @@
-import coalesceMoveAndReturnForHighIRStatements from './hir-move-return-coalescing';
-
 import {
   HighIRStatement,
   HIR_VARIABLE,
@@ -99,13 +97,11 @@ const recursivelyPerformTailRecursiveCallTransformationOnStatements = (
 const performTailRecursiveCallTransformationOnHighIRFunction = (
   highIRFunction: HighIRFunction
 ): HighIRFunction => {
-  const optimizedStatements =
-    coalesceMoveAndReturnForHighIRStatements(highIRFunction.body) ?? highIRFunction.body;
   const potentialRewrittenStatements = recursivelyPerformTailRecursiveCallTransformationOnStatements(
     highIRFunction,
-    optimizedStatements
+    highIRFunction.body
   );
-  if (potentialRewrittenStatements == null) return { ...highIRFunction, body: optimizedStatements };
+  if (potentialRewrittenStatements == null) return highIRFunction;
   return {
     ...highIRFunction,
     body: [

--- a/samlang-core-compiler/hir-toplevel-lowering.ts
+++ b/samlang-core-compiler/hir-toplevel-lowering.ts
@@ -1,4 +1,5 @@
 import lowerSamlangExpression from './hir-expression-lowering';
+import coalesceMoveAndReturnForHighIRStatements from './hir-move-return-coalescing';
 import HighIRStringManager from './hir-string-manager';
 import performTailRecursiveCallTransformationOnHighIRFunction from './hir-tail-recursion-transformation-hir';
 import lowerSamlangType from './hir-types-lowering';
@@ -117,14 +118,14 @@ const compileSamlangSourcesToHighIRSources = (
       );
       if (compiledTypeDefinition != null) compiledTypeDefinitions.push(compiledTypeDefinition);
       members.forEach((member) =>
-        compileFunction(
-          moduleReference,
-          className,
-          typeParameters,
-          stringManager,
-          member
-        ).forEach((it) =>
-          compiledFunctions.push(performTailRecursiveCallTransformationOnHighIRFunction(it))
+        compileFunction(moduleReference, className, typeParameters, stringManager, member).forEach(
+          (it) =>
+            compiledFunctions.push(
+              performTailRecursiveCallTransformationOnHighIRFunction({
+                ...it,
+                body: coalesceMoveAndReturnForHighIRStatements(it.body) ?? it.body,
+              })
+            )
         )
       );
     })


### PR DESCRIPTION
## Summary

Title

## Test Plan

`yarn test`
