### PR TITLE
[ast][compiler][optimization][hir] Adjust while AST

### DIFF
--- a/samlang-core-ast/__tests__/hir-expressions.test.ts
+++ b/samlang-core-ast/__tests__/hir-expressions.test.ts
@@ -29,10 +29,34 @@ it('debugPrintHighIRStatement works', () => {
               {
                 caseNumber: 1,
                 statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_IDENTIFIER_TYPE('Bar')))],
+                breakValue: null,
               },
               {
                 caseNumber: 2,
                 statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_IDENTIFIER_TYPE('Bar')))],
+                breakValue: null,
+              },
+            ],
+            finalAssignments: [
+              {
+                name: 'ma',
+                type: HIR_INT_TYPE,
+                branchValues: [HIR_VARIABLE('b1', HIR_INT_TYPE), HIR_VARIABLE('b2', HIR_INT_TYPE)],
+              },
+            ],
+          }),
+          HIR_SWITCH({
+            caseVariable: 'f',
+            cases: [
+              {
+                caseNumber: 1,
+                statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_IDENTIFIER_TYPE('Bar')))],
+                breakValue: HIR_ZERO,
+              },
+              {
+                caseNumber: 2,
+                statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_IDENTIFIER_TYPE('Bar')))],
+                breakValue: HIR_ZERO,
               },
             ],
             finalAssignments: [
@@ -70,7 +94,6 @@ it('debugPrintHighIRStatement works', () => {
                 assignedExpression: HIR_VARIABLE('dev', HIR_IDENTIFIER_TYPE('Bar')),
               }),
             ],
-            conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
           }),
           HIR_WHILE({
             loopVariables: [
@@ -94,12 +117,7 @@ it('debugPrintHighIRStatement works', () => {
                 assignedExpression: HIR_VARIABLE('dev', HIR_IDENTIFIER_TYPE('Bar')),
               }),
             ],
-            conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-            returnAssignment: {
-              name: 'v',
-              type: HIR_INT_TYPE,
-              value: HIR_VARIABLE('_t2_v', HIR_INT_TYPE),
-            },
+            breakCollector: { name: 'v', type: HIR_INT_TYPE },
           }),
           HIR_RETURN(HIR_VARIABLE('foo', HIR_IDENTIFIER_TYPE('Bar'))),
         ],
@@ -127,7 +145,17 @@ it('debugPrintHighIRStatement works', () => {
             pointerExpression: HIR_VARIABLE('big', HIR_STRUCT_TYPE([HIR_INT_TYPE, HIR_INT_TYPE])),
             index: 0,
           }),
+          HIR_IF_ELSE({
+            booleanExpression: HIR_ZERO,
+            s1: [],
+            s2: [],
+            s1BreakValue: HIR_ZERO,
+            s2BreakValue: HIR_ZERO,
+            finalAssignments: [],
+          }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'bar',
@@ -153,23 +181,35 @@ if 0 {
       ma = (b2: int);
     }
   }
+  let ma: int;
+  switch (f) {
+    case 1: {
+      return (foo: Bar);
+      undefined = 0;
+      break;
+    }
+    case 2: {
+      return (foo: Bar);
+      undefined = 0;
+      break;
+    }
+  }
   let foo: Bar = (dev: Bar);
   let n: int = (_tail_rec_param_n: int);
   let acc: int = (_tail_rec_param_acc: int);
-  do {
+  while (true) {
     let foo: Bar = (dev: Bar);
     n = (_t0_n: int);
     acc = (_t1_acc: int);
-  } while ((c: int));
+  }
   let n: int = (_tail_rec_param_n: int);
   let acc: int = (_tail_rec_param_acc: int);
   let v: int;
