### PR TITLE
[optimization] Propagate partially optimized binary expressions

### DIFF
--- a/samlang-core-optimization/__tests__/hir-conditional-constant-propagation-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-conditional-constant-propagation-optimization.test.ts
@@ -193,6 +193,106 @@ return 42;`
   );
 });
 
+it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of binary statements 1/n.', () => {
+  assertCorrectlyOptimized(
+    [
+      HIR_BINARY({
+        name: 'a1',
+        operator: '+',
+        e1: HIR_VARIABLE('a0', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+      HIR_BINARY({
+        name: 'a2',
+        operator: '+',
+        e1: HIR_VARIABLE('a1', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+    ],
+    `let a1: int = (a0: int) + 2;\nlet a2: int = (a0: int) + 4;`
+  );
+});
+
+it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of binary statements 2/n.', () => {
+  assertCorrectlyOptimized(
+    [
+      HIR_BINARY({
+        name: 'a1',
+        operator: '+',
+        e1: HIR_VARIABLE('a0', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+      HIR_BINARY({
+        name: 'a2',
+        operator: '-',
+        e1: HIR_VARIABLE('a1', HIR_INT_TYPE),
+        e2: HIR_INT(3),
+      }),
+    ],
+    `let a1: int = (a0: int) + 2;\nlet a2: int = (a0: int) + -1;`
+  );
+});
+
+it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of binary statements 3/n.', () => {
+  assertCorrectlyOptimized(
+    [
+      HIR_BINARY({
+        name: 'a1',
+        operator: '-',
+        e1: HIR_VARIABLE('a0', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+      HIR_BINARY({
+        name: 'a2',
+        operator: '+',
+        e1: HIR_VARIABLE('a1', HIR_INT_TYPE),
+        e2: HIR_INT(3),
+      }),
+    ],
+    `let a1: int = (a0: int) + -2;\nlet a2: int = (a0: int) + 1;`
+  );
+});
+
+it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of binary statements 4/n.', () => {
+  assertCorrectlyOptimized(
+    [
+      HIR_BINARY({
+        name: 'a1',
+        operator: '-',
+        e1: HIR_VARIABLE('a0', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+      HIR_BINARY({
+        name: 'a2',
+        operator: '-',
+        e1: HIR_VARIABLE('a1', HIR_INT_TYPE),
+        e2: HIR_INT(3),
+      }),
+    ],
+    `let a1: int = (a0: int) + -2;\nlet a2: int = (a0: int) + -5;`
+  );
+});
+
+it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of binary statements 5/n.', () => {
+  assertCorrectlyOptimized(
+    [
+      HIR_BINARY({
+        name: 'a1',
+        operator: '*',
+        e1: HIR_VARIABLE('a0', HIR_INT_TYPE),
+        e2: HIR_INT(2),
+      }),
+      HIR_BINARY({
+        name: 'a2',
+        operator: '*',
+        e1: HIR_VARIABLE('a1', HIR_INT_TYPE),
+        e2: HIR_INT(3),
+      }),
+    ],
+    `let a1: int = (a0: int) * 2;\nlet a2: int = (a0: int) * 6;`
+  );
+});
+
 it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statement 1/n.', () => {
   assertCorrectlyOptimized(
     [

--- a/samlang-core-optimization/__tests__/hir-inline-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-inline-optimization.test.ts
@@ -298,21 +298,21 @@ it('optimizeFunctionsByInlining test 1', () => {
     if (_inline_0_c: bool) {
       _inline_0_fa = (acc1: int);
     } else {
-      let _inline_0_n1: int = (n1: int) + -1;
+      let _inline_0_n1: int = (n: int) + -2;
       let _inline_0_acc1: int = (n1: int) * (acc1: int);
       let _inline_4_c: bool = (_inline_0_n1: int) == 0;
       let _inline_4_fa: int;
       if (_inline_4_c: bool) {
         _inline_4_fa = (_inline_0_acc1: int);
       } else {
-        let _inline_4_n1: int = (_inline_0_n1: int) + -1;
+        let _inline_4_n1: int = (n: int) + -3;
         let _inline_4_acc1: int = (_inline_0_n1: int) * (_inline_0_acc1: int);
         let _inline_4__inline_0_c: bool = (_inline_4_n1: int) == 0;
         let _inline_4__inline_0_fa: int;
         if (_inline_4__inline_0_c: bool) {
           _inline_4__inline_0_fa = (_inline_4_acc1: int);
         } else {
-          let _inline_4__inline_0_n1: int = (_inline_4_n1: int) + -1;
+          let _inline_4__inline_0_n1: int = (n: int) + -4;
           let _inline_4__inline_0_acc1: int = (_inline_4_n1: int) * (_inline_4_acc1: int);
           let _inline_4__inline_0_v: int = factorial((_inline_4__inline_0_n1: int), (_inline_4__inline_0_acc1: int));
           _inline_4__inline_0_fa = (_inline_4__inline_0_v: int);

--- a/samlang-core-optimization/hir-dead-code-elimination-optimization.ts
+++ b/samlang-core-optimization/hir-dead-code-elimination-optimization.ts
@@ -59,6 +59,7 @@ const optimizeHighIRStatement = (
       return switchStatement;
     }
     case 'HighIRCastStatement':
+      if (!set.has(statement.name)) return [];
       collectUseFromExpression(statement.assignedExpression);
       return [statement];
     case 'HighIRStructInitializationStatement':

--- a/samlang-core-optimization/index.ts
+++ b/samlang-core-optimization/index.ts
@@ -56,7 +56,9 @@ const optimizeFunctionForRounds = (
   }
   return {
     ...highIRFunction,
-    body: optimizeHighIRStatementsByConditionalConstantPropagation(statements),
+    body: optimizeHighIRStatementsByDeadCodeElimination(
+      optimizeHighIRStatementsByConditionalConstantPropagation(statements)
+    ),
   };
 };
 


### PR DESCRIPTION
## Summary

Consolidate things like `b = a + 1; c = b + 2` into `c = a + 3`. When used together with DCE, this can be very powerful.

## Test Plan

`yarn test`
