### PR TITLE
[checker] Add constructors as normal functions to the environment

### DIFF
--- a/samlang-core/__tests__/checker-integration-test.test.ts
+++ b/samlang-core/__tests__/checker-integration-test.test.ts
@@ -4,9 +4,9 @@ import { samlangProgramCheckerTestSources } from '../test-programs';
 
 const expectedErrors: readonly string[] = [
   'access-private-member.sam:12:13-12:16: [UnresolvedName]: Name `A.b` is not resolved.',
-  'add-panic-to-class.sam:7:50-7:56: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
-  'add-panic-to-class.sam:8:27-8:33: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
-  'add-with-class.sam:7:30-7:36: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
+  'add-panic-to-class.sam:7:50-7:58: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
+  'add-panic-to-class.sam:8:27-8:35: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
+  'add-with-class.sam:7:30-7:38: [UnexpectedType]: Expected: `() -> int`, actual: `() -> A`.',
   'complete-trash.sam:1:1-1:5: [SyntaxError]: Unexpected token among the classes.',
   'complete-trash.sam:1:11-1:14: [SyntaxError]: Unexpected token among the classes.',
   'complete-trash.sam:1:15-1:21: [SyntaxError]: Unexpected token among the classes.',

--- a/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
+++ b/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
@@ -1,4 +1,10 @@
-import { functionType, intType, ModuleReference, Range } from '../../ast/common-nodes';
+import {
+  functionType,
+  identifierType,
+  intType,
+  ModuleReference,
+  Range,
+} from '../../ast/common-nodes';
 import type { SamlangModule, SourceClassDefinition } from '../../ast/samlang-nodes';
 import { SourceExpressionFalse } from '../../ast/samlang-nodes';
 import { mapOf } from '../../utils';
@@ -94,7 +100,18 @@ describe('global-typing-context-builder', () => {
     expect(actualGlobalTypingContext.size).toBe(3);
 
     expect(actualGlobalTypingContext.get(module0Reference)).toStrictEqual({
-      Class0: { typeParameters: [], typeDefinition, functions: {}, methods: {} },
+      Class0: {
+        typeParameters: [],
+        typeDefinition,
+        functions: {
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module0Reference, 'Class0', [])),
+            typeParameters: [],
+          },
+        },
+        methods: {},
+      },
     });
     expect(actualGlobalTypingContext.get(module1Reference)).toStrictEqual({
       Class1: {
@@ -102,6 +119,11 @@ describe('global-typing-context-builder', () => {
         typeDefinition,
         functions: {
           f1: { isPublic: false, type: functionType([], intType), typeParameters: [] },
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class1', [])),
+            typeParameters: [],
+          },
         },
         methods: {
           m1: { isPublic: true, type: functionType([], intType), typeParameters: [] },
@@ -110,7 +132,13 @@ describe('global-typing-context-builder', () => {
       Class2: {
         typeParameters: [],
         typeDefinition,
-        functions: {},
+        functions: {
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class2', [])),
+            typeParameters: [],
+          },
+        },
         methods: {},
       },
     });
@@ -130,7 +158,18 @@ describe('global-typing-context-builder', () => {
     expect(actualGlobalTypingContext.size).toBe(3);
 
     expect(actualGlobalTypingContext.get(module0Reference)).toStrictEqual({
-      Class0: { typeParameters: [], typeDefinition, functions: {}, methods: {} },
+      Class0: {
+        typeParameters: [],
+        typeDefinition,
+        functions: {
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module0Reference, 'Class0', [])),
+            typeParameters: [],
+          },
+        },
+        methods: {},
+      },
     });
     expect(actualGlobalTypingContext.get(module1Reference)).toStrictEqual({
       Class1: {
@@ -138,12 +177,28 @@ describe('global-typing-context-builder', () => {
         typeDefinition,
         functions: {
           f1: { isPublic: false, type: functionType([], intType), typeParameters: [] },
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class1', [])),
+            typeParameters: [],
+          },
         },
         methods: {
           m1: { isPublic: true, type: functionType([], intType), typeParameters: [] },
         },
       },
-      Class2: { typeParameters: [], typeDefinition, functions: {}, methods: {} },
+      Class2: {
+        typeParameters: [],
+        typeDefinition,
+        functions: {
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class2', [])),
+            typeParameters: [],
+          },
+        },
+        methods: {},
+      },
     });
   });
 
@@ -164,6 +219,11 @@ describe('global-typing-context-builder', () => {
         typeDefinition,
         functions: {
           f1: { isPublic: false, type: functionType([], intType), typeParameters: [] },
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class1', [])),
+            typeParameters: [],
+          },
         },
         methods: {
           m1: { isPublic: true, type: functionType([], intType), typeParameters: [] },
@@ -172,7 +232,13 @@ describe('global-typing-context-builder', () => {
       Class2: {
         typeParameters: [],
         typeDefinition,
-        functions: {},
+        functions: {
+          init: {
+            isPublic: true,
+            type: functionType([], identifierType(module1Reference, 'Class2', [])),
+            typeParameters: [],
+          },
+        },
         methods: {},
       },
     });

--- a/samlang-core/checker/module-type-checker.ts
+++ b/samlang-core/checker/module-type-checker.ts
@@ -154,6 +154,7 @@ export default class ModuleTypeChecker {
     nameWithRange: readonly (readonly [string, Range])[]
   ): void {
     const nameSet = new Set<string>();
+    nameSet.add('init');
     nameWithRange.forEach(([name, range]) => {
       if (nameSet.has(name)) {
         this.errorCollector.reportCollisionError(range, name);

--- a/samlang-core/services/__tests__/index.test.ts
+++ b/samlang-core/services/__tests__/index.test.ts
@@ -429,6 +429,20 @@ class Main {
         insertText: 'of($0)$1',
         detail: '<T>((T) -> List<T>)',
       },
+      {
+        insertTextFormat: InsertTextFormats.Snippet,
+        kind: CompletionItemKinds.FUNCTION,
+        detail: '<T>((unit) -> List<T>)',
+        insertText: 'Nil($0)$1',
+        label: 'Nil(a0: unit): List<T>',
+      },
+      {
+        insertTextFormat: InsertTextFormats.Snippet,
+        kind: CompletionItemKinds.FUNCTION,
+        detail: '<T>(([T * List<T>]) -> List<T>)',
+        insertText: 'Cons($0)$1',
+        label: 'Cons(a0: [T * List<T>]): List<T>',
+      },
     ]);
     expect(service.autoComplete(testModuleReference, Position(12, 31))).toEqual([
       {
@@ -469,6 +483,13 @@ class Main {
         label: 'sam(): Developer',
         insertText: 'sam()',
         detail: '() -> Developer',
+      },
+      {
+        insertTextFormat: InsertTextFormats.Snippet,
+        kind: CompletionItemKinds.FUNCTION,
+        detail: '(string, string, List<string>) -> Developer',
+        insertText: 'init($0, $1, $2)$3',
+        label: 'init(a0: string, a1: string, a2: List<string>): Developer',
       },
     ]);
   });

--- a/samlang-core/test-programs.ts
+++ b/samlang-core/test-programs.ts
@@ -25,13 +25,13 @@ class A {
 }
 
 class C(val v: bool) {
-  function init(): C = { v: true }
+  function create(): C = { v: true }
 }
 
 class Main {
   function main(): unit = {
     val _ = A.b();
-    val _ = C.init();
+    val _ = C.create();
   }
 }
 `,
@@ -40,12 +40,12 @@ class Main {
     testName: 'add-panic-to-class',
     sourceCode: `
 class A(val a: int) {
-  function init(): A = { a: 42 }
+  function create(): A = { a: 42 }
 }
 
 class Main {
-  function main1(): int = Builtins.panic("Ah") + A.init()
-  function main2(): int = A.init() + Builtins.panic("Ah")
+  function main1(): int = Builtins.panic("Ah") + A.create()
+  function main2(): int = A.create() + Builtins.panic("Ah")
   private function main(): int = Main.main1() + Main.main2()
 }
 `,
@@ -54,11 +54,11 @@ class Main {
     testName: 'add-with-class',
     sourceCode: `
 class A(val a: int) {
-  function init(): A = { a: 42 }
+  function create(): A = { a: 42 }
 }
 
 class Main {
-  function main(): int = 3 + A.init()
+  function main(): int = 3 + A.create()
 }
 `,
   },
@@ -278,14 +278,14 @@ class Main {
     testName: 'overengineered-helloworld-2',
     sourceCode: `
 class NewYear2019<T>(val message: T) {
-  function init(): NewYear2019<string> = { message: "Hello World!" }
+  function create(): NewYear2019<string> = { message: "Hello World!" }
   method getMessage(): T = {
     val { message as msg } = this; msg
   }
 }
 
 class Main {
-  function main(): string = NewYear2019.init().getMessage()
+  function main(): string = NewYear2019.create().getMessage()
 }
 `,
   },
@@ -782,7 +782,7 @@ class FunctionExample {
 }
 
 class Box<T>(val content: T) {
-  function <T> init(content: T): Box<T> = { content } // object short hand syntax
+  function <T> create(content: T): Box<T> = { content } // object short hand syntax
   method getContent(): T = {
     val { content } = this; content
   }
@@ -816,7 +816,7 @@ class Main {
 
   private function consistencyTest(): unit = {
     val _ = Main.assertEquals(Option.getSome(3).map((i) -> i + 1).forceValue(), 4, "Ah1");
-    val _ = Main.assertEquals(Box.init(42).getContent(), 42, "Ah2");
+    val _ = Main.assertEquals(Box.create(42).getContent(), 42, "Ah2");
     val _ = Main.assertEquals(FunctionExample.getIdentityFunction()(42), 42, "Ah3");
     val _ = Main.assertEquals(Student.dummyStudent().getAge(), 0, "Ah4");
     val _ = Main.assertEquals(Math.plus(2, 2), 4, "Ah5");

--- a/tests/DifferentModulesDemo.sam
+++ b/tests/DifferentModulesDemo.sam
@@ -30,7 +30,7 @@ class FunctionExample {
 }
 
 class Box<T>(val content: T) {
-  function <T> init(content: T): Box<T> = { content }
+  function <T> create(content: T): Box<T> = { content }
 
   method getContent(): T = {
     val { content }: Box<T> = this;
@@ -62,7 +62,7 @@ class DifferentModulesDemo {
 
   function run(): unit = {
     val _ = ForTests.assertIntEquals(Option.getSome(3).map((i: int) -> i + 1).forceValue(), 4);
-    val _ = ForTests.assertIntEquals(Box.init(42).getContent(), 42);
+    val _ = ForTests.assertIntEquals(Box.create(42).getContent(), 42);
     val _ = ForTests.assertIntEquals(FunctionExample.getIdentityFunction()(42), 42);
     val _ = ForTests.assertIntEquals(Student.dummyStudent().getAge(), 0);
     val _ = ForTests.assertIntEquals(Math.plus(2, 2), 4);


### PR DESCRIPTION
## Summary

This diff intends to change the language design to de-specialize constructor functions. It makes them normal functions that you can use as first class values. This is intended to reduce the various similar cases in type checking into one unified case.

This diff adds them to the env first, so that collision is detected. In future diffs, I will add the runtime support and switch everything to use function call instead.

## Test Plan

```
yarn test
yarn test:integration
```