-  do {
+  while (true) {
     let foo: Bar = (dev: Bar);
     n = (_t0_n: int);
     acc = (_t1_acc: int);
-    v = (_t2_v: int);
-  } while ((c: int));
+  }
   return (foo: Bar);
   bar = (b1: int);
 } else {
@@ -178,6 +218,13 @@ if 0 {
   let vibez: int = h((big: (int, int)));
   stresso((d: int));
   let f: int = (big: (int, int))[0];
+  if 0 {
+    undefined = 0;
+    break;
+  } else {
+    undefined = 0;
+    break;
+  }
   bar = (b2: int);
 }`);
 });

--- a/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/hir-toplevel-lowering.test.ts
@@ -223,8 +223,8 @@ it('compileSamlangSourcesToHighIRSources integration test', () => {
   expect(debugPrintHighIRModule(actualCompiledModule)).toEqual(
     `
 function _compiled_program_main(): int {
-  do {
-  } while (1);
+  while (true) {
+  }
   return 0;
 }
 `.trimLeft()

--- a/samlang-core-compiler/__tests__/llvm-lowering-translator.test.ts
+++ b/samlang-core-compiler/__tests__/llvm-lowering-translator.test.ts
@@ -10,6 +10,7 @@ import {
   HIR_NAME,
   HIR_VARIABLE,
   HIR_ZERO,
+  HIR_ONE,
   HIR_BINARY,
   HIR_FUNCTION_CALL,
   HIR_IF_ELSE,
@@ -67,13 +68,13 @@ const assertExpressionLoweringWorks = (
   assertStatementLoweringWorks([HIR_RETURN(expression)], expectedString, globalStrings);
 };
 
-it('prettyPrintLLVMFunction works for base expressions 1/n', () => {
+it('LLVM lowering works for base expressions 1/n', () => {
   assertExpressionLoweringWorks(HIR_INT(42), '  ret i64 42');
   assertExpressionLoweringWorks(HIR_TRUE, '  ret i1 1');
   assertExpressionLoweringWorks(HIR_FALSE, '  ret i1 0');
 });
 
-it('prettyPrintLLVMFunction works for base expressions 2/n', () => {
+it('LLVM lowering works for base expressions 2/n', () => {
   assertStatementLoweringWorks([HIR_RETURN(HIR_INT(42))], '  ret i64 42');
   assertStatementLoweringWorks([HIR_RETURN(HIR_NAME('bar', INT))], '  ret i64 @bar');
   assertStatementLoweringWorks([HIR_RETURN(HIR_VARIABLE('bar', INT))], '  ret i64 %bar');
@@ -91,7 +92,7 @@ l0_start:
   );
 });
 
-it('prettyPrintLLVMFunction works for base expressions 3/n', () => {
+it('LLVM lowering works for base expressions 3/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_INDEX_ACCESS({
@@ -108,7 +109,7 @@ it('prettyPrintLLVMFunction works for base expressions 3/n', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for base expressions 4/n', () => {
+it('LLVM lowering works for base expressions 4/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_BINARY({
@@ -124,7 +125,7 @@ it('prettyPrintLLVMFunction works for base expressions 4/n', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_FUNCTION_CALL', () => {
+it('LLVM lowering works for HIR_FUNCTION_CALL', () => {
   assertStatementLoweringWorks(
     [
       HIR_FUNCTION_CALL({
@@ -147,7 +148,7 @@ it('prettyPrintLLVMFunction works for HIR_FUNCTION_CALL', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 1/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 1/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_BINARY({
@@ -160,6 +161,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 1/n', () => {
         booleanExpression: HIR_VARIABLE('bb', HIR_BOOL_TYPE),
         s1: [],
         s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
     ],
@@ -167,13 +170,15 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 1/n', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 2/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 2/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_IF_ELSE({
         booleanExpression: HIR_VARIABLE('bb', HIR_BOOL_TYPE),
         s1: [],
         s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -194,7 +199,7 @@ l3_if_else_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 3/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 3/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_IF_ELSE({
@@ -207,6 +212,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 3/n', () => {
             returnType: INT,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -226,7 +233,7 @@ l3_if_else_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 4/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 4/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_IF_ELSE({
@@ -239,6 +246,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 4/n', () => {
           }),
         ],
         s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -258,7 +267,7 @@ l3_if_else_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 5/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 5/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_BINARY({
@@ -283,6 +292,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 5/n', () => {
             returnType: INT,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
     ],
@@ -298,7 +309,7 @@ l3_if_else_end:`
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 6/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 6/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_IF_ELSE({
@@ -319,6 +330,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 6/n', () => {
             returnCollector: 'b2',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -341,7 +354,7 @@ l3_if_else_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_IF_ELSE 7/n', () => {
+it('LLVM lowering works for HIR_IF_ELSE 7/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_IF_ELSE({
@@ -373,6 +386,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 7/n', () => {
                 returnCollector: 'b3',
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
               {
                 name: 'ma_nested',
@@ -383,6 +398,8 @@ it('prettyPrintLLVMFunction works for HIR_IF_ELSE 7/n', () => {
             ],
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -413,7 +430,7 @@ l3_if_else_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_SWITCH 1/n', () => {
+it('LLVM lowering works for HIR_SWITCH 1/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_SWITCH({
@@ -428,6 +445,7 @@ it('prettyPrintLLVMFunction works for HIR_SWITCH 1/n', () => {
                 returnType: INT,
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 2,
@@ -438,6 +456,7 @@ it('prettyPrintLLVMFunction works for HIR_SWITCH 1/n', () => {
                 returnType: INT,
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [],
@@ -454,15 +473,15 @@ l1_match_end:`
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_SWITCH 2/n', () => {
+it('LLVM lowering works for HIR_SWITCH 2/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_SWITCH({
         caseVariable: 'c',
         cases: [
-          { caseNumber: 1, statements: [] },
-          { caseNumber: 0, statements: [] },
-          { caseNumber: 2, statements: [] },
+          { caseNumber: 1, statements: [], breakValue: null },
+          { caseNumber: 0, statements: [], breakValue: null },
+          { caseNumber: 2, statements: [], breakValue: null },
         ],
         finalAssignments: [{ name: 'ma', type: INT, branchValues: [HIR_ZERO, HIR_ZERO, HIR_ZERO] }],
       }),
@@ -479,14 +498,14 @@ l1_match_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_SWITCH 3/n', () => {
+it('LLVM lowering works for HIR_SWITCH 3/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_SWITCH({
         caseVariable: 'c',
         cases: [
-          { caseNumber: 1, statements: [] },
-          { caseNumber: 0, statements: [] },
+          { caseNumber: 1, statements: [], breakValue: null },
+          { caseNumber: 0, statements: [], breakValue: null },
           {
             caseNumber: 2,
             statements: [
@@ -497,6 +516,7 @@ it('prettyPrintLLVMFunction works for HIR_SWITCH 3/n', () => {
                 returnCollector: 'b2',
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -521,7 +541,7 @@ l1_match_end:
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_WHILE 1/n', () => {
+it('LLVM lowering works for HIR_WHILE 1/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_WHILE({
@@ -534,46 +554,113 @@ it('prettyPrintLLVMFunction works for HIR_WHILE 1/n', () => {
             returnCollector: 'b2',
           }),
         ],
-        conditionValue: HIR_ZERO,
       }),
     ],
     `  br label %l1_loop_start
 l1_loop_start:
   %n = phi i64 [ 0, %l0_start ], [ 0, %l1_loop_start ]
   %b2 = call i64 @foo() nounwind
-  br i1 0, label %l1_loop_start, label %l2_loop_end
-l2_loop_end:`
+  br label %l1_loop_start`
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_WHILE 2/n', () => {
+it('LLVM lowering works for HIR_WHILE 3/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_WHILE({
         loopVariables: [{ name: 'n', type: INT, initialValue: HIR_ZERO, loopValue: HIR_ZERO }],
         statements: [
-          HIR_FUNCTION_CALL({
-            functionExpression: HIR_NAME('foo', INT),
-            functionArguments: [],
-            returnType: INT,
-            returnCollector: 'b2',
+          HIR_IF_ELSE({
+            booleanExpression: HIR_ZERO,
+            s1: [],
+            s2: [],
+            s1BreakValue: HIR_ZERO,
+            s2BreakValue: HIR_ONE,
+            finalAssignments: [],
           }),
         ],
-        conditionValue: HIR_ZERO,
-        returnAssignment: { name: 'v', type: INT, value: HIR_ZERO },
+        breakCollector: { name: 'v', type: INT },
       }),
     ],
     `  br label %l1_loop_start
 l1_loop_start:
-  %n = phi i64 [ 0, %l0_start ], [ 0, %l1_loop_start ]
-  %b2 = call i64 @foo() nounwind
-  br i1 0, label %l1_loop_start, label %l2_loop_end
+  %n = phi i64 [ 0, %l0_start ], [ 0, %l5_if_else_end ]
+  br i1 0, label %l3_if_else_true, label %l4_if_else_false
+l3_if_else_true:
+  br label %l2_loop_end
+l4_if_else_false:
+  br label %l2_loop_end
 l2_loop_end:
-  %v = phi i64 [ 0, %l1_loop_start ]`
+  %v = phi i64 [ 0, %l3_if_else_true ], [ 1, %l4_if_else_false ]`
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_STRUCT_INITIALIZATION 1/n', () => {
+it('LLVM lowering works for HIR_WHILE 3/n', () => {
+  assertStatementLoweringWorks(
+    [
+      HIR_WHILE({
+        loopVariables: [{ name: 'n', type: INT, initialValue: HIR_ZERO, loopValue: HIR_ZERO }],
+        statements: [
+          HIR_IF_ELSE({
+            booleanExpression: HIR_ZERO,
+            s1: [],
+            s2: [],
+            s1BreakValue: null,
+            s2BreakValue: HIR_ONE,
+            finalAssignments: [
+              { name: 'f', type: INT, branch1Value: HIR_ZERO, branch2Value: HIR_ONE },
+            ],
+          }),
+        ],
+        breakCollector: { name: 'v', type: INT },
+      }),
+    ],
+    `  br label %l1_loop_start
+l1_loop_start:
+  %n = phi i64 [ 0, %l0_start ], [ 0, %l5_if_else_end ]
+  br i1 0, label %l5_if_else_end, label %l4_if_else_false
+l4_if_else_false:
+  br label %l2_loop_end
+l5_if_else_end:
+  %f = phi i64 [ 0, %l1_loop_start ]
+  br label %l1_loop_start
+l2_loop_end:
+  %v = phi i64 [ 1, %l4_if_else_false ]`
+  );
+});
+
+it('LLVM lowering works for HIR_WHILE 4/n', () => {
+  assertStatementLoweringWorks(
+    [
+      HIR_WHILE({
+        loopVariables: [{ name: 'n', type: INT, initialValue: HIR_ZERO, loopValue: HIR_ZERO }],
+        statements: [
+          HIR_SWITCH({
+            caseVariable: 'b2',
+            cases: [
+              { caseNumber: 0, statements: [], breakValue: HIR_ZERO },
+              { caseNumber: 1, statements: [], breakValue: HIR_ONE },
+            ],
+            finalAssignments: [],
+          }),
+        ],
+        breakCollector: { name: 'v', type: INT },
+      }),
+    ],
+    `  br label %l1_loop_start
+l1_loop_start:
+  %n = phi i64 [ 0, %l0_start ], [ 0, %l3_match_end ]
+  switch i64 %b2, label %l5_match_case_1 [ i64 0, label %l4_match_case_0 i64 1, label %l5_match_case_1 ]
+l4_match_case_0:
+  br label %l2_loop_end
+l5_match_case_1:
+  br label %l2_loop_end
+l2_loop_end:
+  %v = phi i64 [ 0, %l4_match_case_0 ], [ 1, %l5_match_case_1 ]`
+  );
+});
+
+it('LLVM lowering works for HIR_STRUCT_INITIALIZATION 1/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_STRUCT_INITIALIZATION({
@@ -591,7 +678,7 @@ it('prettyPrintLLVMFunction works for HIR_STRUCT_INITIALIZATION 1/n', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_STRUCT_INITIALIZATION 2/n', () => {
+it('LLVM lowering works for HIR_STRUCT_INITIALIZATION 2/n', () => {
   assertStatementLoweringWorks(
     [
       HIR_STRUCT_INITIALIZATION({
@@ -609,7 +696,7 @@ it('prettyPrintLLVMFunction works for HIR_STRUCT_INITIALIZATION 2/n', () => {
   );
 });
 
-it('prettyPrintLLVMFunction works for HIR_CAST with type conversion', () => {
+it('LLVM lowering works for HIR_CAST with type conversion', () => {
   assertStatementLoweringWorks(
     [HIR_CAST({ name: 's', type: HIR_STRING_TYPE, assignedExpression: HIR_ZERO })],
     '  %s = inttoptr i64 0 to i64*'

--- a/samlang-core-compiler/hir-expression-lowering.ts
+++ b/samlang-core-compiler/hir-expression-lowering.ts
@@ -679,7 +679,14 @@ class HighIRExpressionLoweringManager {
             ];
 
         functionReturnCollectorType = functionTypeWithoutContext.returnType;
-        functionCall = HIR_IF_ELSE({ booleanExpression, s1, s2, finalAssignments });
+        functionCall = HIR_IF_ELSE({
+          booleanExpression,
+          s1,
+          s2,
+          s1BreakValue: null,
+          s2BreakValue: null,
+          finalAssignments,
+        });
         break;
       }
     }
@@ -733,6 +740,8 @@ class HighIRExpressionLoweringManager {
               booleanExpression: e1Result.expression,
               s1: e2Result.statements,
               s2: [],
+              s1BreakValue: null,
+              s2BreakValue: null,
               finalAssignments: [
                 {
                   name: temp,
@@ -765,6 +774,8 @@ class HighIRExpressionLoweringManager {
               booleanExpression: e1Result.expression,
               s1: [],
               s2: e2Result.statements,
+              s1BreakValue: null,
+              s2BreakValue: null,
               finalAssignments: [
                 {
                   name: temp,
@@ -858,6 +869,8 @@ class HighIRExpressionLoweringManager {
         booleanExpression: loweredBoolExpression,
         s1: e1LoweringResult.statements,
         s2: e2LoweringResult.statements,
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: isVoidReturn
           ? []
           : [
@@ -933,6 +946,7 @@ class HighIRExpressionLoweringManager {
           cases: loweredMatchingList.map((it) => ({
             caseNumber: it.tagOrder,
             statements: it.statements,
+            breakValue: null,
           })),
           finalAssignments: [],
         })
@@ -944,6 +958,7 @@ class HighIRExpressionLoweringManager {
           cases: loweredMatchingList.map(({ tagOrder: caseNumber, statements }) => ({
             caseNumber,
             statements,
+            breakValue: null,
           })),
           finalAssignments: [
             {

--- a/samlang-core-optimization/__tests__/hir-common-subexpression-elimination-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-common-subexpression-elimination-optimization.test.ts
@@ -67,6 +67,8 @@ it('optimizeHighIRStatementsByCommonSubExpressionElimination works on if-else st
           }),
           HIR_RETURN(HIR_ZERO),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
     ],
@@ -109,6 +111,7 @@ it('optimizeHighIRStatementsByCommonSubExpressionElimination works on switch sta
                 returnType: HIR_INT_TYPE,
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 1,
@@ -130,6 +133,7 @@ it('optimizeHighIRStatementsByCommonSubExpressionElimination works on switch sta
               }),
               HIR_RETURN(HIR_ZERO),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 2,
@@ -151,6 +155,7 @@ it('optimizeHighIRStatementsByCommonSubExpressionElimination works on switch sta
               }),
               HIR_RETURN(HIR_ZERO),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [],

--- a/samlang-core-optimization/__tests__/hir-conditional-constant-propagation-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-conditional-constant-propagation-optimization.test.ts
@@ -314,6 +314,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnType: HIR_INT_TYPE,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
       HIR_BINARY({ name: 'b2', operator: '>', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -333,6 +335,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnType: HIR_INT_TYPE,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
       HIR_BINARY({ name: 'b3', operator: '<=', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -354,6 +358,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnCollector: 'a2',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma1',
@@ -382,6 +388,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnCollector: 'a22',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma2',
@@ -463,6 +471,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnType: HIR_INT_TYPE,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
       HIR_IF_ELSE({
@@ -483,6 +493,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnCollector: 'a2',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma1',
@@ -497,6 +509,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
         booleanExpression: HIR_VARIABLE('b', HIR_BOOL_TYPE),
         s1: [],
         s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma2',
@@ -553,6 +567,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnType: HIR_INT_TYPE,
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 2,
@@ -563,6 +578,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnType: HIR_INT_TYPE,
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [],
@@ -580,6 +596,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'b1',
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 2,
@@ -591,6 +608,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'b2',
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -607,6 +625,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
           {
             caseNumber: 1,
             statements: [],
+            breakValue: null,
           },
           {
             caseNumber: 2,
@@ -618,6 +637,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 e2: HIR_INT(1),
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -683,8 +703,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: HIR_VARIABLE('n', HIR_INT_TYPE),
+            s2BreakValue: null,
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -694,24 +715,21 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
       }),
     ],
     `let n: int = 10;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
-  let c: int;
   let _tmp_n: int;
   if (is_zero: bool) {
-    c = 0;
-    _tmp_n = (n: int);
+    undefined = (n: int);
+    break;
   } else {
     let s2_n: int = (n: int) + -1;
-    c = 1;
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-} while ((c: int));`
+}`
   );
 });
 
@@ -745,8 +763,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: HIR_VARIABLE('n', HIR_INT_TYPE),
+            s2BreakValue: null,
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -756,137 +775,29 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       }),
       HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
     ],
     `let n: int = 10;
 let v: int;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
-  let c: int;
   let _tmp_n: int;
   if (is_zero: bool) {
-    c = 0;
-    _tmp_n = (n: int);
+    v = (n: int);
+    break;
   } else {
     let s2_n: int = (n: int) + -1;
-    c = 1;
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-  v = (_tmp_n: int);
-} while ((c: int));
+}
 return (v: int);`
   );
 });
 
 it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 3/n.', () => {
-  assertCorrectlyOptimized(
-    [
-      HIR_WHILE({
-        loopVariables: [
-          {
-            name: 'n',
-            type: HIR_INT_TYPE,
-            initialValue: HIR_INT(10),
-            loopValue: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-          },
-        ],
-        statements: [
-          HIR_BINARY({
-            name: 'is_zero',
-            operator: '==',
-            e1: HIR_VARIABLE('n', HIR_INT_TYPE),
-            e2: HIR_ZERO,
-          }),
-          HIR_IF_ELSE({
-            booleanExpression: HIR_VARIABLE('is_zero', HIR_BOOL_TYPE),
-            s1: [],
-            s2: [
-              HIR_BINARY({
-                name: 's2_n',
-                operator: '-',
-                e1: HIR_VARIABLE('n', HIR_INT_TYPE),
-                e2: HIR_ONE,
-              }),
-            ],
-            finalAssignments: [
-              {
-                name: '_tmp_n',
-                type: HIR_INT_TYPE,
-                branch1Value: HIR_VARIABLE('n', HIR_INT_TYPE),
-                branch2Value: HIR_VARIABLE('s2_n', HIR_INT_TYPE),
-              },
-            ],
-          }),
-        ],
-        conditionValue: HIR_FALSE,
-      }),
-    ],
-    ``
-  );
-});
-
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 4/n.', () => {
-  assertCorrectlyOptimized(
-    [
-      HIR_WHILE({
-        loopVariables: [
-          {
-            name: 'n',
-            type: HIR_INT_TYPE,
-            initialValue: HIR_INT(10),
-            loopValue: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-          },
-        ],
-        statements: [
-          HIR_BINARY({
-            name: 'is_zero',
-            operator: '==',
-            e1: HIR_VARIABLE('n', HIR_INT_TYPE),
-            e2: HIR_ZERO,
-          }),
-          HIR_IF_ELSE({
-            booleanExpression: HIR_VARIABLE('is_zero', HIR_BOOL_TYPE),
-            s1: [],
-            s2: [
-              HIR_BINARY({
-                name: 's2_n',
-                operator: '-',
-                e1: HIR_VARIABLE('n', HIR_INT_TYPE),
-                e2: HIR_ONE,
-              }),
-            ],
-            finalAssignments: [
-              {
-                name: '_tmp_n',
-                type: HIR_INT_TYPE,
-                branch1Value: HIR_VARIABLE('n', HIR_INT_TYPE),
-                branch2Value: HIR_VARIABLE('s2_n', HIR_INT_TYPE),
-              },
-            ],
-          }),
-        ],
-        conditionValue: HIR_FALSE,
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
-      }),
-      HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
-    ],
-    `return 9;`
-  );
-});
-
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 2/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_WHILE({
@@ -916,8 +827,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: HIR_VARIABLE('s2_n', HIR_INT_TYPE),
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -927,19 +839,20 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       }),
       HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
     ],
     `let v: int;
-do {
-  v = 9;
-} while (1);
+while (true) {
+  let _tmp_n: int;
+  if 0 {
+    _tmp_n = 10;
+  } else {
+    v = 9;
+    break;
+  }
+}
 return (v: int);`
   );
 });

