### PR TITLE
[ast][hir] Introduce all nodes for new HIR

### DIFF
--- a/samlang-core-ast/__tests__/hir-nodes.test.ts
+++ b/samlang-core-ast/__tests__/hir-nodes.test.ts
@@ -1,11 +1,22 @@
 import {
   prettyPrintHighIRType,
   prettyPrintHighIRTypeDefinition,
+  debugPrintHighIRStatement,
+  debugPrintHighIRModule,
   HIR_BOOL_TYPE,
   HIR_INT_TYPE,
   HIR_STRING_TYPE,
   HIR_IDENTIFIER_TYPE,
   HIR_FUNCTION_TYPE,
+  HIR_FUNCTION_CALL,
+  HIR_IF_ELSE,
+  HIR_INDEX_ACCESS,
+  HIR_STRUCT_INITIALIZATION,
+  HIR_ZERO,
+  HIR_INT,
+  HIR_NAME,
+  HIR_VARIABLE,
+  HIR_BINARY,
 } from '../hir-nodes';
 
 it('prettyPrintHighIRType works', () => {
@@ -39,4 +50,110 @@ it('prettyPrintHighIRTypeDefinition works', () => {
       mappings: [HIR_INT_TYPE, HIR_IDENTIFIER_TYPE('C', [])],
     })
   ).toBe('variant type B<C> = [int, C]');
+});
+
+it('debugPrintHighIRStatement works', () => {
+  expect(
+    debugPrintHighIRStatement(
+      HIR_IF_ELSE({
+        booleanExpression: HIR_ZERO,
+        s1: [
+          HIR_STRUCT_INITIALIZATION({
+            structVariableName: 'baz',
+            type: HIR_IDENTIFIER_TYPE('FooBar', []),
+            expressionList: [HIR_NAME('meggo', HIR_STRING_TYPE)],
+          }),
+          HIR_BINARY({ name: 'dd', operator: '<', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_BINARY({ name: 'dd', operator: '^', e1: HIR_INT(0), e2: HIR_INT(0) }),
+        ],
+        s2: [
+          HIR_BINARY({ name: 'dd', operator: '+', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_BINARY({ name: 'dd', operator: '-', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_BINARY({ name: 'dd', operator: '*', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_BINARY({ name: 'dd', operator: '/', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_BINARY({ name: 'dd', operator: '%', e1: HIR_INT(0), e2: HIR_INT(0) }),
+          HIR_FUNCTION_CALL({
+            functionExpression: HIR_NAME('h', HIR_INT_TYPE),
+            functionArguments: [HIR_VARIABLE('big', HIR_IDENTIFIER_TYPE('FooBar', []))],
+            returnType: HIR_INT_TYPE,
+            returnCollector: 'vibez',
+          }),
+          HIR_FUNCTION_CALL({
+            functionExpression: HIR_NAME('stresso', HIR_INT_TYPE),
+            functionArguments: [HIR_VARIABLE('d', HIR_INT_TYPE)],
+            returnType: HIR_INT_TYPE,
+          }),
+          HIR_INDEX_ACCESS({
+            name: 'f',
+            type: HIR_INT_TYPE,
+            pointerExpression: HIR_VARIABLE('big', HIR_IDENTIFIER_TYPE('FooBar', [])),
+            index: 0,
+          }),
+        ],
+        finalAssignments: [
+          {
+            name: 'bar',
+            type: HIR_INT_TYPE,
+            branch1Value: HIR_VARIABLE('b1', HIR_INT_TYPE),
+            branch2Value: HIR_VARIABLE('b2', HIR_INT_TYPE),
+          },
+        ],
+      })
+    )
+  ).toBe(`let bar: int;
+if 0 {
+  let baz: FooBar = [meggo];
+  let dd: bool = 0 < 0;
+  let dd: bool = 0 ^ 0;
+  bar = (b1: int);
+} else {
+  let dd: int = 0 + 0;
+  let dd: int = 0 - 0;
+  let dd: int = 0 * 0;
+  let dd: int = 0 / 0;
+  let dd: int = 0 % 0;
+  let vibez: int = h((big: FooBar));
+  stresso((d: int));
+  let f: int = (big: FooBar)[0];
+  bar = (b2: int);
+}`);
+});
+
+it('debugPrintHighIRModule works', () => {
+  expect(
+    debugPrintHighIRModule({
+      globalVariables: [{ name: 'dev_meggo', content: 'vibez' }],
+      typeDefinitions: [
+        {
+          identifier: 'Foo',
+          type: 'object',
+          typeParameters: [],
+          mappings: [HIR_INT_TYPE, HIR_BOOL_TYPE],
+        },
+      ],
+      functions: [
+        {
+          name: 'Bar',
+          parameters: ['f'],
+          type: HIR_FUNCTION_TYPE([HIR_INT_TYPE], HIR_INT_TYPE),
+          body: [
+            HIR_INDEX_ACCESS({
+              name: 'f',
+              type: HIR_INT_TYPE,
+              pointerExpression: HIR_VARIABLE('big', HIR_IDENTIFIER_TYPE('FooBar', [])),
+              index: 0,
+            }),
+          ],
+          returnValue: HIR_ZERO,
+        },
+      ],
+    })
+  ).toBe(`const dev_meggo = 'vibez';
+
+object type Foo = [int, bool]
+function Bar(f: int): int {
+  let f: int = (big: FooBar)[0];
+  return 0;
+}
+`);
 });

--- a/samlang-core-ast/hir-nodes.ts
+++ b/samlang-core-ast/hir-nodes.ts
@@ -1,3 +1,8 @@
+import type { GlobalVariable } from './common-nodes';
+import type { IROperator } from './common-operators';
+
+import { zip } from 'samlang-core-utils';
+
 export type HighIRPrimitiveType = {
   readonly __type__: 'PrimitiveType';
   readonly type: 'bool' | 'int' | 'string';
@@ -67,3 +72,336 @@ export const prettyPrintHighIRTypeDefinition = ({
     typeParameters.length === 0 ? identifier : `${identifier}<${typeParameters.join(', ')}>`;
   return `${type} type ${idPart} = [${mappings.map(prettyPrintHighIRType).join(', ')}]`;
 };
+
+interface BaseHighIRExpression {
+  readonly __type__: string;
+  readonly type: HighIRType;
+}
+
+export interface HighIRIntLiteralExpression extends BaseHighIRExpression {
+  readonly __type__: 'HighIRIntLiteralExpression';
+  readonly value: number;
+}
+
+export interface HighIRNameExpression extends BaseHighIRExpression {
+  readonly __type__: 'HighIRNameExpression';
+  readonly name: string;
+}
+
+export interface HighIRVariableExpression extends BaseHighIRExpression {
+  readonly __type__: 'HighIRVariableExpression';
+  readonly name: string;
+}
+
+export type HighIRExpression =
+  | HighIRIntLiteralExpression
+  | HighIRNameExpression
+  | HighIRVariableExpression;
+
+interface BaseHighIRStatement {
+  readonly __type__: string;
+}
+
+export interface HighIRIndexAccessStatement extends BaseHighIRStatement {
+  readonly __type__: 'HighIRIndexAccessStatement';
+  readonly name: string;
+  readonly type: HighIRType;
+  readonly pointerExpression: HighIRExpression;
+  readonly index: number;
+}
+
+export interface HighIRBinaryStatement extends BaseHighIRExpression {
+  readonly __type__: 'HighIRBinaryStatement';
+  readonly name: string;
+  readonly type: HighIRType;
+  readonly operator: IROperator;
+  readonly e1: HighIRExpression;
+  readonly e2: HighIRExpression;
+}
+
+export interface HighIRFunctionCallStatement extends BaseHighIRStatement {
+  readonly __type__: 'HighIRFunctionCallStatement';
+  readonly functionExpression: HighIRExpression;
+  readonly functionArguments: readonly HighIRExpression[];
+  readonly returnType: HighIRType;
+  readonly returnCollector?: string;
+}
+
+export interface HighIRIfElseStatement extends BaseHighIRStatement {
+  readonly __type__: 'HighIRIfElseStatement';
+  readonly booleanExpression: HighIRExpression;
+  readonly s1: readonly HighIRStatement[];
+  readonly s2: readonly HighIRStatement[];
+  readonly finalAssignments: readonly {
+    readonly name: string;
+    readonly type: HighIRType;
+    readonly branch1Value: HighIRExpression;
+    readonly branch2Value: HighIRExpression;
+  }[];
+}
+
+export interface HighIRStructInitializationStatement extends BaseHighIRStatement {
+  readonly __type__: 'HighIRStructInitializationStatement';
+  readonly structVariableName: string;
+  readonly type: HighIRType;
+  readonly expressionList: readonly HighIRExpression[];
+}
+
+export type HighIRStatement =
+  | HighIRBinaryStatement
+  | HighIRIndexAccessStatement
+  | HighIRFunctionCallStatement
+  | HighIRIfElseStatement
+  | HighIRStructInitializationStatement;
+
+type ConstructorArgumentObject<E extends BaseHighIRExpression | BaseHighIRStatement> = Omit<
+  E,
+  '__type__'
+>;
+
+export const HIR_FALSE: HighIRIntLiteralExpression = {
+  __type__: 'HighIRIntLiteralExpression',
+  type: HIR_BOOL_TYPE,
+  value: 0,
+};
+
+export const HIR_TRUE: HighIRIntLiteralExpression = {
+  __type__: 'HighIRIntLiteralExpression',
+  type: HIR_BOOL_TYPE,
+  value: 1,
+};
+
+export const HIR_INT = (value: number): HighIRIntLiteralExpression => ({
+  __type__: 'HighIRIntLiteralExpression',
+  type: HIR_INT_TYPE,
+  value,
+});
+
+export const HIR_ZERO: HighIRIntLiteralExpression = HIR_INT(0);
+export const HIR_ONE: HighIRIntLiteralExpression = HIR_INT(1);
+
+export const HIR_NAME = (name: string, type: HighIRType): HighIRNameExpression => ({
+  __type__: 'HighIRNameExpression',
+  type,
+  name,
+});
+
+export const HIR_VARIABLE = (name: string, type: HighIRType): HighIRVariableExpression => ({
+  __type__: 'HighIRVariableExpression',
+  type,
+  name,
+});
+
+const getBinaryOperatorResultType = (operator: IROperator): HighIRType => {
+  switch (operator) {
+    case '*':
+    case '/':
+    case '%':
+    case '+':
+    case '-':
+      return HIR_INT_TYPE;
+    case '^':
+    case '<':
+    case '>':
+    case '<=':
+    case '>=':
+    case '==':
+    case '!=':
+      return HIR_BOOL_TYPE;
+  }
+};
+
+export const HIR_BINARY = ({
+  name,
+  operator,
+  e1,
+  e2,
+}: Omit<ConstructorArgumentObject<HighIRBinaryStatement>, 'type'>): HighIRBinaryStatement => ({
+  __type__: 'HighIRBinaryStatement',
+  name,
+  type: getBinaryOperatorResultType(operator),
+  operator,
+  e1,
+  e2,
+});
+
+export const HIR_INDEX_ACCESS = ({
+  name,
+  type,
+  pointerExpression,
+  index,
+}: ConstructorArgumentObject<HighIRIndexAccessStatement>): HighIRIndexAccessStatement => ({
+  __type__: 'HighIRIndexAccessStatement',
+  name,
+  type,
+  pointerExpression,
+  index,
+});
+
+export const HIR_FUNCTION_CALL = ({
+  functionExpression,
+  functionArguments,
+  returnType,
+  returnCollector,
+}: ConstructorArgumentObject<HighIRFunctionCallStatement>): HighIRFunctionCallStatement => ({
+  __type__: 'HighIRFunctionCallStatement',
+  functionExpression,
+  functionArguments,
+  returnType,
+  returnCollector,
+});
+
+export const HIR_IF_ELSE = ({
+  booleanExpression,
+  s1,
+  s2,
+  finalAssignments,
+}: ConstructorArgumentObject<HighIRIfElseStatement>): HighIRIfElseStatement => ({
+  __type__: 'HighIRIfElseStatement',
+  booleanExpression,
+  s1,
+  s2,
+  finalAssignments,
+});
+
+export const HIR_STRUCT_INITIALIZATION = ({
+  structVariableName,
+  type,
+  expressionList,
+}: ConstructorArgumentObject<HighIRStructInitializationStatement>): HighIRStructInitializationStatement => ({
+  __type__: 'HighIRStructInitializationStatement',
+  structVariableName,
+  type,
+  expressionList,
+});
+
+export const debugPrintHighIRExpression = (expression: HighIRExpression): string => {
+  switch (expression.__type__) {
+    case 'HighIRIntLiteralExpression':
+      return expression.value.toString();
+    case 'HighIRVariableExpression':
+      return `(${expression.name}: ${prettyPrintHighIRType(expression.type)})`;
+    case 'HighIRNameExpression':
+      return expression.name;
+  }
+};
+
+export const debugPrintHighIRStatement = (statement: HighIRStatement, startLevel = 0): string => {
+  const collector: string[] = [];
+  let level = startLevel;
+
+  const printer = (s: HighIRStatement) => {
+    switch (s.__type__) {
+      case 'HighIRIndexAccessStatement': {
+        const type = prettyPrintHighIRType(s.type);
+        const pointerExpression = debugPrintHighIRExpression(s.pointerExpression);
+        collector.push(
+          '  '.repeat(level),
+          `let ${s.name}: ${type} = ${pointerExpression}[${s.index}];\n`
+        );
+        break;
+      }
+      case 'HighIRBinaryStatement': {
+        const type = prettyPrintHighIRType(s.type);
+        const e1 = debugPrintHighIRExpression(s.e1);
+        const e2 = debugPrintHighIRExpression(s.e2);
+        collector.push('  '.repeat(level), `let ${s.name}: ${type} = ${e1} ${s.operator} ${e2};\n`);
+        break;
+      }
+      case 'HighIRFunctionCallStatement': {
+        const functionString = debugPrintHighIRExpression(s.functionExpression);
+        const argumentString = s.functionArguments.map(debugPrintHighIRExpression).join(', ');
+        const collectorString =
+          s.returnCollector != null
+            ? `let ${s.returnCollector}: ${prettyPrintHighIRType(s.returnType)} = `
+            : '';
+        collector.push(
+          '  '.repeat(level),
+          `${collectorString}${functionString}(${argumentString});\n`
+        );
+        break;
+      }
+      case 'HighIRIfElseStatement':
+        s.finalAssignments.forEach((finalAssignment) => {
+          const type = prettyPrintHighIRType(finalAssignment.type);
+          collector.push('  '.repeat(level), `let ${finalAssignment.name}: ${type};\n`);
+        });
+        collector.push(
+          '  '.repeat(level),
+          `if ${debugPrintHighIRExpression(s.booleanExpression)} {\n`
+        );
+        level += 1;
+        s.s1.forEach(printer);
+        s.finalAssignments.forEach((finalAssignment) => {
+          const v1 = debugPrintHighIRExpression(finalAssignment.branch1Value);
+          collector.push('  '.repeat(level), `${finalAssignment.name} = ${v1};\n`);
+        });
+        level -= 1;
+        collector.push('  '.repeat(level), `} else {\n`);
+        level += 1;
+        s.s2.forEach(printer);
+        s.finalAssignments.forEach((finalAssignment) => {
+          const v2 = debugPrintHighIRExpression(finalAssignment.branch2Value);
+          collector.push('  '.repeat(level), `${finalAssignment.name} = ${v2};\n`);
+        });
+        level -= 1;
+        collector.push('  '.repeat(level), `}\n`);
+        break;
+      case 'HighIRStructInitializationStatement': {
+        const expressionString = s.expressionList.map(debugPrintHighIRExpression).join(', ');
+        collector.push(
+          '  '.repeat(level),
+          `let ${s.structVariableName}: ${prettyPrintHighIRType(s.type)} = [${expressionString}];\n`
+        );
+        break;
+      }
+    }
+  };
+
+  printer(statement);
+
+  return collector.join('').trimEnd();
+};
+
+export interface HighIRFunction {
+  readonly name: string;
+  readonly parameters: readonly string[];
+  readonly type: HighIRFunctionType;
+  readonly body: readonly HighIRStatement[];
+  readonly returnValue: HighIRExpression;
+}
+
+export interface HighIRModule {
+  readonly globalVariables: readonly GlobalVariable[];
+  readonly typeDefinitions: readonly HighIRTypeDefinition[];
+  readonly functions: readonly HighIRFunction[];
+}
+
+export const debugPrintHighIRFunction = ({
+  name,
+  parameters,
+  type: { argumentTypes, returnType },
+  body: bodyStatements,
+  returnValue,
+}: HighIRFunction): string => {
+  const typedParameters = zip(parameters, argumentTypes)
+    .map(([parameter, parameterType]) => `${parameter}: ${prettyPrintHighIRType(parameterType)}`)
+    .join(', ');
+  const header = `function ${name}(${typedParameters}): ${prettyPrintHighIRType(returnType)} {`;
+  const body = [
+    ...bodyStatements.map((it) => debugPrintHighIRStatement(it, 1)),
+    `  return ${debugPrintHighIRExpression(returnValue)};`,
+  ].join('\n');
+  return `${header}\n${body}\n}\n`;
+};
+
+export const debugPrintHighIRModule = ({
+  globalVariables,
+  typeDefinitions,
+  functions,
+}: HighIRModule): string =>
+  [
+    ...globalVariables.map(({ name, content }) => `const ${name} = '${content}';\n`),
+    ...typeDefinitions.map(prettyPrintHighIRTypeDefinition),
+    ...functions.map((it) => debugPrintHighIRFunction(it)),
+  ].join('\n');

--- a/samlang-core-ast/mir-nodes.ts
+++ b/samlang-core-ast/mir-nodes.ts
@@ -189,7 +189,7 @@ export type MidIRStatement =
 
 type ConstructorArgumentObject<E extends BaseMidIRExpression | BaseMidIRStatement> = Omit<
   E,
-  '__type__' | 'precedence'
+  '__type__'
 >;
 
 export const MIR_FALSE: MidIRIntLiteralExpression = {

--- a/samlang-core-compiler/mir-expression-lowering.ts
+++ b/samlang-core-compiler/mir-expression-lowering.ts
@@ -558,15 +558,13 @@ class MidIRExpressionLoweringManager {
           functionTypeWithoutContext.returnType
         );
 
-        const s2FunctionExpression = this.lowerWithPotentialCast(
-          functionTypeWithContext,
-          MIR_VARIABLE(functionTempRaw, MIR_ANY_TYPE),
-          loweredStatements
-        );
-
         functionReturnCollectorType = functionTypeWithoutContext.returnType;
         functionCall = MIR_FUNCTION_CALL({
-          functionExpression: s2FunctionExpression,
+          functionExpression: this.lowerWithPotentialCast(
+            functionTypeWithContext,
+            MIR_VARIABLE(functionTempRaw, MIR_ANY_TYPE),
+            loweredStatements
+          ),
           functionArguments: [MIR_VARIABLE(contextTemp, MIR_ANY_TYPE), ...loweredFunctionArguments],
           returnType: functionTypeWithoutContext.returnType,
           returnCollector: isVoidReturn ? undefined : returnCollectorName,
@@ -1030,10 +1028,9 @@ class MidIRExpressionLoweringManager {
             );
             break;
           }
-          case 'VariablePattern': {
+          case 'VariablePattern':
             this.varibleContext.bind(pattern.name, loweredAssignedExpression);
             break;
-          }
           case 'WildCardPattern':
             break;
         }
@@ -1075,9 +1072,7 @@ const lowerSamlangExpression = (
     typeSynthesizer,
     stringManager
   );
-  if (expression.__type__ === 'StatementBlockExpression') {
-    manager.depth = -1;
-  }
+  if (expression.__type__ === 'StatementBlockExpression') manager.depth = -1;
   const result = manager.lower(expression);
   return { ...result, syntheticFunctions: manager.syntheticFunctions };
 };


### PR DESCRIPTION
## Summary

The new HIR follows the following design principles:
- Same as MIR, but all type information is preserved so no casts on this level. Especially, generics are not erased at this level. This allows the later MIR level to specialize all the generics on a much closer IR.
- No optimization on this level, so nodes like while, single if, break that are introduced just for tailrec optimizations are not here.

## Test Plan

`yarn test`
