### PR TITLE
[compiler][hir] Make `encodeHighIRNameAfterGenericsSpecialization` return name only when there are no type args

### DIFF
--- a/samlang-core-compiler/__tests__/hir-type-conversion.test.ts
+++ b/samlang-core-compiler/__tests__/hir-type-conversion.test.ts
@@ -186,6 +186,8 @@ describe('hir-type-conversion', () => {
       encodeHighIRNameAfterGenericsSpecialization('A', [HIR_FUNCTION_TYPE([], HIR_INT_TYPE)])
     ).toThrow();
 
+    expect(encodeHighIRNameAfterGenericsSpecialization('A', [])).toBe('A');
+
     expect(
       encodeHighIRNameAfterGenericsSpecialization('A', [
         HIR_INT_TYPE,

--- a/samlang-core-compiler/hir-type-conversion.ts
+++ b/samlang-core-compiler/hir-type-conversion.ts
@@ -175,7 +175,10 @@ const encodeHighIRTypeForGenericsSpecialization = (type: HighIRType): string => 
 export const encodeHighIRNameAfterGenericsSpecialization = (
   name: string,
   typeArguments: readonly HighIRType[]
-): string => `${name}_${typeArguments.map(encodeHighIRTypeForGenericsSpecialization).join('_')}`;
+): string =>
+  typeArguments.length === 0
+    ? name
+    : `${name}_${typeArguments.map(encodeHighIRTypeForGenericsSpecialization).join('_')}`;
 
 const lowerSamlangPrimitiveType = (type: PrimitiveType): HighIRPrimitiveType => {
   switch (type.name) {


### PR DESCRIPTION
## Summary

Title

## Test Plan

`yarn test`