--- a/samlang-core-optimization/__tests__/hir-dead-code-elimination-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-dead-code-elimination-optimization.test.ts
@@ -30,7 +30,7 @@ const assertCorrectlyOptimized = (statements: HighIRStatement[], expected: strin
   ).toBe(expected);
 };
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of simple statements 1/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on a series of simple statements 1/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'u1', operator: '/', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -71,7 +71,7 @@ return (ii: int);`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on a series of simple statements 2/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on a series of simple statements 2/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'u1', operator: '/', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -101,7 +101,7 @@ ff();`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statements 1/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on if-else statements 1/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -121,6 +121,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnType: HIR_INT_TYPE,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
     ],
@@ -133,7 +135,7 @@ if (b: bool) {
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statements 2/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on if-else statements 2/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -155,6 +157,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnCollector: 'a2',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -179,7 +183,7 @@ return (ma: int);`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statements 3/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on if-else statements 3/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -199,6 +203,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnType: HIR_INT_TYPE,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -218,7 +224,7 @@ if (b: bool) {
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statements 4/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on if-else statements 4/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -240,6 +246,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
             returnCollector: 'a2',
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'ma',
@@ -259,7 +267,7 @@ if (b: bool) {
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else statements 5/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on if-else statements 5/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -267,6 +275,8 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
         booleanExpression: HIR_VARIABLE('b', HIR_BOOL_TYPE),
         s1: [],
         s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
     ],
@@ -274,7 +284,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on if-else st
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch statements 1/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on switch statements 1/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -284,10 +294,12 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
           {
             caseNumber: 0,
             statements: [HIR_BINARY({ name: 'c', operator: '==', e1: HIR_ZERO, e2: HIR_ONE })],
+            breakValue: null,
           },
           {
             caseNumber: 1,
             statements: [HIR_BINARY({ name: 'd', operator: '==', e1: HIR_ZERO, e2: HIR_ONE })],
+            breakValue: null,
           },
         ],
         finalAssignments: [],
@@ -297,7 +309,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch statements 2/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on switch statements 2/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -314,6 +326,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'a1',
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 1,
@@ -325,6 +338,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'a2',
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -348,7 +362,7 @@ switch (b) {
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch statements 3/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on switch statements 3/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_BINARY({ name: 'b', operator: '==', e1: HIR_ZERO, e2: HIR_ONE }),
@@ -365,6 +379,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'a1',
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 1,
@@ -376,6 +391,7 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on switch sta
                 returnCollector: 'a2',
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -404,7 +420,7 @@ return (ma: int);`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 1/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on while statement 1/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_WHILE({
@@ -434,8 +450,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -445,28 +462,24 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
       }),
     ],
     `let n: int = 10;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
-  let c: int;
   let _tmp_n: int;
   if (is_zero: bool) {
-    c = 0;
     _tmp_n = (n: int);
   } else {
     let s2_n: int = (n: int) + -1;
-    c = 1;
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-} while ((c: int));`
+}`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 2/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on while statement 2/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_WHILE({
@@ -502,8 +515,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: HIR_ZERO,
+            s2BreakValue: null,
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -513,33 +527,26 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       }),
     ],
     `let n: int = 10;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
