### PR TITLE
[ast][compiler] Introduce `MidIRIndexAssignStatement` to replace special-case GC instructions

### DIFF
--- a/samlang-core-ast/__tests__/mir-nodes.test.ts
+++ b/samlang-core-ast/__tests__/mir-nodes.test.ts
@@ -16,8 +16,6 @@ import {
   MIR_NAME,
   MIR_VARIABLE,
   MIR_BINARY,
-  MIR_INC_REF,
-  MIR_DEC_REF,
   MIR_INT_TYPE,
   MIR_BOOL_TYPE,
   MIR_ANY_TYPE,
@@ -53,8 +51,6 @@ describe('mir-nodes', () => {
               MIR_IF_ELSE({
                 booleanExpression: MIR_ZERO,
                 s1: [
-                  MIR_INC_REF(MIR_ZERO),
-                  MIR_DEC_REF(MIR_ZERO),
                   MIR_CAST({
                     name: 'foo',
                     type: MIR_IDENTIFIER_TYPE('Bar'),
@@ -166,8 +162,6 @@ describe('mir-nodes', () => {
 function Bar(f) {
   let bar;
   if (0) {
-    0[0] += 1;
-    0[0] -= 1;
     let foo = /** @type {Bar} */ (dev);
     let n = _tail_rec_param_n;
     let acc = _tail_rec_param_acc;
@@ -286,8 +280,6 @@ function Bar(f) {
               MIR_IF_ELSE({
                 booleanExpression: MIR_ZERO,
                 s1: [
-                  MIR_INC_REF(MIR_ZERO),
-                  MIR_DEC_REF(MIR_ZERO),
                   MIR_CAST({
                     name: 'foo',
                     type: MIR_IDENTIFIER_TYPE('Bar'),
@@ -395,8 +387,6 @@ type Foo = [number, any];
 function Bar(f: number): number {
   let bar: number;
   if (0) {
-    0[0] += 1;
-    0[0] -= 1;
     let foo = dev as Bar;
     let n: number = _tail_rec_param_n;
     let acc: number = _tail_rec_param_acc;

--- a/samlang-core-compiler/__tests__/llvm-sources-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/llvm-sources-lowering.test.ts
@@ -2,6 +2,11 @@ import { prettyPrintLLVMFunction, prettyPrintLLVMSources } from 'samlang-core-as
 import {
   MidIRExpression,
   MidIRStatement,
+  MIR_INT_TYPE as INT,
+  MIR_BOOL_TYPE,
+  MIR_FUNCTION_TYPE,
+  MIR_IDENTIFIER_TYPE,
+  MIR_STRING_TYPE,
   MIR_FALSE,
   MIR_TRUE,
   MIR_NAME,
@@ -14,16 +19,10 @@ import {
   MIR_BREAK,
   MIR_WHILE,
   MIR_INDEX_ACCESS,
+  MIR_INDEX_ASSIGN,
   MIR_INT,
   MIR_CAST,
   MIR_STRUCT_INITIALIZATION,
-  MIR_INC_REF,
-  MIR_DEC_REF,
-  MIR_INT_TYPE as INT,
-  MIR_FUNCTION_TYPE,
-  MIR_IDENTIFIER_TYPE,
-  MIR_STRING_TYPE,
-  MIR_BOOL_TYPE,
 } from 'samlang-core-ast/mir-nodes';
 import type { MidIRFunction } from 'samlang-core-ast/mir-nodes';
 
@@ -121,9 +120,16 @@ l0_start:
           pointerExpression: MIR_VARIABLE('bar', MIR_IDENTIFIER_TYPE('Bar')),
           index: 3,
         }),
+        MIR_INDEX_ASSIGN({
+          assignedExpression: MIR_VARIABLE('foo', INT),
+          pointerExpression: MIR_VARIABLE('bar', MIR_IDENTIFIER_TYPE('Bar')),
+          index: 3,
+        }),
       ],
       `  %_temp_0_index_pointer_temp = getelementptr %Bar, %Bar* %bar, i32 0, i32 3
-  %foo = load i64, i64* %_temp_0_index_pointer_temp`
+  %foo = load i64, i64* %_temp_0_index_pointer_temp
+  %_temp_1_index_pointer_temp = getelementptr %Bar, %Bar* %bar, i32 0, i32 3
+  store i64 %foo, i64* %_temp_1_index_pointer_temp`
     );
   });
 
@@ -618,26 +624,6 @@ l2_loop_end:
     assertStatementLoweringWorks(
       [MIR_CAST({ name: 's', type: MIR_STRING_TYPE, assignedExpression: MIR_ZERO })],
       '  %s = inttoptr i64 0 to i64*'
-    );
-  });
-
-  it('LLVM lowering works for MIR_INC_REF', () => {
-    assertStatementLoweringWorks(
-      [MIR_INC_REF(MIR_VARIABLE('obj', MIR_IDENTIFIER_TYPE('Obj')))],
-      `  %_temp_0_ref_count_slot_ptr = getelementptr %Obj, %Obj* %obj, i32 0, i32 0
-  %_temp_1_ref_count_old = load i64, i64* %_temp_0_ref_count_slot_ptr
-  %_temp_2_ref_count_new = add i64 %_temp_1_ref_count_old, 1
-  store i64 %_temp_2_ref_count_new, i64* %_temp_0_ref_count_slot_ptr`
-    );
-  });
-
-  it('LLVM lowering works for MIR_DEC_REF', () => {
-    assertStatementLoweringWorks(
-      [MIR_DEC_REF(MIR_VARIABLE('obj', MIR_IDENTIFIER_TYPE('Obj')))],
-      `  %_temp_0_ref_count_slot_ptr = getelementptr %Obj, %Obj* %obj, i32 0, i32 0
-  %_temp_1_ref_count_old = load i64, i64* %_temp_0_ref_count_slot_ptr
-  %_temp_2_ref_count_new = sub i64 %_temp_1_ref_count_old, 1
-  store i64 %_temp_2_ref_count_new, i64* %_temp_0_ref_count_slot_ptr`
     );
   });
 

--- a/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
+++ b/samlang-core-compiler/__tests__/mir-sources-lowering.test.ts
@@ -272,26 +272,30 @@ function cc(): number {
 }
 function main(): number {
   let v1: number = 0 + 0;
-  obj[0] += 1;
+  let _mid_t0: number = obj[0];
+  let _mid_t1: number = _mid_t0 + 1;
+  obj[0] = _mid_t1;
   let O: Object = [1, 0, obj];
-  let _mid_t0 = 0 as any;
-  let v1: Variant = [1, 0, _mid_t0];
-  let _mid_t1: number = G1[0];
-  let _mid_t2: boolean = _mid_t1 > 0;
-  if (_mid_t2) {
-    G1[0] += 1;
+  let _mid_t2 = 0 as any;
+  let v1: Variant = [1, 0, _mid_t2];
+  let _mid_t3: number = G1[0];
+  let _mid_t5: boolean = _mid_t3 > 0;
+  if (_mid_t5) {
+    let _mid_t4: number = _mid_t3 + 1;
+    G1[0] = _mid_t4;
   }
   let v2: Variant = [1, 0, G1];
-  let _mid_t3: number = G1[0];
-  let _mid_t4: boolean = _mid_t3 > 0;
-  if (_mid_t4) {
-    G1[0] += 1;
+  let _mid_t6: number = G1[0];
+  let _mid_t8: boolean = _mid_t6 > 0;
+  if (_mid_t8) {
+    let _mid_t7: number = _mid_t6 + 1;
+    G1[0] = _mid_t7;
   }
-  let _mid_t5 = __decRef_string as (t0: any) => number;
-  let c1: CC = [1, _mid_t5, aaa, G1];
-  let _mid_t6 = bbb as (t0: any) => number;
-  let _mid_t7 = 0 as any;
-  let c2: CC = [1, __decRef_nothing, _mid_t6, _mid_t7];
+  let _mid_t9 = __decRef_string as (t0: any) => number;
+  let c1: CC = [1, _mid_t9, aaa, G1];
+  let _mid_t10 = bbb as (t0: any) => number;
+  let _mid_t11 = 0 as any;
+  let c2: CC = [1, __decRef_nothing, _mid_t10, _mid_t11];
   __decRef_Object(O);
   __decRef_Variant(v1);
   __decRef_Variant(v2);
@@ -309,10 +313,12 @@ function _compiled_program_main(): number {
     let _mid_t2: (t0: any, t1: number) => number = cc[2];
     let _mid_t3: any = cc[3];
     let _mid_t4: CC = _mid_t2(_mid_t3, 0);
-    G1[0] += 1;
-    let _mid_t5 = G1 as any;
-    let _mid_t6 = __decRef_CC as (t0: any) => number;
-    let c3: CC = [1, _mid_t6, aaa, _mid_t5];
+    let _mid_t5: number = G1[0];
+    let _mid_t6: number = _mid_t5 + 1;
+    G1[0] = _mid_t6;
+    let _mid_t7 = G1 as any;
+    let _mid_t8 = __decRef_CC as (t0: any) => number;
+    let c3: CC = [1, _mid_t8, aaa, _mid_t7];
     __decRef_CC(_mid_t4);
     __decRef_CC(c3);
     finalV = v2;
@@ -321,7 +327,8 @@ function _compiled_program_main(): number {
 }
 function __decRef_Object(o: Object): number {
   let currentRefCount: number = o[0];
-  o[0] -= 1;
+  let decrementedRefCount: number = currentRefCount + -1;
+  o[0] = decrementedRefCount;
   let dead: boolean = currentRefCount <= 1;
   if (dead) {
     let pointer_casted = o as any;
@@ -331,7 +338,8 @@ function __decRef_Object(o: Object): number {
 }
 function __decRef_Variant(o: Variant): number {
   let currentRefCount: number = o[0];
-  o[0] -= 1;
+  let decrementedRefCount: number = currentRefCount + -1;
+  o[0] = decrementedRefCount;
   let dead: boolean = currentRefCount <= 1;
   if (dead) {
     let pointer_casted = o as any;
@@ -341,7 +349,8 @@ function __decRef_Variant(o: Variant): number {
 }
 function __decRef_CC(o: CC): number {
   let currentRefCount: number = o[0];
-  o[0] -= 1;
+  let decrementedRefCount: number = currentRefCount + -1;
+  o[0] = decrementedRefCount;
   let dead: boolean = currentRefCount <= 1;
   if (dead) {
     let destructor: (t0: any) => number = o[1];
@@ -356,7 +365,8 @@ function __decRef_string(o: Str): number {
   let currentRefCount: number = o[0];
   let performGC: boolean = currentRefCount > 0;
   if (performGC) {
-    o[0] -= 1;
+    let decrementedRefCount: number = currentRefCount + -1;
+    o[0] = decrementedRefCount;
     let dead: boolean = currentRefCount <= 1;
     if (dead) {
       _builtin_free(o);


### PR DESCRIPTION
## Summary

Close #698, and after several months, close #513. Reference counting based garbage collector is fully functional now!

## Test Plan

```
yarn test
yarn test:integration
```
