### PR TITLE
[misc] Final cleanup more launch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "samlang.programPath": "samlang-cli/bin/index.js",
+  "samlang.programPath": "samlang-cli/bin/lsp.js",
   "eslint.nodePath": ".yarn/sdks",
   "files.associations": { "*.m": "matlab", "*.ml": "ocaml", "*.mli": "ocaml", "*.h": "c" },
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",

--- a/samlang-cli/build.js
+++ b/samlang-cli/build.js
@@ -6,10 +6,26 @@ build({
   bundle: true,
   sourcemap: false,
   platform: 'node',
-  target: 'es2017',
+  target: 'es2019',
   logLevel: 'error',
   outfile: 'bin/index.js',
-  external: ['@dev-sam/samlang-core', 'binaryen', 'vscode-languageserver/node'],
+  external: ['@dev-sam/samlang-core', 'binaryen'],
+  plugins: [pnpPlugin()],
+}).catch((err) => {
+  // eslint-disable-next-line no-console
+  console.log(err);
+  process.exit(1);
+});
+
+build({
+  entryPoints: ['src/lsp.ts'],
+  bundle: true,
+  minify: true,
+  sourcemap: false,
+  platform: 'node',
+  target: 'es2019',
+  logLevel: 'error',
+  outfile: 'bin/lsp.js',
   plugins: [pnpPlugin()],
 }).catch((err) => {
   // eslint-disable-next-line no-console

--- a/samlang-cli/loader.d.ts
+++ b/samlang-cli/loader.d.ts
@@ -1,0 +1,3 @@
+// eslint-disable-next-line import/no-internal-modules
+import samlangGeneratedWebAssemblyLoader from '@dev-sam/samlang-core/loader';
+export default samlangGeneratedWebAssemblyLoader;

--- a/samlang-cli/package.json
+++ b/samlang-cli/package.json
@@ -4,7 +4,8 @@
   "license": "AGPLv3",
   "files": [
     "bin",
-    "loader.js"
+    "loader.js",
+    "loader.d.ts"
   ],
   "scripts": {
     "compile": "tsc --incremental --noEmit",

--- a/samlang-cli/src/__tests__/cli.test.ts
+++ b/samlang-cli/src/__tests__/cli.test.ts
@@ -4,7 +4,6 @@ function assertCalled(commandLineArguments: readonly string[], called: keyof CLI
   const runner: CLIRunners = {
     format: jest.fn(),
     compile: jest.fn(),
-    lsp: jest.fn(),
     version: jest.fn(),
     help: jest.fn(),
   };
@@ -21,12 +20,9 @@ describe('samlang-cli/cli', () => {
     expect(parseCLIArguments([])).toEqual({ type: 'compile', needHelp: false });
     expect(parseCLIArguments(['format'])).toEqual({ type: 'format', needHelp: false });
     expect(parseCLIArguments(['compile'])).toEqual({ type: 'compile', needHelp: false });
-    expect(parseCLIArguments(['lsp'])).toEqual({ type: 'lsp', needHelp: false });
     expect(parseCLIArguments(['format', '--help'])).toEqual({ type: 'format', needHelp: true });
     expect(parseCLIArguments(['compile', '--help'])).toEqual({ type: 'compile', needHelp: true });
-    expect(parseCLIArguments(['lsp', '--help'])).toEqual({ type: 'lsp', needHelp: true });
     expect(parseCLIArguments(['compile', '-h'])).toEqual({ type: 'compile', needHelp: true });
-    expect(parseCLIArguments(['lsp', '-h'])).toEqual({ type: 'lsp', needHelp: true });
     expect(parseCLIArguments(['version'])).toEqual({ type: 'version' });
     expect(parseCLIArguments(['dfasfsdf'])).toEqual({ type: 'help' });
     expect(parseCLIArguments(['help'])).toEqual({ type: 'help' });
@@ -36,12 +32,9 @@ describe('samlang-cli/cli', () => {
     assertCalled([], 'compile');
     assertCalled(['format'], 'format');
     assertCalled(['compile'], 'compile');
-    assertCalled(['lsp'], 'lsp');
     assertCalled(['format', '--help'], 'format');
     assertCalled(['compile', '--help'], 'compile');
-    assertCalled(['lsp', '--help'], 'lsp');
     assertCalled(['compile', '-h'], 'compile');
-    assertCalled(['lsp', '-h'], 'lsp');
     assertCalled(['version'], 'version');
     assertCalled(['dfasfsdf'], 'help');
     assertCalled(['help'], 'help');

--- a/samlang-cli/src/cli.ts
+++ b/samlang-cli/src/cli.ts
@@ -12,11 +12,10 @@ export function parseCLIArguments(commandLineArguments: readonly string[]): Pars
     return { type: 'compile', needHelp: false };
   }
 
-  let type: 'format' | 'compile' | 'lsp';
+  let type: 'format' | 'compile';
   switch (commandLineArguments[0]) {
     case 'format':
     case 'compile':
-    case 'lsp':
       type = commandLineArguments[0];
       break;
     case 'version':
@@ -31,7 +30,6 @@ export function parseCLIArguments(commandLineArguments: readonly string[]): Pars
 export interface CLIRunners {
   format(needHelp: boolean): void;
   compile(needHelp: boolean): void;
-  lsp(needHelp: boolean): void;
   version(): void;
   help(): void;
 }
@@ -47,9 +45,6 @@ export default function cliMainRunner(
       return;
     case 'compile':
       runners.compile(action.needHelp);
-      return;
-    case 'lsp':
-      runners.lsp(action.needHelp);
       return;
     case 'version':
       runners.version();

--- a/samlang-cli/src/utils.ts
+++ b/samlang-cli/src/utils.ts
@@ -1,0 +1,61 @@
+import { lstatSync, readdirSync, readFileSync } from 'fs';
+import { join, normalize, relative, resolve, sep } from 'path';
+
+import type { ModuleReference } from '@dev-sam/samlang-core';
+
+import loadSamlangProjectConfiguration, { SamlangProjectConfiguration } from './configuration';
+
+export function getConfiguration(): SamlangProjectConfiguration {
+  const configuration = loadSamlangProjectConfiguration();
+  if (
+    configuration === 'NO_CONFIGURATION' ||
+    configuration === 'UNPARSABLE_CONFIGURATION_FILE' ||
+    configuration === 'UNREADABLE_CONFIGURATION_FILE'
+  ) {
+    // eslint-disable-next-line no-console
+    console.error(configuration);
+    process.exit(2);
+  }
+  return configuration;
+}
+
+export function collectSources(
+  { sourceDirectory }: SamlangProjectConfiguration,
+  moduleReferenceCreator: (parts: readonly string[]) => ModuleReference
+): readonly (readonly [ModuleReference, string])[] {
+  const sourcePath = resolve(sourceDirectory);
+  const sources: (readonly [ModuleReference, string])[] = [];
+
+  function filePathToModuleReference(
+    absoluteSourcePath: string,
+    filePath: string
+  ): ModuleReference {
+    const relativeFile = normalize(relative(absoluteSourcePath, filePath));
+    const relativeFileWithoutExtension = relativeFile.substring(0, relativeFile.length - 4);
+    return moduleReferenceCreator(relativeFileWithoutExtension.split(sep));
+  }
+
+  function walk(startPath: string, visitor: (file: string) => void): void {
+    function recursiveVisit(path: string): void {
+      if (lstatSync(path).isFile()) {
+        visitor(path);
+        return;
+      }
+
+      if (lstatSync(path).isDirectory()) {
+        readdirSync(path).some((relativeChildPath) =>
+          recursiveVisit(join(path, relativeChildPath))
+        );
+      }
+    }
+
+    return recursiveVisit(startPath);
+  }
+
+  walk(sourcePath, (file) => {
+    if (!file.endsWith('.sam')) return;
+    sources.push([filePathToModuleReference(sourcePath, file), readFileSync(file).toString()]);
+  });
+
+  return sources;
+}

--- a/samlang-core/__tests__/compiler-integration-test.test.ts
+++ b/samlang-core/__tests__/compiler-integration-test.test.ts
@@ -79,6 +79,7 @@ result['${testCaseName}'] = printed;
         },
       })
     );
+    wasmModule.dispose();
 
     const actualResult = Object.fromEntries(
       runnableSamlangProgramTestCases.map(({ testCaseName }) => {

--- a/samlang-core/__tests__/main.test.ts
+++ b/samlang-core/__tests__/main.test.ts
@@ -55,5 +55,6 @@ function _Demo_Main_main(): number {
 
 _Demo_Main_main();
 `);
+    expect(result.interpreterResult).toBe('hello world\n');
   });
 });

--- a/samlang-core/build.js
+++ b/samlang-core/build.js
@@ -6,7 +6,7 @@ build({
   bundle: true,
   sourcemap: false,
   platform: 'node',
-  target: 'es2017',
+  target: 'es2019',
   logLevel: 'error',
   outfile: 'dist/index.js',
   loader: { '.wat': 'text' },

--- a/samlang-core/dist/index.d.ts
+++ b/samlang-core/dist/index.d.ts
@@ -21,7 +21,7 @@ export function compileSamlangSources(
 ): SamlangSourcesCompilationResult;
 
 export type SamlangSingleSourceCompilationResult =
-  | { readonly __type__: 'OK'; readonly emittedTSCode: string; readonly emittedWasmText: string }
+  | { readonly __type__: 'OK'; readonly emittedTSCode: string; readonly interpreterResult: string }
   | { readonly __type__: 'ERROR'; readonly errors: readonly string[] };
 
 export function compileSingleSamlangSource(

--- a/samlang-core/loader.js
+++ b/samlang-core/loader.js
@@ -1,8 +1,11 @@
-module.exports = function samlangGeneratedWebAssemblyLoader(bytes, builtinsPatch = () => ({})) {
+module.exports = function samlangGeneratedWebAssemblyLoader(
+  /** @type {ArrayBufferView | ArrayBuffer} */ bytes,
+  builtinsPatch = () => ({})
+) {
   const memory = new WebAssembly.Memory({ initial: 2, maximum: 65536 });
   const codeModule = new WebAssembly.Module(bytes);
 
-  function pointerToString(p) {
+  function pointerToString(/** @type {number} */ p) {
     const mem = new Uint32Array(memory.buffer);
     const start = p / 4;
     const length = mem[start + 1];

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-samlang",
   "displayName": "vscode-samlang",
   "description": "SAMLANG for VSCode",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "publisher": "dev-sam",
   "repository": {
     "url": "https://github.com/SamChou19815/samlang"

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -64,13 +64,13 @@ export function activate(): void {
   const serverOptions = {
     run: {
       module: serverModule,
-      args: ['lsp'],
+      args: [],
       transport: TransportKind.ipc,
     },
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
-      args: ['lsp'],
+      args: [],
       options: { execArgv: ['--nolazy', '--inspect=6009'] },
     },
   };


### PR DESCRIPTION
## Summary

### [core] Tweak demo API to return more useful info

Emitted WASM code tend to be horribly long since it includes the standard library. It's more useful to include the interpreter result from webassembly binary code directly.

### [cli] Fix LSP build to make the lsp launcher self contained

## Test Plan

```
yarn test
yarn test:integration
```