-  let c: int;
   let _tmp_n: int;
   if (is_zero: bool) {
-    c = 0;
-    _tmp_n = (n: int);
+    undefined = 0;
+    break;
   } else {
     let s2_n: int = (n: int) + -1;
-    c = 1;
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-} while ((c: int));`
+}`
   );
 });
 
-it('optimizeHighIRStatementsByConditionalConstantPropagation works on while statement 3/n.', () => {
+it('optimizeHighIRStatementsByDeadCodeElimination works on while statement 3/n.', () => {
   assertCorrectlyOptimized(
     [
       HIR_WHILE({
@@ -569,8 +576,9 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: HIR_ZERO,
             finalAssignments: [
-              { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
                 name: '_tmp_n',
                 type: HIR_INT_TYPE,
@@ -580,32 +588,24 @@ it('optimizeHighIRStatementsByConditionalConstantPropagation works on while stat
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       }),
       HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
     ],
     `let n: int = 10;
 let v: int;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
-  let c: int;
   let _tmp_n: int;
   if (is_zero: bool) {
-    c = 0;
     _tmp_n = (n: int);
   } else {
     let s2_n: int = (n: int) + -1;
-    c = 1;
-    _tmp_n = (s2_n: int);
+    v = 0;
+    break;
   }
   n = (_tmp_n: int);
-  v = (_tmp_n: int);
-} while ((c: int));
+}
 return (v: int);`
   );
 });

--- a/samlang-core-optimization/__tests__/hir-inline-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-inline-optimization.test.ts
@@ -84,12 +84,16 @@ it('estimateFunctionInlineCost test', () => {
               e2: HIR_INT(3),
             }),
           ],
+          s1BreakValue: null,
+          s2BreakValue: null,
           finalAssignments: [],
         }),
         HIR_IF_ELSE({
           booleanExpression: HIR_ZERO,
           s1: [],
           s2: [],
+          s1BreakValue: null,
+          s2BreakValue: null,
           finalAssignments: [
             {
               name: 'a',
@@ -112,6 +116,7 @@ it('estimateFunctionInlineCost test', () => {
                   e2: HIR_INT(3),
                 }),
               ],
+              breakValue: null,
             },
           ],
           finalAssignments: [],
@@ -129,6 +134,7 @@ it('estimateFunctionInlineCost test', () => {
                   e2: HIR_INT(3),
                 }),
               ],
+              breakValue: null,
             },
           ],
           finalAssignments: [{ name: '', type: HIR_INT_TYPE, branchValues: [HIR_ZERO] }],
@@ -145,27 +151,11 @@ it('estimateFunctionInlineCost test', () => {
               e2: HIR_INT(3),
             }),
           ],
-          conditionValue: HIR_ZERO,
-        }),
-        HIR_WHILE({
-          loopVariables: [
-            { name: '', type: HIR_INT_TYPE, initialValue: HIR_ZERO, loopValue: HIR_ZERO },
-          ],
-          statements: [
-            HIR_BINARY({
-              name: '',
-              operator: '+',
-              e1: HIR_VARIABLE('', HIR_INT_TYPE),
-              e2: HIR_INT(3),
-            }),
-          ],
-          conditionValue: HIR_ZERO,
-          returnAssignment: { name: '', type: HIR_INT_TYPE, value: HIR_ZERO },
         }),
         HIR_RETURN(HIR_VARIABLE('ss', HIR_INT_TYPE)),
       ],
     })
