### PR TITLE
[compiler] Unflag reference counting feature

### DIFF
--- a/samlang-cli/src/cli-service.ts
+++ b/samlang-cli/src/cli-service.ts
@@ -137,8 +137,7 @@ export function compileEverything(
   outputDirectory: string
 ): boolean {
   const midIRSources = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(sources),
-    /* referenceCounting */ false
+    compileSamlangSourcesToHighIRSources(sources)
   );
   const moduleReferences = sources.entries().map(([moduleReference]) => moduleReference);
 

--- a/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
@@ -22,19 +22,20 @@ import lowerHighIRSourcesToMidIRSources from '../mir-sources-lowering';
 
 type SimplifiedSources = Omit<HighIRSources, 'globalVariables' | 'mainFunctionNames'>;
 
-const assertLowered = (sources: SimplifiedSources, referenceCounting: boolean, expected: string) =>
+const assertLowered = (sources: SimplifiedSources, expected: string) =>
   expect(
     debugPrintMidIRSources(
-      lowerHighIRSourcesToMidIRSources(
-        { ...sources, globalVariables: [], mainFunctionNames: [ENCODED_COMPILED_PROGRAM_MAIN] },
-        referenceCounting
-      )
+      lowerHighIRSourcesToMidIRSources({
+        ...sources,
+        globalVariables: [],
+        mainFunctionNames: [ENCODED_COMPILED_PROGRAM_MAIN],
+      })
     )
   ).toBe(expected);
 
 describe('mir-sources-lowering', () => {
   it('lowerHighIRSourcesToMidIRSources smoke test', () => {
-    assertLowered({ closureTypes: [], typeDefinitions: [], functions: [] }, false, '');
+    assertLowered({ closureTypes: [], typeDefinitions: [], functions: [] }, '');
   });
 
   const commonComprehensiveSources = ((): SimplifiedSources => {
@@ -156,51 +157,9 @@ describe('mir-sources-lowering', () => {
     };
   })();
 
-  it('lowerHighIRSourcesToMidIRSources comprehensive test without reference counting', () => {
+  it('lowerHighIRSourcesToMidIRSources comprehensive test.', () => {
     assertLowered(
       commonComprehensiveSources,
-      false,
-      `type CC = ((any, int) -> int, any);
-
-type Object = (int, int);
-
-type Variant = (int, any);
-
-function _compiled_program_main(): int {
-  let finalV: int;
-  if 1 {
-    main(0);
-    let _mid_t0: (any, int) -> int = (cc: CC)[0];
-    let _mid_t1: any = (cc: CC)[1];
-    (_mid_t0: (any, int) -> int)((_mid_t1: any), 0);
-    let v1: int = (a: Object)[0];
-    let v2: int = (b: Variant)[0];
-    let _mid_t2: any = (b: Variant)[1];
-    let v3: int = (_mid_t2: any);
-    let v4: string = (b: Variant)[1];
-    finalV = (v1: int);
-  } else {
-    let v1: int = 0 + 0;
-    let O: Object = [0];
-    let _mid_t3: any = 0;
-    let v1: Variant = [0, (_mid_t3: any)];
-    let v2: Variant = [0, G1];
-    let c1: CC = [aaa, G1];
-    let _mid_t4: (any) -> int = bbb;
-    let _mid_t5: any = 0;
-    let c2: CC = [(_mid_t4: (any) -> int), (_mid_t5: any)];
-    finalV = (v2: int);
-  }
-  return 0;
-}
-`
-    );
-  });
-
-  it('lowerHighIRSourcesToMidIRSources comprehensive test with reference counting', () => {
-    assertLowered(
-      commonComprehensiveSources,
-      true,
       `type CC = (int, (any, int) -> int, any);
 
 type Object = (int, int, int);

--- a/samlang-core-compiler/mir-sources-lowering.ts
+++ b/samlang-core-compiler/mir-sources-lowering.ts
@@ -65,7 +65,6 @@ function lowerHighIRExpression(expression: HighIRExpression): MidIRExpression {
 
 class HighIRToMidIRLoweringManager {
   constructor(
-    private readonly referenceCounting: boolean,
     private readonly closureTypeDefinitions: Readonly<Record<string, MidIRFunctionType>>,
     private readonly typeDefinitions: Readonly<Record<string, HighIRTypeDefinition>>
   ) {}
@@ -117,7 +116,7 @@ class HighIRToMidIRLoweringManager {
           this.typeDefinitions[pointerType.name],
           `Missing ${pointerType.name}`
         );
-        const physicalIndex = this.referenceCounting ? index + 1 : index;
+        const physicalIndex = index + 1;
         if (typeDefinition.type === 'object') {
           return [
             MIR_INDEX_ACCESS({ name, type: variableType, pointerExpression, index: physicalIndex }),
@@ -193,13 +192,13 @@ class HighIRToMidIRLoweringManager {
               name: tempFunction,
               type: functionType,
               pointerExpression,
-              index: this.referenceCounting ? 1 : 0,
+              index: 1,
             }),
             MIR_INDEX_ACCESS({
               name: tempContext,
               type: MIR_ANY_TYPE,
               pointerExpression,
-              index: this.referenceCounting ? 2 : 1,
+              index: 2,
             }),
             // TODO(ref-counting): increase reference counting for function parameters
             MIR_FUNCTION_CALL({
@@ -249,10 +248,8 @@ class HighIRToMidIRLoweringManager {
                 );
                 return MIR_VARIABLE(temp, MIR_ANY_TYPE);
               });
-        if (this.referenceCounting) {
-          // TODO(ref-counting): increasing ref count for other expressions
-          expressionList.unshift(MIR_ONE);
-        }
+        // TODO(ref-counting): increasing ref count for other expressions
+        expressionList.unshift(MIR_ONE);
         statements.push(MIR_STRUCT_INITIALIZATION({ structVariableName, type, expressionList }));
         return statements;
       }
@@ -290,14 +287,12 @@ class HighIRToMidIRLoweringManager {
           MIR_STRUCT_INITIALIZATION({
             structVariableName: statement.closureVariableName,
             type: closureType,
-            expressionList: this.referenceCounting
-              ? [
-                  MIR_ONE,
-                  // TODO(ref-counting): add destructor for context
-                  functionNameSlot,
-                  contextSlot,
-                ]
-              : [functionNameSlot, contextSlot],
+            expressionList: [
+              MIR_ONE,
+              // TODO(ref-counting): add destructor for context
+              functionNameSlot,
+              contextSlot,
+            ],
           })
         );
         return statements;
@@ -306,10 +301,7 @@ class HighIRToMidIRLoweringManager {
   };
 }
 
-export default function lowerHighIRSourcesToMidIRSources(
-  sources: HighIRSources,
-  referenceCounting: boolean
-): MidIRSources {
+export default function lowerHighIRSourcesToMidIRSources(sources: HighIRSources): MidIRSources {
   const typeDefinitions: MidIRTypeDefinition[] = [];
   const closureTypeDefinitionMapForLowering = Object.fromEntries(
     sources.closureTypes.map((it) => {
@@ -322,25 +314,22 @@ export default function lowerHighIRSourcesToMidIRSources(
       );
       typeDefinitions.push({
         identifier: it.identifier,
-        mappings: referenceCounting
-          ? [MIR_INT_TYPE, functionType, MIR_ANY_TYPE]
-          : [functionType, MIR_ANY_TYPE],
+        mappings: [MIR_INT_TYPE, functionType, MIR_ANY_TYPE],
       });
       return [it.identifier, functionType];
     })
   );
   const typeDefinitionMapForLowering = Object.fromEntries(
     sources.typeDefinitions.map((it) => {
-      let mappings =
+      const mappings =
         it.type === 'object' ? it.mappings.map(lowerHighIRType) : [MIR_INT_TYPE, MIR_ANY_TYPE];
-      mappings = referenceCounting ? [MIR_INT_TYPE, ...mappings] : mappings;
+      mappings.unshift(MIR_INT_TYPE);
       typeDefinitions.push({ identifier: it.identifier, mappings });
       return [it.identifier, it];
     })
   );
   const functions = sources.functions.map((highIRFunction) =>
     new HighIRToMidIRLoweringManager(
-      referenceCounting,
       closureTypeDefinitionMapForLowering,
       typeDefinitionMapForLowering
     ).lowerHighIRFunction(highIRFunction)

--- a/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
+++ b/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
@@ -47,8 +47,7 @@ describe('compiler-integration-tests', () => {
   }
 
   const midIRUnoptimizedSingleSource = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(checkedSources),
-    /* referenceCounting */ false
+    compileSamlangSourcesToHighIRSources(checkedSources)
   );
 
   function testMIRSources(midSources: MidIRSources): void {

--- a/samlang-demo/src/index.ts
+++ b/samlang-demo/src/index.ts
@@ -39,8 +39,7 @@ export default function runSamlangDemo(programString: string): SamlangDemoResult
 
   const demoSamlangModule = checkedSources.forceGet(demoModuleReference);
   const midIRSources = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(checkedSources),
-    /* referenceCounting */ false
+    compileSamlangSourcesToHighIRSources(checkedSources)
   );
   const llvmSources = lowerMidIRSourcesToLLVMSources(midIRSources);
 


### PR DESCRIPTION
## Summary

It should be made compatible with JS emit, although with slightly slower performance. (But since we are emitting in JS, performance is not a big issue anyways...)

## Test Plan

`yarn test`
