### PR TITLE
[ast][llvm] Make binary statement accept operand type

### DIFF
--- a/samlang-core-ast/__tests__/llvm-nodes.test.ts
+++ b/samlang-core-ast/__tests__/llvm-nodes.test.ts
@@ -198,6 +198,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '+',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(3),
       })
@@ -209,6 +210,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '-',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(3),
       })
@@ -220,6 +222,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '*',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(3),
       })
@@ -231,6 +234,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '/',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(3),
       })
@@ -242,6 +246,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '%',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(3),
       })
@@ -253,6 +258,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '^',
+        operandType: LLVM_BOOL_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -264,6 +270,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '<',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -275,6 +282,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '<=',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -286,6 +294,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '>',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -297,6 +306,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '>=',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -308,6 +318,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '==',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })
@@ -319,6 +330,7 @@ it('prettyPrintLLVMInstruction works for LLVM_BINARY.', () => {
       LLVM_BINARY({
         resultVariable: 'foo',
         operator: '!=',
+        operandType: LLVM_INT_TYPE,
         v1: LLVM_VARIABLE('bar'),
         v2: LLVM_INT(1),
       })

--- a/samlang-core-ast/llvm-nodes.ts
+++ b/samlang-core-ast/llvm-nodes.ts
@@ -140,6 +140,7 @@ export type LLVMBinaryInstruction = {
   readonly __type__: 'LLVMBinaryInstruction';
   readonly resultVariable: string;
   readonly operator: IROperator;
+  readonly operandType: LLVMType;
   readonly v1: LLVMValue;
   readonly v2: LLVMValue;
 };
@@ -249,12 +250,14 @@ export const LLVM_GET_ELEMENT_PTR = ({
 export const LLVM_BINARY = ({
   resultVariable,
   operator,
+  operandType,
   v1,
   v2,
 }: ConstructorArgumentObject<LLVMBinaryInstruction>): LLVMBinaryInstruction => ({
   __type__: 'LLVMBinaryInstruction',
   resultVariable,
   operator,
+  operandType,
   v1,
   v2,
 });
@@ -379,46 +382,47 @@ export const prettyPrintLLVMInstruction = (instruction: LLVMInstruction): string
       const result = `%${instruction.resultVariable}`;
       const v1 = prettyPrintLLVMValue(instruction.v1);
       const v2 = prettyPrintLLVMValue(instruction.v2);
-      let stringOperatorAndType: string;
+      let operator: string;
       switch (instruction.operator) {
         case '+':
-          stringOperatorAndType = 'add i64';
+          operator = 'add';
           break;
         case '-':
-          stringOperatorAndType = 'sub i64';
+          operator = 'sub';
           break;
         case '*':
-          stringOperatorAndType = 'mul i64';
+          operator = 'mul';
           break;
         case '/':
-          stringOperatorAndType = 'sdiv i64';
+          operator = 'sdiv';
           break;
         case '%':
-          stringOperatorAndType = 'srem i64';
+          operator = 'srem';
           break;
         case '^':
-          stringOperatorAndType = 'xor i1';
+          operator = 'xor';
           break;
         case '<':
-          stringOperatorAndType = 'icmp slt i64';
+          operator = 'icmp slt';
           break;
         case '<=':
-          stringOperatorAndType = 'icmp sle i64';
+          operator = 'icmp sle';
           break;
         case '>':
-          stringOperatorAndType = 'icmp sgt i64';
+          operator = 'icmp sgt';
           break;
         case '>=':
-          stringOperatorAndType = 'icmp sge i64';
+          operator = 'icmp sge';
           break;
         case '==':
-          stringOperatorAndType = 'icmp eq i64';
+          operator = 'icmp eq';
           break;
         case '!=':
-          stringOperatorAndType = 'icmp ne i64';
+          operator = 'icmp ne';
           break;
       }
-      return `${result} = ${stringOperatorAndType} ${v1}, ${v2}`;
+      const type = prettyPrintLLVMType(instruction.operandType);
+      return `${result} = ${operator} ${type} ${v1}, ${v2}`;
     }
     case 'LLVMLoadInstruction': {
       const { resultVariable, sourceVariable } = instruction;

--- a/samlang-core-compiler/llvm-lowering-translator.ts
+++ b/samlang-core-compiler/llvm-lowering-translator.ts
@@ -67,16 +67,20 @@ class LLVMLoweringManager {
       case 'HighIRIndexAccessStatement':
         this.lowerHighIRIndexAccessStatement(s);
         return;
-      case 'HighIRBinaryStatement':
+      case 'HighIRBinaryStatement': {
+        const loweredE1 = this.lowerHighIRExpression(s.e1);
+        const loweredE2 = this.lowerHighIRExpression(s.e2);
         this.emitInstruction(
           LLVM_BINARY({
             resultVariable: s.name,
             operator: s.operator,
-            v1: this.lowerHighIRExpression(s.e1).value,
-            v2: this.lowerHighIRExpression(s.e2).value,
+            operandType: loweredE1.type,
+            v1: loweredE1.value,
+            v2: loweredE2.value,
           })
         );
         return;
+      }
       case 'HighIRFunctionCallStatement':
         this.emitInstruction(
           LLVM_CALL({

--- a/samlang-core-interpreter/__tests__/llvm-ir-interpreter.test.ts
+++ b/samlang-core-interpreter/__tests__/llvm-ir-interpreter.test.ts
@@ -229,6 +229,7 @@ it('interpretLLVMModule setup tuple and print test', () => {
             LLVM_BINARY({
               resultVariable: 'sum',
               operator: '+',
+              operandType: LLVM_INT_TYPE,
               v1: LLVM_VARIABLE('v1'),
               v2: LLVM_VARIABLE('v2'),
             }),
@@ -379,6 +380,7 @@ it('interpretLLVMModule factorial function call integration test', () => {
             LLVM_BINARY({
               resultVariable: 'com',
               operator: '==',
+              operandType: LLVM_INT_TYPE,
               v1: LLVM_VARIABLE('n'),
               v2: ZERO,
             }),
@@ -387,12 +389,14 @@ it('interpretLLVMModule factorial function call integration test', () => {
             LLVM_BINARY({
               resultVariable: 'new_n',
               operator: '-',
+              operandType: LLVM_INT_TYPE,
               v1: LLVM_VARIABLE('n'),
               v2: ONE,
             }),
             LLVM_BINARY({
               resultVariable: 'new_acc',
               operator: '*',
+              operandType: LLVM_INT_TYPE,
               v1: LLVM_VARIABLE('acc'),
               v2: LLVM_VARIABLE('n'),
             }),


### PR DESCRIPTION


## Summary

We needed this for == and !=

## Test Plan

`yarn test`