-  ).toBe(39);
+  ).toBe(34);
 });
 
 const assertCorrectlyInlined = (functions: readonly HighIRFunction[], expected: string): void => {
@@ -219,6 +209,8 @@ it('optimizeFunctionsByInlining test 1', () => {
                 returnCollector: 'v',
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
               {
                 name: 'fa',
@@ -319,6 +311,8 @@ it('optimizeFunctionsByInlining test 1', () => {
                 assignedExpression: HIR_ZERO,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [],
           }),
         ],
@@ -418,6 +412,8 @@ it('optimizeFunctionsByInlining test 2', () => {
                 returnType: HIR_INT_TYPE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [],
           }),
         ],
@@ -480,6 +476,8 @@ it('optimizeFunctionsByInlining test 3', () => {
               }),
             ],
             s2: [HIR_CAST({ name: 'a', type: HIR_INT_TYPE, assignedExpression: HIR_ZERO })],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [],
           }),
         ],
@@ -542,6 +540,8 @@ it('optimizeFunctionsByInlining test 4', () => {
               }),
             ],
             s2: [HIR_CAST({ name: 'a', type: HIR_INT_TYPE, assignedExpression: HIR_ZERO })],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
               {
                 name: 'b',
@@ -651,12 +651,14 @@ it('optimizeFunctionsByInlining test 6', () => {
                     returnType: HIR_INT_TYPE,
                   }),
                 ],
+                breakValue: null,
               },
               {
                 caseNumber: 1,
                 statements: [
                   HIR_CAST({ name: 'a', type: HIR_INT_TYPE, assignedExpression: HIR_ZERO }),
                 ],
+                breakValue: null,
               },
             ],
             finalAssignments: [
@@ -733,6 +735,7 @@ it('optimizeFunctionsByInlining test 7', () => {
                 statements: [
                   HIR_CAST({ name: 'a', type: HIR_INT_TYPE, assignedExpression: HIR_ZERO }),
                 ],
+                breakValue: null,
               },
               {
                 caseNumber: 1,
@@ -743,6 +746,7 @@ it('optimizeFunctionsByInlining test 7', () => {
                     returnType: HIR_INT_TYPE,
                   }),
                 ],
+                breakValue: null,
               },
             ],
             finalAssignments: [],
@@ -831,19 +835,16 @@ it('optimizeFunctionsByInlining test 8', () => {
               },
             ],
             statements: [
-              HIR_FUNCTION_CALL({
-                functionExpression: HIR_NAME('fooBar', HIR_INT_TYPE),
-                functionArguments: [],
-                returnType: HIR_INT_TYPE,
-                returnCollector: '_tmp_n',
+              HIR_IF_ELSE({
+                booleanExpression: HIR_ZERO,
+                s1: [],
+                s2: [],
+                s1BreakValue: HIR_ZERO,
+                s2BreakValue: HIR_ZERO,
+                finalAssignments: [],
               }),
             ],
-            conditionValue: HIR_TRUE,
-            returnAssignment: {
-              name: 'v',
-              type: HIR_INT_TYPE,
-              value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-            },
+            breakCollector: { name: 'v', type: HIR_INT_TYPE },
           }),
           HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
         ],
@@ -852,29 +853,16 @@ it('optimizeFunctionsByInlining test 8', () => {
     `function fooBar(): int {
   let n: int = 10;
   let v: int;
-  do {
-    let _inline_0_n: int = 10;
-    let _inline_0_v: int;
-    do {
-      let _inline_1_n: int = 10;
-      let _inline_1_v: int;
-      do {
-        let _inline_1__inline_0_n: int = 10;
-        let _inline_1__inline_0_v: int;
-        do {
-          let _inline_1__inline_0__tmp_n: int = fooBar();
-          _inline_1__inline_0_n = (_inline_1__inline_0__tmp_n: int);
-          _inline_1__inline_0_v = (_inline_1__inline_0__tmp_n: int);
-        } while (1);
-        _inline_1_n = (_inline_1__inline_0_v: int);
-        _inline_1_v = (_inline_1__inline_0_v: int);
-      } while (1);
-      _inline_0_n = (_inline_1_v: int);
-      _inline_0_v = (_inline_1_v: int);
-    } while (1);
-    n = (_inline_0_v: int);
-    v = (_inline_0_v: int);
-  } while (1);
+  while (true) {
+    if 0 {
+      v = 0;
+      break;
+    } else {
+      v = 0;
+      break;
+    }
+    n = (_tmp_n: int);
+  }
   return (v: int);
 }
 `
@@ -906,7 +894,6 @@ it('optimizeFunctionsByInlining test 9', () => {
                 returnCollector: '_tmp_n',
               }),
             ],
-            conditionValue: HIR_TRUE,
           }),
           HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
         ],
@@ -914,38 +901,38 @@ it('optimizeFunctionsByInlining test 9', () => {
     ],
     `function fooBar(): int {
   let n: int = 10;
-  do {
+  while (true) {
     let _inline_0_n: int = 10;
-    do {
+    while (true) {
       let _inline_1_n: int = 10;
-      do {
+      while (true) {
         let _inline_1__inline_0_n: int = 10;
-        do {
+        while (true) {
           let _inline_2_n: int = 10;
-          do {
+          while (true) {
             let _inline_2__inline_0_n: int = 10;
-            do {
+            while (true) {
               let _inline_2__inline_1_n: int = 10;
-              do {
+              while (true) {
                 let _inline_2__inline_1__inline_0_n: int = 10;
-                do {
+                while (true) {
                   let _inline_2__inline_1__inline_0__tmp_n: int = fooBar();
                   _inline_2__inline_1__inline_0_n = (_inline_2__inline_1__inline_0__tmp_n: int);
-                } while (1);
+                }
                 _inline_2__inline_1_n = (v: int);
-              } while (1);
+              }
               _inline_2__inline_0_n = (v: int);
-            } while (1);
+            }
             _inline_2_n = (v: int);
-          } while (1);
+          }
           _inline_1__inline_0_n = (v: int);
-        } while (1);
+        }
         _inline_1_n = (v: int);
-      } while (1);
+      }
       _inline_0_n = (v: int);
-    } while (1);
+    }
     n = (v: int);
-  } while (1);
+  }
   return (v: int);
 }
 `

--- a/samlang-core-optimization/__tests__/hir-local-value-numbering-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-local-value-numbering-optimization.test.ts
@@ -137,6 +137,8 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on if-else 1/n', () => {
             index: 1,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       }),
       HIR_INDEX_ACCESS({
@@ -195,6 +197,8 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on if-else 2/n', () => {
             index: 1,
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
           {
             name: 'bar',
@@ -245,6 +249,7 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on switch 1/n', () => {
                 index: 1,
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 1,
@@ -262,6 +267,7 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on switch 1/n', () => {
                 index: 1,
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [],
@@ -314,6 +320,7 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on switch 2/n', () => {
                 index: 1,
               }),
             ],
+            breakValue: null,
           },
           {
             caseNumber: 1,
@@ -331,6 +338,7 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on switch 2/n', () => {
                 index: 1,
               }),
             ],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -387,6 +395,8 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on while statement 1/n.'
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
               { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
@@ -398,11 +408,10 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on while statement 1/n.'
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
       }),
     ],
     `let n: int = 10;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
   let c: int;
   let _tmp_n: int;
@@ -415,7 +424,7 @@ do {
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-} while ((c: int));`
+}`
   );
 });
 
@@ -449,6 +458,8 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on while statement 2/n.'
                 e2: HIR_ONE,
               }),
             ],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [
               { name: 'c', type: HIR_INT_TYPE, branch1Value: HIR_FALSE, branch2Value: HIR_TRUE },
               {
@@ -460,18 +471,13 @@ it('optimizeHighIRStatementsByLocalValueNumbering works on while statement 2/n.'
             ],
           }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_tmp_n', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       }),
       HIR_RETURN(HIR_VARIABLE('v', HIR_INT_TYPE)),
     ],
     `let n: int = 10;
 let v: int;
