### PR TITLE
[test] Only test IR optimization interpretation in CI

### DIFF
--- a/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
+++ b/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
@@ -144,9 +144,9 @@ mirBaseTestCases.forEach((testCase) => {
         optimizeIRCompilationUnit(it, { doesPerformInlining: true })
       );
     });
-  }
 
-  it(`IR[all]: ${testCase.testCaseName}`, () => {
-    testMidIROptimizerResult(testCase, (it) => optimizeIRCompilationUnit(it));
-  });
+    it(`IR[all]: ${testCase.testCaseName}`, () => {
+      testMidIROptimizerResult(testCase, (it) => optimizeIRCompilationUnit(it));
+    });
+  }
 });

--- a/samlang-core-optimization/hir-common-subexpression-elimination-optimization.ts
+++ b/samlang-core-optimization/hir-common-subexpression-elimination-optimization.ts
@@ -2,12 +2,7 @@ import optimizeHighIRStatementsByLocalValueNumbering from './hir-local-value-num
 import { BindedValue, bindedValueToString } from './hir-optimization-common';
 import type OptimizationResourceAllocator from './optimization-resource-allocator';
 
-import {
-  HighIRStatement,
-  HIR_INDEX_ACCESS,
-  HIR_BINARY,
-  HIR_SWITCH,
-} from 'samlang-core-ast/hir-expressions';
+import { HighIRStatement, HIR_INDEX_ACCESS, HIR_BINARY } from 'samlang-core-ast/hir-expressions';
 import {
   checkNotNull,
   Hashable,


### PR DESCRIPTION
## Summary

The MIR optimization code will not be changed recently and it will eventually be removed. Therefore, let's save some time by only test it in CI.

## Test Plan

`yarn test`
