### PR TITLE
[compiler] Unflag reference counting feature (again)

### DIFF
--- a/configurations/tsconfig.base.json
+++ b/configurations/tsconfig.base.json
@@ -6,7 +6,7 @@
     "forceConsistentCasingInFileNames": true,
     "importsNotUsedAsValues": "error",
     "isolatedModules": false,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["esnext"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noUncheckedIndexedAccess": true,

--- a/samlang-cli/package.json
+++ b/samlang-cli/package.json
@@ -7,7 +7,7 @@
     "samlang-runtime"
   ],
   "scripts": {
-    "compile": "tsc --incremental",
+    "compile": "tsc --incremental --noEmit",
     "bundle": "node build.js"
   },
   "bin": {

--- a/samlang-cli/src/cli-service.ts
+++ b/samlang-cli/src/cli-service.ts
@@ -137,8 +137,7 @@ export function compileEverything(
   outputDirectory: string
 ): boolean {
   const midIRSources = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(sources),
-    /* referenceCounting */ true
+    compileSamlangSourcesToHighIRSources(sources)
   );
   const moduleReferences = sources.entries().map(([moduleReference]) => moduleReference);
 

--- a/samlang-cli/tsconfig.json
+++ b/samlang-cli/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../configurations/tsconfig.base.json",
-  "compilerOptions": {
-    "noEmit": true
-  },
   "include": ["src"]
 }

--- a/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
@@ -22,19 +22,20 @@ import lowerHighIRSourcesToMidIRSources from '../mir-sources-lowering';
 
 type SimplifiedSources = Omit<HighIRSources, 'globalVariables' | 'mainFunctionNames'>;
 
-const assertLowered = (sources: SimplifiedSources, referenceCounting: boolean, expected: string) =>
+const assertLowered = (sources: SimplifiedSources, expected: string) =>
   expect(
     debugPrintMidIRSources(
-      lowerHighIRSourcesToMidIRSources(
-        { ...sources, globalVariables: [], mainFunctionNames: [ENCODED_COMPILED_PROGRAM_MAIN] },
-        referenceCounting
-      )
+      lowerHighIRSourcesToMidIRSources({
+        ...sources,
+        globalVariables: [],
+        mainFunctionNames: [ENCODED_COMPILED_PROGRAM_MAIN],
+      })
     )
   ).toBe(expected);
 
 describe('mir-sources-lowering', () => {
   it('lowerHighIRSourcesToMidIRSources smoke test', () => {
-    assertLowered({ closureTypes: [], typeDefinitions: [], functions: [] }, false, '');
+    assertLowered({ closureTypes: [], typeDefinitions: [], functions: [] }, '');
   });
 
   const commonComprehensiveSources = ((): SimplifiedSources => {
@@ -156,51 +157,9 @@ describe('mir-sources-lowering', () => {
     };
   })();
 
-  it('lowerHighIRSourcesToMidIRSources comprehensive test without reference counting', () => {
-    assertLowered(
-      commonComprehensiveSources,
-      false,
-      `type CC = ((any, int) -> int, any);
-
-type Object = (int, int);
-
-type Variant = (int, any);
-
-function _compiled_program_main(): int {
-  let finalV: int;
-  if 1 {
-    main(0);
-    let _mid_t0: (any, int) -> int = (cc: CC)[0];
-    let _mid_t1: any = (cc: CC)[1];
-    (_mid_t0: (any, int) -> int)((_mid_t1: any), 0);
-    let v1: int = (a: Object)[0];
-    let v2: int = (b: Variant)[0];
-    let _mid_t2: any = (b: Variant)[1];
-    let v3: int = (_mid_t2: any);
-    let v4: string = (b: Variant)[1];
-    finalV = (v1: int);
-  } else {
-    let v1: int = 0 + 0;
-    let O: Object = [0];
-    let _mid_t3: any = 0;
-    let v1: Variant = [0, (_mid_t3: any)];
-    let v2: Variant = [0, G1];
-    let c1: CC = [aaa, G1];
-    let _mid_t4: (any) -> int = bbb;
-    let _mid_t5: any = 0;
-    let c2: CC = [(_mid_t4: (any) -> int), (_mid_t5: any)];
-    finalV = (v2: int);
-  }
-  return 0;
-}
-`
-    );
-  });
-
   it('lowerHighIRSourcesToMidIRSources comprehensive test with reference counting', () => {
     assertLowered(
       commonComprehensiveSources,
-      true,
       `type CC = (int, (any, int) -> int, any);
 
 type Object = (int, int, int);

--- a/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
+++ b/samlang-core-integration-tests/__tests__/compiler-integration-test.test.ts
@@ -47,8 +47,7 @@ describe('compiler-integration-tests', () => {
   }
 
   const midIRUnoptimizedSingleSource = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(checkedSources),
-    /* referenceCounting */ false
+    compileSamlangSourcesToHighIRSources(checkedSources)
   );
 
   function testMIRSources(midSources: MidIRSources): void {

--- a/samlang-demo/src/index.ts
+++ b/samlang-demo/src/index.ts
@@ -39,8 +39,7 @@ export default function runSamlangDemo(programString: string): SamlangDemoResult
 
   const demoSamlangModule = checkedSources.forceGet(demoModuleReference);
   const midIRSources = lowerHighIRSourcesToMidIRSources(
-    compileSamlangSourcesToHighIRSources(checkedSources),
-    /* referenceCounting */ false
+    compileSamlangSourcesToHighIRSources(checkedSources)
   );
   const llvmSources = lowerMidIRSourcesToLLVMSources(midIRSources);
 

--- a/samlang-demo/tsconfig.json
+++ b/samlang-demo/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../configurations/tsconfig.base.json",
   "compilerOptions": {
-    "noEmit": false,
     "emitDeclarationOnly": true,
     "outDir": "bin"
   },


### PR DESCRIPTION
## Summary

After fixing the weird segfault issue due to 32-bit pointer usage, it's OK to land this again.

## Test Plan

```
yarn test
yarn test:integration
```