-do {
+while (true) {
   let is_zero: bool = (n: int) == 0;
   let c: int;
   let _tmp_n: int;
@@ -484,8 +490,7 @@ do {
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
-  v = (_tmp_n: int);
-} while ((c: int));
+}
 return (v: int);`
   );
 });

--- a/samlang-core-optimization/__tests__/hir-tail-recursion-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-tail-recursion-optimization.test.ts
@@ -94,7 +94,14 @@ it('optimizeHighIRFunctionByTailRecursionRewrite fails case 6/n', () => {
     parameters: [],
     type: HIR_FUNCTION_TYPE([], HIR_INT_TYPE),
     body: [
-      HIR_IF_ELSE({ booleanExpression: HIR_ZERO, s1: [], s2: [], finalAssignments: [] }),
+      HIR_IF_ELSE({
+        booleanExpression: HIR_ZERO,
+        s1: [],
+        s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
+        finalAssignments: [],
+      }),
       HIR_RETURN(HIR_VARIABLE('', HIR_INT_TYPE)),
     ],
   });
@@ -106,7 +113,14 @@ it('optimizeHighIRFunctionByTailRecursionRewrite fails case 7/n', () => {
     parameters: [],
     type: HIR_FUNCTION_TYPE([], HIR_INT_TYPE),
     body: [
-      HIR_IF_ELSE({ booleanExpression: HIR_ZERO, s1: [], s2: [], finalAssignments: [] }),
+      HIR_IF_ELSE({
+        booleanExpression: HIR_ZERO,
+        s1: [],
+        s2: [],
+        s1BreakValue: null,
+        s2BreakValue: null,
+        finalAssignments: [],
+      }),
       HIR_RETURN(HIR_ZERO),
     ],
   });
@@ -171,14 +185,13 @@ it('optimizeHighIRFunctionByTailRecursionRewrite simple infinite loop case', () 
     },
     `function loopy(_tailrec_param_n: int): int {
   let n: int = (_tailrec_param_n: int);
-  let _tailrec_0_: int;
-  do {
+  let r: int;
+  while (true) {
     let a: int = (n: int) + 0;
     let r: int = 0 + 0;
     n = (a: int);
-    _tailrec_0_ = (r: int);
-  } while (1);
-  return (_tailrec_0_: int);
+  }
+  return (r: int);
 }
 `
   );
@@ -197,10 +210,12 @@ it('optimizeHighIRFunctionByTailRecursionRewrite nested complex case', () => {
             {
               caseNumber: 0,
               statements: [],
+              breakValue: null,
             },
             {
               caseNumber: 1,
               statements: [],
+              breakValue: null,
             },
             {
               caseNumber: 2,
@@ -222,6 +237,8 @@ it('optimizeHighIRFunctionByTailRecursionRewrite nested complex case', () => {
                       returnCollector: 'r',
                     }),
                   ],
+                  s1BreakValue: null,
+                  s2BreakValue: null,
                   finalAssignments: [
                     {
                       name: 'nested_return',
@@ -232,6 +249,7 @@ it('optimizeHighIRFunctionByTailRecursionRewrite nested complex case', () => {
                   ],
                 }),
               ],
+              breakValue: null,
             },
           ],
           finalAssignments: [
@@ -247,46 +265,34 @@ it('optimizeHighIRFunctionByTailRecursionRewrite nested complex case', () => {
     },
     `function loopy(_tailrec_param_n: int): int {
   let n: int = (_tailrec_param_n: int);
-  let _tailrec_4_: int;
-  do {
-    let v: int;
-    let _tailrec_2_: int;
-    let _tailrec_3_: bool;
+  let v: int;
+  while (true) {
+    let _tailrec_1_: int;
     switch (n) {
       case 0: {
         v = 0;
-        _tailrec_2_ = 0;
-        _tailrec_3_ = 0;
+        break;
       }
       case 1: {
         v = 1;
-        _tailrec_2_ = 0;
-        _tailrec_3_ = 0;
+        break;
       }
       case 2: {
-        let nested_return: int;
         let _tailrec_0_: int;
-        let _tailrec_1_: bool;
         if 0 {
-          nested_return = 1;
-          _tailrec_0_ = 0;
-          _tailrec_1_ = 0;
+          v = 1;
+          break;
         } else {
           let nn: int = (n: int) + -1;
           let r: int = 0 + 0;
-          nested_return = (r: int);
           _tailrec_0_ = (nn: int);
-          _tailrec_1_ = 1;
         }
-        v = (nested_return: int);
-        _tailrec_2_ = (_tailrec_0_: int);
-        _tailrec_3_ = (_tailrec_1_: bool);
+        _tailrec_1_ = (_tailrec_0_: int);
       }
     }
-    n = (_tailrec_2_: int);
-    _tailrec_4_ = (v: int);
-  } while ((_tailrec_3_: bool));
-  return (_tailrec_4_: int);
+    n = (_tailrec_1_: int);
+  }
+  return (v: int);
 }
 `
   );

--- a/samlang-core-optimization/__tests__/hir-unused-name-elimination-optimization.test.ts
+++ b/samlang-core-optimization/__tests__/hir-unused-name-elimination-optimization.test.ts
@@ -64,7 +64,18 @@ it('optimizeHighIRModuleByEliminatingUnusedOnes test', () => {
           HIR_RETURN(HIR_NAME('bar', HIR_INT_TYPE)),
           HIR_SWITCH({
             caseVariable: 'a',
-            cases: [{ caseNumber: 0, statements: [HIR_RETURN(HIR_NAME('bar', HIR_INT_TYPE))] }],
+            cases: [
+              {
+                caseNumber: 0,
+                statements: [HIR_RETURN(HIR_NAME('bar', HIR_INT_TYPE))],
+                breakValue: null,
+              },
+              {
+                caseNumber: 1,
+                statements: [HIR_RETURN(HIR_NAME('bar', HIR_INT_TYPE))],
+                breakValue: HIR_ZERO,
+              },
+            ],
             finalAssignments: [
               {
                 name: 'dff',
@@ -84,12 +95,16 @@ it('optimizeHighIRModuleByEliminatingUnusedOnes test', () => {
               }),
             ],
             s2: [HIR_CAST({ name: '', type: HIR_INT_TYPE, assignedExpression: HIR_ZERO })],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [],
           }),
           HIR_IF_ELSE({
             booleanExpression: HIR_ZERO,
             s1: [],
             s2: [],
+            s1BreakValue: HIR_ZERO,
+            s2BreakValue: HIR_ZERO,
             finalAssignments: [
               {
                 name: 'fff',
@@ -111,15 +126,13 @@ it('optimizeHighIRModuleByEliminatingUnusedOnes test', () => {
                 e2: HIR_NAME('bar', HIR_INT_TYPE),
               }),
             ],
-            conditionValue: HIR_ZERO,
           }),
           HIR_WHILE({
             loopVariables: [
               { name: 'f', type: HIR_INT_TYPE, initialValue: HIR_ZERO, loopValue: HIR_ZERO },
             ],
             statements: [],
-            conditionValue: HIR_ZERO,
-            returnAssignment: { name: 'd', type: HIR_INT_TYPE, value: HIR_ZERO },
+            breakCollector: { name: 'd', type: HIR_INT_TYPE },
           }),
         ],
       },

--- a/samlang-core-optimization/hir-common-subexpression-elimination-optimization.ts
+++ b/samlang-core-optimization/hir-common-subexpression-elimination-optimization.ts
@@ -103,8 +103,9 @@ const optimizeHighIRStatement = (
     }
 
     case 'HighIRSwitchStatement': {
-      const casesWithSets = statement.cases.map(({ caseNumber, statements }) => ({
+      const casesWithSets = statement.cases.map(({ caseNumber, statements, breakValue }) => ({
         caseNumber,
+        breakValue,
         ...optimizeHighIRStatementsWithSet(statements, allocator),
       }));
       const commonExpressions = intersectionOf(
@@ -117,7 +118,11 @@ const optimizeHighIRStatement = (
       return [
         {
           ...statement,
-          cases: casesWithSets.map(({ caseNumber, statements }) => ({ caseNumber, statements })),
+          cases: casesWithSets.map(({ caseNumber, statements, breakValue }) => ({
+            caseNumber,
+            statements,
+            breakValue,
+          })),
         },
         ...hoistedStatements.reverse(),
       ];

--- a/samlang-core-optimization/hir-dead-code-elimination-optimization.ts
+++ b/samlang-core-optimization/hir-dead-code-elimination-optimization.ts
@@ -68,16 +68,13 @@ const optimizeHighIRStatement = (
       return switchStatement;
     }
     case 'HighIRWhileStatement': {
-      let returnAssignment = statement.returnAssignment;
-      if (returnAssignment != null) {
-        if (set.has(returnAssignment.name)) {
-          collectUseFromExpression(returnAssignment.value);
-        } else {
-          returnAssignment = undefined;
+      let breakCollector = statement.breakCollector;
+      if (breakCollector != null) {
+        if (!set.has(breakCollector.name)) {
+          breakCollector = undefined;
         }
       }
       statement.loopVariables.forEach((it) => collectUseFromExpression(it.loopValue));
-      collectUseFromExpression(statement.conditionValue);
       const statements = optimizeHighIRStatements(statement.statements, set);
       const loopVariables = statement.loopVariables
         .map((variable) => {
@@ -88,7 +85,7 @@ const optimizeHighIRStatement = (
           return null;
         })
         .filter(isNotNull);
-      return [{ ...statement, loopVariables, statements, returnAssignment }];
+      return [{ ...statement, loopVariables, statements, breakCollector }];
     }
     case 'HighIRCastStatement':
       if (!set.has(statement.name)) return [];

--- a/samlang-core-optimization/hir-optimization-common.ts
+++ b/samlang-core-optimization/hir-optimization-common.ts
@@ -41,7 +41,13 @@ export class LocalValueContextForOptimization extends LocalStackedContext<HighIR
 }
 
 export const ifElseOrNull = (ifElse: HighIRIfElseStatement): readonly HighIRStatement[] => {
-  if (ifElse.s1.length === 0 && ifElse.s2.length === 0 && ifElse.finalAssignments.length === 0) {
+  if (
+    ifElse.s1.length === 0 &&
+    ifElse.s2.length === 0 &&
+    ifElse.s1BreakValue == null &&
+    ifElse.s2BreakValue == null &&
+    ifElse.finalAssignments.length === 0
+  ) {
     return [];
   }
   return [ifElse];
@@ -51,7 +57,7 @@ export const switchOrNull = (
   switchStatement: HighIRSwitchStatement
 ): readonly HighIRStatement[] => {
   if (
-    switchStatement.cases.every((it) => it.statements.length === 0) &&
+    switchStatement.cases.every((it) => it.statements.length === 0 && it.breakValue == null) &&
     switchStatement.finalAssignments.length === 0
   ) {
     return [];

--- a/samlang-core-optimization/hir-unused-name-elimination-optimization.ts
+++ b/samlang-core-optimization/hir-unused-name-elimination-optimization.ts
@@ -50,6 +50,12 @@ const collectUsedNamesFromStatement = (
       collectUsedNamesFromExpression(nameSet, typeSet, statement.booleanExpression);
       statement.s1.forEach((it) => collectUsedNamesFromStatement(nameSet, typeSet, it));
       statement.s2.forEach((it) => collectUsedNamesFromStatement(nameSet, typeSet, it));
+      if (statement.s1BreakValue != null) {
+        collectUsedNamesFromExpression(nameSet, typeSet, statement.s1BreakValue);
+      }
+      if (statement.s2BreakValue != null) {
+        collectUsedNamesFromExpression(nameSet, typeSet, statement.s2BreakValue);
+      }
       statement.finalAssignments.forEach((finalAssignment) => {
         collectUsedNamesFromExpression(nameSet, typeSet, finalAssignment.branch1Value);
         collectUsedNamesFromExpression(nameSet, typeSet, finalAssignment.branch2Value);
@@ -57,9 +63,12 @@ const collectUsedNamesFromStatement = (
       });
       break;
     case 'HighIRSwitchStatement':
-      statement.cases
-        .flatMap((it) => it.statements)
-        .forEach((it) => collectUsedNamesFromStatement(nameSet, typeSet, it));
+      statement.cases.forEach((oneCase) => {
+        oneCase.statements.forEach((it) => collectUsedNamesFromStatement(nameSet, typeSet, it));
+        if (oneCase.breakValue != null) {
+          collectUsedNamesFromExpression(nameSet, typeSet, oneCase.breakValue);
+        }
+      });
       statement.finalAssignments.forEach((final) => {
         final.branchValues.forEach((it) => collectUsedNamesFromExpression(nameSet, typeSet, it));
         collectForTypeSet(final.type, typeSet);
@@ -72,10 +81,8 @@ const collectUsedNamesFromStatement = (
         collectUsedNamesFromExpression(nameSet, typeSet, it.loopValue);
       });
       statement.statements.forEach((it) => collectUsedNamesFromStatement(nameSet, typeSet, it));
-      collectUsedNamesFromExpression(nameSet, typeSet, statement.conditionValue);
-      if (statement.returnAssignment != null) {
-        collectForTypeSet(statement.returnAssignment.type, typeSet);
-        collectUsedNamesFromExpression(nameSet, typeSet, statement.returnAssignment.value);
+      if (statement.breakCollector != null) {
+        collectForTypeSet(statement.breakCollector.type, typeSet);
       }
       break;
     case 'HighIRCastStatement':

--- a/samlang-core-printer/__tests__/printer-js.test.ts
+++ b/samlang-core-printer/__tests__/printer-js.test.ts
@@ -116,8 +116,8 @@ const w = "World!";
 const f1 = "\\"foo";
 const f2 = "'foo";
 const _module_Test_class_Main_function_main = () => {
-  let _t0 = _builtin_stringConcat(h, w);
-  let _t1 = _builtin_println(_t0);
+  var _t0 = _builtin_stringConcat(h, w);
+  var _t1 = _builtin_println(_t0);
 };
 const _compiled_program_main = () => {
   _module_Test_class_Main_function_main();
@@ -250,6 +250,8 @@ it('confirm samlang & equivalent JS have same print output', () => {
               booleanExpression: HIR_VARIABLE('bb', HIR_BOOL_TYPE),
               s1: [HIR_RETURN(HIR_NAME('y', HIR_STRING_TYPE))],
               s2: [HIR_RETURN(HIR_NAME('n', HIR_STRING_TYPE))],
+              s1BreakValue: null,
+              s2BreakValue: null,
               finalAssignments: [],
             }),
           ],
@@ -391,6 +393,8 @@ it('confirm samlang & equivalent JS have same print output', () => {
                 }),
               ],
               s2: [],
+              s1BreakValue: null,
+              s2BreakValue: null,
               finalAssignments: [],
             }),
           ],
@@ -410,7 +414,7 @@ it('HIR statements to JS string test', () => {
         index: 3,
       })
     )
-  ).toBe(`let foo = samlang[3];`);
+  ).toBe(`var foo = samlang[3];`);
   expect(
     highIRStatementToString(
       HIR_BINARY({
@@ -420,13 +424,15 @@ it('HIR statements to JS string test', () => {
         e2: HIR_INT(2),
       })
     )
-  ).toBe(`let foo = Math.floor(3 / 2);`);
+  ).toBe(`var foo = Math.floor(3 / 2);`);
   expect(
     highIRStatementToString(
       HIR_IF_ELSE({
         booleanExpression: HIR_INT(5),
         s1: [],
         s2: [HIR_RETURN(HIR_ZERO)],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       })
     )
@@ -441,23 +447,19 @@ it('HIR statements to JS string test', () => {
         booleanExpression: HIR_INT(5),
         s1: [HIR_RETURN(HIR_ZERO)],
         s2: [HIR_RETURN(HIR_ZERO)],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [
-          {
-            name: 'f',
-            type: HIR_INT_TYPE,
-            branch1Value: HIR_ZERO,
-            branch2Value: HIR_ZERO,
-          },
+          { name: 'f', type: HIR_INT_TYPE, branch1Value: HIR_ZERO, branch2Value: HIR_ZERO },
         ],
       })
     )
-  ).toBe(`let f;
-if (5) {
+  ).toBe(`if (5) {
   return 0;
-  f = 0;
+  var f = 0;
 } else {
   return 0;
-  f = 0;
+  var f = 0;
 }`);
   expect(
     highIRStatementToString(
@@ -469,9 +471,13 @@ if (5) {
             booleanExpression: HIR_INT(5),
             s1: [HIR_RETURN(HIR_ZERO)],
             s2: [HIR_RETURN(HIR_ZERO)],
+            s1BreakValue: null,
+            s2BreakValue: null,
             finalAssignments: [],
           }),
         ],
+        s1BreakValue: null,
+        s2BreakValue: null,
         finalAssignments: [],
       })
     )
@@ -492,10 +498,12 @@ if (5) {
           {
             caseNumber: 1,
             statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_INT_TYPE))],
+            breakValue: null,
           },
           {
             caseNumber: 2,
             statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_INT_TYPE))],
+            breakValue: null,
           },
         ],
         finalAssignments: [],
@@ -519,10 +527,12 @@ if (5) {
           {
             caseNumber: 1,
             statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_INT_TYPE))],
+            breakValue: null,
           },
           {
             caseNumber: 2,
             statements: [HIR_RETURN(HIR_VARIABLE('foo', HIR_INT_TYPE))],
+            breakValue: null,
           },
         ],
         finalAssignments: [
@@ -534,16 +544,15 @@ if (5) {
         ],
       })
     )
-  ).toBe(`let ma;
-switch (f) {
+  ).toBe(`switch (f) {
   case 1: {
     return foo;
-    ma = 0;
+    var ma = 0;
     break;
   }
   case 2: {
     return foo;
-    ma = 0;
+    var ma = 0;
     break;
   }
 }`);
@@ -556,7 +565,7 @@ switch (f) {
         returnCollector: 'val',
       })
     )
-  ).toBe('let val = func();');
+  ).toBe('var val = func();');
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -575,7 +584,7 @@ switch (f) {
         returnCollector: 'res',
       })
     )
-  ).toBe(`let res = ${ENCODED_FUNCTION_NAME_PRINTLN}(0);`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_PRINTLN}(0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -585,7 +594,7 @@ switch (f) {
         returnCollector: 'res',
       })
     )
-  ).toBe(`let res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}(0);`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_TO_INT}(0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -595,7 +604,7 @@ switch (f) {
         returnCollector: 'res',
       })
     )
-  ).toBe(`let res = ${ENCODED_FUNCTION_NAME_INT_TO_STRING}(5);`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_INT_TO_STRING}(5);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -605,7 +614,7 @@ switch (f) {
         returnCollector: 'res',
       })
     )
-  ).toBe(`let res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}(0, 0);`);
+  ).toBe(`var res = ${ENCODED_FUNCTION_NAME_STRING_CONCAT}(0, 0);`);
   expect(
     highIRStatementToString(
       HIR_FUNCTION_CALL({
@@ -615,7 +624,7 @@ switch (f) {
         returnCollector: 'panik',
       })
     )
-  ).toBe(`let panik = ${ENCODED_FUNCTION_NAME_THROW}(0);`);
+  ).toBe(`var panik = ${ENCODED_FUNCTION_NAME_THROW}(0);`);
   expect(
     highIRStatementToString(
       HIR_CAST({
@@ -624,7 +633,7 @@ switch (f) {
         assignedExpression: HIR_INT(19815),
       })
     )
-  ).toBe(`let foo = 19815;`);
+  ).toBe(`var foo = 19815;`);
   expect(highIRStatementToString(HIR_RETURN(HIR_ZERO))).toBe('return 0;');
   expect(
     highIRStatementToString(
@@ -634,7 +643,7 @@ switch (f) {
         expressionList: [HIR_ZERO, HIR_ZERO, HIR_INT(13)],
       })
     )
-  ).toBe(`let st = [0, 0, 13];`);
+  ).toBe(`var st = [0, 0, 13];`);
 
   expect(
     highIRStatementToString(
@@ -660,16 +669,16 @@ switch (f) {
             assignedExpression: HIR_VARIABLE('dev', HIR_INT_TYPE),
           }),
         ],
-        conditionValue: HIR_ZERO,
       })
     )
-  ).toBe(`let n = _tail_rec_param_n;
-let acc = _tail_rec_param_acc;
-do {
-  let foo = dev;
+  ).toBe(`var n = _tail_rec_param_n;
+var acc = _tail_rec_param_acc;
+_while_label_0:
+while (true) {
+  var foo = dev;
   n = _t0_n;
   acc = _t1_acc;
-} while (0);`);
+}`);
   expect(
     highIRStatementToString(
       HIR_WHILE({
@@ -693,25 +702,55 @@ do {
             type: HIR_INT_TYPE,
             assignedExpression: HIR_VARIABLE('dev', HIR_INT_TYPE),
           }),
+          HIR_IF_ELSE({
+            booleanExpression: HIR_ZERO,
+            s1: [],
+            s2: [],
+            s1BreakValue: HIR_ZERO,
+            s2BreakValue: HIR_ZERO,
+            finalAssignments: [],
+          }),
+          HIR_SWITCH({
+            caseVariable: 'foo',
+            cases: [
+              { caseNumber: 0, statements: [], breakValue: HIR_ZERO },
+              { caseNumber: 1, statements: [], breakValue: HIR_ZERO },
+            ],
+            finalAssignments: [],
+          }),
         ],
-        conditionValue: HIR_VARIABLE('c', HIR_INT_TYPE),
-        returnAssignment: {
-          name: 'v',
-          type: HIR_INT_TYPE,
-          value: HIR_VARIABLE('_t2_v', HIR_INT_TYPE),
-        },
+        breakCollector: { name: 'v', type: HIR_INT_TYPE },
       })
     )
-  ).toBe(`let n = _tail_rec_param_n;
-let acc = _tail_rec_param_acc;
-let v;
-do {
-  let foo = dev;
+  ).toBe(`var n = _tail_rec_param_n;
+var acc = _tail_rec_param_acc;
+_while_label_0:
+while (true) {
+  var foo = dev;
+  if (0) {
+
+    var v = 0;
+    break _while_label_0;
+  } else {
+
+    var v = 0;
+    break _while_label_0;
+  }
+  switch (foo) {
+    case 0: {
+
+      var v = 0;
+      break _while_label_0;
+    }
+    case 1: {
+
+      var v = 0;
+      break _while_label_0;
+    }
+  }
   n = _t0_n;
   acc = _t1_acc;
-  v = _t2_v;
-  var _loop_condition = c;
-} while (_loop_condition);`);
+}`);
 });
 
 it('HIR function to JS string test 1', () => {
@@ -732,7 +771,7 @@ it('HIR function to JS string test 1', () => {
       })
     )
   ).toBe(`const baz = (d, t, i) => {
-  let b = 1857;
+  var b = 1857;
 };
 `);
 });


### PR DESCRIPTION
## Summary

The current while AST avoids the `break` instruction, but comes with the cost of being very cumbersome. The convoluted way of producing the break condition probably will hinder future potential optimizations. Therefore, this diff aims to fix this by refactoring the AST to make break more explicit.

In this diff, I make them attached to if-else, and switch, but I will explore whether this restriction should be removed.

## Test Plan

- `yarn test`
- `yarn test:integration`