### PR TITLE
[lang] Eliminate tuples

### DIFF
--- a/samlang-core/__tests__/errors.test.ts
+++ b/samlang-core/__tests__/errors.test.ts
@@ -42,8 +42,8 @@ const testCases: readonly (readonly [CompileTimeError, string])[] = [
     '__DUMMY__.sam:0:0-0:0: [UnexpectedTypeKind]: Expected kind: `array`, actual: `int`.',
   ],
   [
-    new ArityMismatchError(Location.DUMMY, 'tuple', 1, 2),
-    '__DUMMY__.sam:0:0-0:0: [ArityMismatchError]: Incorrect tuple size. Expected: 1, actual: 2.',
+    new ArityMismatchError(Location.DUMMY, 'pair', 1, 2),
+    '__DUMMY__.sam:0:0-0:0: [ArityMismatchError]: Incorrect pair size. Expected: 1, actual: 2.',
   ],
   [
     new InsufficientTypeInferenceContextError(Location.DUMMY),

--- a/samlang-core/ast/__tests__/samlang-nodes.test.ts
+++ b/samlang-core/ast/__tests__/samlang-nodes.test.ts
@@ -7,7 +7,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
   SourceUnknownType,
   UndecidedTypes,
@@ -32,14 +31,6 @@ describe('samlang-nodes', () => {
         ])
       )
     ).toBe('Foo<unit, int, Bar>');
-    expect(
-      prettyPrintType(
-        SourceTupleType(DummySourceReason, [
-          SourceUnitType(DummySourceReason),
-          SourceIntType(DummySourceReason),
-        ])
-      )
-    ).toBe('[unit * int]');
     expect(
       prettyPrintType(SourceFunctionType(DummySourceReason, [], SourceUnitType(DummySourceReason)))
     ).toBe('() -> unit');
@@ -209,58 +200,6 @@ describe('samlang-nodes', () => {
           SourceBoolType(DummySourceReason),
         ]),
         SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A', [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ])
-      )
-    ).toBeTruthy();
-
-    expect(
-      isTheSameType(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        SourceUnitType(DummySourceReason)
-      )
-    ).toBeFalsy();
-    expect(
-      isTheSameType(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        SourceTupleType(DummySourceReason, [])
-      )
-    ).toBeFalsy();
-    expect(
-      isTheSameType(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)])
-      )
-    ).toBeFalsy();
-    expect(
-      isTheSameType(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        SourceTupleType(DummySourceReason, [
-          SourceBoolType(DummySourceReason),
-          SourceIntType(DummySourceReason),
-        ])
-      )
-    ).toBeFalsy();
-    expect(
-      isTheSameType(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        SourceTupleType(DummySourceReason, [
           SourceIntType(DummySourceReason),
           SourceBoolType(DummySourceReason),
         ])

--- a/samlang-core/ast/samlang-nodes.ts
+++ b/samlang-core/ast/samlang-nodes.ts
@@ -33,11 +33,6 @@ export interface SamlangIdentifierType extends SamlangBaseType {
   readonly typeArguments: readonly SamlangType[];
 }
 
-export interface SamlangTupleType extends SamlangBaseType {
-  readonly type: 'TupleType';
-  readonly mappings: readonly SamlangType[];
-}
-
 export interface SamlangFunctionType extends SamlangBaseType {
   readonly type: 'FunctionType';
   readonly argumentTypes: readonly SamlangType[];
@@ -52,7 +47,6 @@ export interface SamlangUndecidedType extends SamlangBaseType {
 export type SamlangType =
   | SamlangPrimitiveType
   | SamlangIdentifierType
-  | SamlangTupleType
   | SamlangFunctionType
   | SamlangUndecidedType;
 
@@ -93,15 +87,6 @@ export const SourceIdentifierType = (
   moduleReference,
   identifier,
   typeArguments,
-});
-
-export const SourceTupleType = (
-  reason: SamlangReason,
-  mappings: readonly SamlangType[]
-): SamlangTupleType => ({
-  type: 'TupleType',
-  reason,
-  mappings,
 });
 
 export const SourceFunctionType = (
@@ -150,8 +135,6 @@ export function prettyPrintType(type: SamlangType): string {
         return type.identifier;
       }
       return `${type.identifier}<${type.typeArguments.map(prettyPrintType).join(', ')}>`;
-    case 'TupleType':
-      return `[${type.mappings.map(prettyPrintType).join(' * ')}]`;
     case 'FunctionType':
       return `(${type.argumentTypes.map(prettyPrintType).join(', ')}) -> ${prettyPrintType(
         type.returnType
@@ -173,14 +156,6 @@ export function isTheSameType(t1: SamlangType, t2: SamlangType): boolean {
         t1.identifier === t2.identifier &&
         t1.typeArguments.length === t2.typeArguments.length &&
         zip(t1.typeArguments, t2.typeArguments).every(([t1Element, t2Element]) =>
-          isTheSameType(t1Element, t2Element)
-        )
-      );
-    case 'TupleType':
-      return (
-        t2.type === 'TupleType' &&
-        t1.mappings.length === t2.mappings.length &&
-        zip(t1.mappings, t2.mappings).every(([t1Element, t2Element]) =>
           isTheSameType(t1Element, t2Element)
         )
       );
@@ -250,12 +225,6 @@ export interface ClassMemberExpression extends BaseExpression {
   readonly memberName: SourceIdentifier;
 }
 
-export interface TupleConstructorExpression extends BaseExpression {
-  readonly __type__: 'TupleConstructorExpression';
-  readonly type: SamlangTupleType;
-  readonly expressions: readonly SamlangExpression[];
-}
-
 export interface FieldAccessExpression extends BaseExpression {
   readonly __type__: 'FieldAccessExpression';
   readonly expression: SamlangExpression;
@@ -318,14 +287,6 @@ export interface LambdaExpression extends BaseExpression {
   readonly body: SamlangExpression;
 }
 
-export interface TuplePattern extends Node {
-  readonly type: 'TuplePattern';
-  readonly destructedNames: readonly {
-    readonly name?: SourceIdentifier;
-    readonly type: SamlangType;
-  }[];
-}
-
 export interface ObjectPatternDestucturedName {
   readonly fieldName: SourceIdentifier;
   readonly fieldOrder: number;
@@ -348,7 +309,7 @@ export interface WildCardPattern extends Node {
   readonly type: 'WildCardPattern';
 }
 
-export type Pattern = TuplePattern | ObjectPattern | VariablePattern | WildCardPattern;
+export type Pattern = ObjectPattern | VariablePattern | WildCardPattern;
 
 export interface SamlangValStatement extends Node {
   readonly pattern: Pattern;
@@ -372,7 +333,6 @@ export type SamlangExpression =
   | ThisExpression
   | VariableExpression
   | ClassMemberExpression
-  | TupleConstructorExpression
   | FieldAccessExpression
   | MethodAccessExpression
   | UnaryExpression
@@ -477,20 +437,6 @@ export const SourceExpressionClassMember = ({
   moduleReference,
   className,
   memberName,
-});
-
-export const SourceExpressionTupleConstructor = ({
-  location = Location.DUMMY,
-  type,
-  associatedComments = [],
-  expressions,
-}: ExpressionConstructorArgumentObject<TupleConstructorExpression>): TupleConstructorExpression => ({
-  __type__: 'TupleConstructorExpression',
-  location,
-  type,
-  precedence: 1,
-  associatedComments,
-  expressions,
 });
 
 export const SourceExpressionFieldAccess = ({

--- a/samlang-core/checker/__tests__/constraint-aware-checker.test.ts
+++ b/samlang-core/checker/__tests__/constraint-aware-checker.test.ts
@@ -5,7 +5,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import { createGlobalErrorCollector } from '../../errors';
@@ -129,63 +128,6 @@ describe('constraint-aware-checker', () => {
         resolution
       )
     ).toEqual(SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'));
-  });
-
-  it('t1=tuple type', () => {
-    const resolution = new TypeResolution();
-
-    expect(
-      checkAndInfer(
-        SourceTupleType(DummySourceReason, []),
-        SourceUnitType(DummySourceReason),
-        resolution
-      ).type
-    ).toBe('FAILED_MEET');
-    expect(
-      checkAndInfer(
-        SourceTupleType(DummySourceReason, []),
-        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
-        resolution
-      ).type
-    ).toBe('FAILED_MEET');
-    expect(
-      checkAndInfer(
-        SourceTupleType(DummySourceReason, []),
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        resolution
-      ).type
-    ).toBe('FAILED_MEET');
-    expect(
-      checkAndInfer(
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        resolution
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
-
-    expect(
-      checkAndInfer(
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
-        resolution
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
-    expect(
-      checkAndInfer(
-        { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
-        SourceTupleType(DummySourceReason, [
-          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        ]),
-        resolution
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
-    expect(
-      checkAndInfer(
-        SourceBoolType(DummySourceReason),
-        { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        resolution
-      ).type
-    ).toBe('FAILED_MEET');
   });
 
   it('t1=function type', () => {

--- a/samlang-core/checker/__tests__/contextual-type-meet.test.ts
+++ b/samlang-core/checker/__tests__/contextual-type-meet.test.ts
@@ -6,7 +6,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
   SourceUnknownType,
 } from '../../ast/samlang-nodes';
@@ -108,43 +107,6 @@ describe('contextual-type-meet', () => {
         SourceUnknownType(DummySourceReason)
       )
     ).toEqual(SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'));
-  });
-
-  it('t1=tuple type', () => {
-    expect(meet(SourceTupleType(DummySourceReason, []), SourceUnitType(DummySourceReason))).toBe(
-      'FAILED_MEET'
-    );
-    expect(
-      meet(
-        SourceTupleType(DummySourceReason, []),
-        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B')
-      )
-    ).toBe('FAILED_MEET');
-    expect(
-      meet(
-        SourceTupleType(DummySourceReason, []),
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)])
-      )
-    ).toBe('FAILED_MEET');
-    expect(
-      meet(
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)])
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
-
-    expect(
-      meet(
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        SourceUnknownType(DummySourceReason)
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
-    expect(
-      meet(
-        SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]),
-        SourceTupleType(DummySourceReason, [SourceUnknownType(DummySourceReason)])
-      )
-    ).toEqual(SourceTupleType(DummySourceReason, [SourceIntType(DummySourceReason)]));
   });
 
   it('t1=function type', () => {

--- a/samlang-core/checker/__tests__/expression-type-fixer.test.ts
+++ b/samlang-core/checker/__tests__/expression-type-fixer.test.ts
@@ -17,7 +17,6 @@ import {
   SourceExpressionString,
   SourceExpressionThis,
   SourceExpressionTrue,
-  SourceExpressionTupleConstructor,
   SourceExpressionUnary,
   SourceExpressionVariable,
   SourceFunctionType,
@@ -25,7 +24,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import fixExpressionType from '../expression-type-fixer';
@@ -134,57 +132,6 @@ describe('expression-type-fixer', () => {
         memberName: SourceId('bar'),
       }),
       SourceFunctionType(DummySourceReason, [], SourceIntType(DummySourceReason))
-    );
-  });
-
-  it('Tuple constructors are correctly resolved.', () => {
-    assertCorrectlyFixed(
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-        ]),
-        expressions: [intOf(1), TRUE],
-      }),
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [
-          { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
-          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        ]),
-        expressions: [intOf(1), TRUE],
-      }),
-      SourceTupleType(DummySourceReason, [
-        SourceIntType(DummySourceReason),
-        SourceBoolType(DummySourceReason),
-      ])
-    );
-
-    assertThrows(
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [
-          { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
-          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        ]),
-        expressions: [intOf(1), TRUE],
-      }),
-      SourceTupleType(DummySourceReason, [
-        SourceBoolType(DummySourceReason),
-        SourceIntType(DummySourceReason),
-      ])
-    );
-
-    assertThrows(
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [
-          { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
-          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        ]),
-        expressions: [TRUE, intOf(1)],
-      }),
-      SourceTupleType(DummySourceReason, [
-        SourceIntType(DummySourceReason),
-        SourceBoolType(DummySourceReason),
-      ])
     );
   });
 

--- a/samlang-core/checker/__tests__/module-references-collector.test.ts
+++ b/samlang-core/checker/__tests__/module-references-collector.test.ts
@@ -21,14 +21,12 @@ import {
   SourceExpressionStatementBlock,
   SourceExpressionThis,
   SourceExpressionTrue,
-  SourceExpressionTupleConstructor,
   SourceExpressionUnary,
   SourceExpressionVariable,
   SourceFunctionType,
   SourceId,
   SourceIdentifierType,
   SourceIntType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import { collectModuleReferenceFromExpression } from '../module-references-collector';
@@ -78,25 +76,6 @@ describe('module-references-collector', () => {
 
   it('collectModuleReferenceFromExpression works 3/n', () => {
     assertFoundAllModuleReferencesFromExpression(
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'f', [
-            SourceFunctionType(
-              DummySourceReason,
-              [SourceIntType(DummySourceReason)],
-              SourceTupleType(DummySourceReason, [SourceBoolType(DummySourceReason)])
-            ),
-          ]),
-        ]),
-        expressions: [intOf(1), TRUE],
-      }),
-      ['__DUMMY__']
-    );
-  });
-
-  it('collectModuleReferenceFromExpression works 6/n', () => {
-    assertFoundAllModuleReferencesFromExpression(
       SourceExpressionFieldAccess({
         type: SourceFunctionType(DummySourceReason, [], SourceIntType(DummySourceReason)),
         expression: SourceExpressionThis({
@@ -129,7 +108,7 @@ describe('module-references-collector', () => {
     );
   });
 
-  it('collectModuleReferenceFromExpression works 8/n', () => {
+  it('collectModuleReferenceFromExpression works 4/n', () => {
     assertFoundAllModuleReferencesFromExpression(
       SourceExpressionBinary({
         type: SourceIntType(DummySourceReason),
@@ -142,7 +121,7 @@ describe('module-references-collector', () => {
     );
   });
 
-  it('collectModuleReferenceFromExpression works 9/n', () => {
+  it('collectModuleReferenceFromExpression works 5/n', () => {
     assertFoundAllModuleReferencesFromExpression(
       SourceExpressionMatch({
         type: SourceIntType(DummySourceReason),
@@ -165,7 +144,7 @@ describe('module-references-collector', () => {
     );
   });
 
-  it('collectModuleReferenceFromExpression works 10/n', () => {
+  it('collectModuleReferenceFromExpression works 6/n', () => {
     assertFoundAllModuleReferencesFromExpression(
       SourceExpressionStatementBlock({
         type: SourceUnitType(DummySourceReason),
@@ -206,7 +185,7 @@ describe('module-references-collector', () => {
     );
   });
 
-  it('collectModuleReferenceFromExpression works 11/n', () => {
+  it('collectModuleReferenceFromExpression works 7/n', () => {
     assertFoundAllModuleReferencesFromExpression(
       SourceExpressionIfElse({
         type: SourceBoolType(DummySourceReason),

--- a/samlang-core/checker/__tests__/type-constraint-solver.test.ts
+++ b/samlang-core/checker/__tests__/type-constraint-solver.test.ts
@@ -7,7 +7,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
   SourceUnknownType,
 } from '../../ast/samlang-nodes';
@@ -68,28 +67,6 @@ describe('type-constraint-solver', () => {
         ['T']
       )
     ).toEqual({ T: 'Baz' });
-  });
-
-  it('tuple type', () => {
-    expect(
-      solve(
-        SourceTupleType(DummySourceReason, [
-          SourceIntType(DummySourceReason),
-          SourceBoolType(DummySourceReason),
-          SourceStringType(DummySourceReason),
-        ]),
-        SourceTupleType(DummySourceReason, [IdType('A'), IdType('B'), IdType('A')]),
-        ['A', 'B']
-      )
-    ).toEqual({ A: 'int', B: 'bool', hasError: 'true' });
-
-    expect(
-      solve(
-        SourceIntType(DummySourceReason),
-        SourceTupleType(DummySourceReason, [IdType('A'), IdType('B'), IdType('A')]),
-        ['A', 'B']
-      )
-    ).toEqual({ A: 'unknown', B: 'unknown', hasError: 'true' });
   });
 
   it('function type', () => {

--- a/samlang-core/checker/__tests__/type-resolution.test.ts
+++ b/samlang-core/checker/__tests__/type-resolution.test.ts
@@ -5,7 +5,6 @@ import {
   SourceFunctionType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import { assert } from '../../utils';
@@ -49,10 +48,8 @@ describe('type-resolution', () => {
         SourceFunctionType(
           DummySourceReason,
           [
-            SourceTupleType(DummySourceReason, [
-              { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
-              { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-            ]),
+            { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
+            { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
             { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
             SourceFunctionType(DummySourceReason, [], SourceUnitType(DummySourceReason)),
           ],
@@ -67,10 +64,8 @@ describe('type-resolution', () => {
       SourceFunctionType(
         DummySourceReason,
         [
-          SourceTupleType(DummySourceReason, [
-            SourceIntType(DummySourceReason),
-            SourceBoolType(DummySourceReason),
-          ]),
+          SourceIntType(DummySourceReason),
+          SourceBoolType(DummySourceReason),
           SourceStringType(DummySourceReason),
           SourceFunctionType(DummySourceReason, [], SourceUnitType(DummySourceReason)),
         ],

--- a/samlang-core/checker/__tests__/type-resolver.test.ts
+++ b/samlang-core/checker/__tests__/type-resolver.test.ts
@@ -7,7 +7,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import typeResolver from '../type-resolver';
@@ -57,20 +56,6 @@ describe('type-resolver', () => {
       )
     ).toEqual(
       SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A', [
-        SourceUnitType(DummySourceReason),
-        SourceBoolType(DummySourceReason),
-      ])
-    );
-
-    expect(
-      resolve(
-        SourceTupleType(DummySourceReason, [
-          { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
-          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-        ])
-      )
-    ).toEqual(
-      SourceTupleType(DummySourceReason, [
         SourceUnitType(DummySourceReason),
         SourceBoolType(DummySourceReason),
       ])

--- a/samlang-core/checker/__tests__/type-substitution.test.ts
+++ b/samlang-core/checker/__tests__/type-substitution.test.ts
@@ -1,10 +1,5 @@
 import { DummySourceReason, ModuleReference } from '../../ast/common-nodes';
-import {
-  SourceFunctionType,
-  SourceIdentifierType,
-  SourceIntType,
-  SourceTupleType,
-} from '../../ast/samlang-nodes';
+import { SourceFunctionType, SourceIdentifierType, SourceIntType } from '../../ast/samlang-nodes';
 import performTypeSubstitution from '../type-substitution';
 
 describe('type-substitution', () => {
@@ -20,11 +15,9 @@ describe('type-substitution', () => {
                 SourceIntType(DummySourceReason),
               ]),
             ]),
-            SourceTupleType(DummySourceReason, [
-              SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'D'),
-              SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'E', [
-                SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'F'),
-              ]),
+            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'D'),
+            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'E', [
+              SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'F'),
             ]),
             { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
           ],
@@ -48,11 +41,9 @@ describe('type-substitution', () => {
               SourceIntType(DummySourceReason),
             ]),
           ]),
-          SourceTupleType(DummySourceReason, [
-            SourceIntType(DummySourceReason),
-            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'E', [
-              SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'F'),
-            ]),
+          SourceIntType(DummySourceReason),
+          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'E', [
+            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'F'),
           ]),
           { type: 'UndecidedType', reason: DummySourceReason, index: 0 },
         ],

--- a/samlang-core/checker/__tests__/type-undecider.test.ts
+++ b/samlang-core/checker/__tests__/type-undecider.test.ts
@@ -3,7 +3,6 @@ import {
   SourceBoolType,
   SourceFunctionType,
   SourceIdentifierType,
-  SourceTupleType,
   SourceUnitType,
   UndecidedTypes,
 } from '../../ast/samlang-nodes';
@@ -24,14 +23,10 @@ describe('type-undecider', () => {
             ]),
             SourceUnitType(DummySourceReason),
             SourceUnitType(DummySourceReason),
-            SourceTupleType(DummySourceReason, [
-              SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T2'),
-            ]),
-          ],
-          SourceTupleType(DummySourceReason, [
+            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T2'),
             SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T3'),
-            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T4'),
-          ])
+          ],
+          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T4')
         ),
         ['T1', 'T2', 'T3', 'T4']
       )[0]
@@ -45,14 +40,10 @@ describe('type-undecider', () => {
           ]),
           SourceUnitType(DummySourceReason),
           SourceUnitType(DummySourceReason),
-          SourceTupleType(DummySourceReason, [
-            { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-          ]),
-        ],
-        SourceTupleType(DummySourceReason, [
+          { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
           { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
-          { type: 'UndecidedType', reason: DummySourceReason, index: 3 },
-        ])
+        ],
+        { type: 'UndecidedType', reason: DummySourceReason, index: 3 }
       )
     );
   });

--- a/samlang-core/checker/__tests__/undecided-type-collector.test.ts
+++ b/samlang-core/checker/__tests__/undecided-type-collector.test.ts
@@ -3,7 +3,6 @@ import {
   SourceBoolType,
   SourceFunctionType,
   SourceIdentifierType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import collectUndecidedTypeIndices from '../undecided-type-collector';
@@ -22,17 +21,11 @@ describe('undecided-type-collector', () => {
               ]),
               SourceUnitType(DummySourceReason),
               SourceUnitType(DummySourceReason),
-              SourceTupleType(DummySourceReason, [
-                { type: 'UndecidedType', reason: DummySourceReason, index: 1 },
-              ]),
             ],
-            SourceTupleType(DummySourceReason, [
-              { type: 'UndecidedType', reason: DummySourceReason, index: 2 },
-              { type: 'UndecidedType', reason: DummySourceReason, index: 3 },
-            ])
+            SourceUnitType(DummySourceReason)
           )
         ).values()
       )
-    ).toEqual([0, 1, 2, 3]);
+    ).toEqual([0]);
   });
 });

--- a/samlang-core/checker/constraint-aware-checker.ts
+++ b/samlang-core/checker/constraint-aware-checker.ts
@@ -44,24 +44,6 @@ function typeMeet(hint: SamlangType, actual: SamlangType, resolution: TypeResolu
         default:
           throw new Error();
       }
-    case 'TupleType':
-      switch (actual.type) {
-        case 'UndecidedType':
-          return meetWithUndecidedType(hint, actual, resolution);
-        case 'TupleType':
-          if (hint.mappings.length !== actual.mappings.length) {
-            throw new Error();
-          }
-          return {
-            type: 'TupleType',
-            reason: actual.reason,
-            mappings: zip(hint.mappings, actual.mappings).map(([type1, type2]) =>
-              meetWithResolution(type1, type2)
-            ),
-          };
-        default:
-          throw new Error();
-      }
     case 'FunctionType':
       switch (actual.type) {
         case 'UndecidedType':

--- a/samlang-core/checker/contextual-type-meet.ts
+++ b/samlang-core/checker/contextual-type-meet.ts
@@ -47,21 +47,6 @@ export default function contextualTypeMeet(
         specific
       );
       return specific;
-    case 'TupleType':
-      if (specific.type === 'TupleType' && general.mappings.length === specific.mappings.length) {
-        return {
-          ...specific,
-          mappings: zip(general.mappings, specific.mappings).map(([g, s]) =>
-            contextualTypeMeet(g, s, errorCollector)
-          ),
-        };
-      }
-      errorCollector.reportUnexpectedTypeError(
-        specific.reason.definitionLocation,
-        general,
-        specific
-      );
-      return specific;
     case 'FunctionType':
       if (
         specific.type === 'FunctionType' &&

--- a/samlang-core/checker/expression-type-fixer.ts
+++ b/samlang-core/checker/expression-type-fixer.ts
@@ -5,7 +5,6 @@ import {
   SamlangExpression,
   SamlangFunctionType,
   SamlangIdentifierType,
-  SamlangTupleType,
   SamlangType,
   SourceBoolType,
   SourceIntType,
@@ -65,16 +64,6 @@ export default function fixExpressionType(
           typeFixItself(typeArgument, null)
         ),
       };
-    case 'TupleConstructorExpression': {
-      const newType = typeFixItself(expression.type, expectedType) as SamlangTupleType;
-      return {
-        ...expression,
-        type: newType,
-        expressions: checkedZip(expression.expressions, newType.mappings).map(([element, type]) =>
-          tryFixExpressionType(element, type)
-        ),
-      };
-    }
     case 'FieldAccessExpression':
     case 'MethodAccessExpression':
       return {

--- a/samlang-core/checker/module-references-collector.ts
+++ b/samlang-core/checker/module-references-collector.ts
@@ -14,9 +14,6 @@ export function collectModuleReferenceFromType(
       collector.add(type.moduleReference);
       type.typeArguments.forEach((it) => collectModuleReferenceFromType(it, collector));
       return;
-    case 'TupleType':
-      type.mappings.forEach((it) => collectModuleReferenceFromType(it, collector));
-      return;
     case 'FunctionType':
       type.argumentTypes.forEach((it) => collectModuleReferenceFromType(it, collector));
       collectModuleReferenceFromType(type.returnType, collector);
@@ -37,9 +34,6 @@ export function collectModuleReferenceFromExpression(
     case 'ClassMemberExpression':
       expression.typeArguments.forEach((it) => collectModuleReferenceFromType(it, collector));
       collector.add(expression.moduleReference);
-      return;
-    case 'TupleConstructorExpression':
-      expression.expressions.forEach((it) => collectModuleReferenceFromExpression(it, collector));
       return;
     case 'FieldAccessExpression':
     case 'MethodAccessExpression':

--- a/samlang-core/checker/ssa-analysis.ts
+++ b/samlang-core/checker/ssa-analysis.ts
@@ -104,9 +104,6 @@ class SsaBuilder extends LocalStackedContext<Location> {
       case 'VariableExpression':
         this.use({ name: expression.name, location: expression.location });
         return;
-      case 'TupleConstructorExpression':
-        expression.expressions.forEach(this.visitExpression);
-        return;
       case 'FieldAccessExpression':
       case 'MethodAccessExpression':
       case 'UnaryExpression':
@@ -154,11 +151,6 @@ class SsaBuilder extends LocalStackedContext<Location> {
           statements.forEach(({ pattern, assignedExpression }) => {
             this.visitExpression(assignedExpression);
             switch (pattern.type) {
-              case 'TuplePattern':
-                pattern.destructedNames.forEach(({ name }) => {
-                  if (name != null) this.define(name);
-                });
-                return;
               case 'ObjectPattern':
                 pattern.destructedNames.forEach((name) =>
                   this.define(name.alias ?? name.fieldName)
@@ -186,9 +178,6 @@ class SsaBuilder extends LocalStackedContext<Location> {
       case 'IdentifierType':
         this.use({ name: type.identifier, location: type.reason.definitionLocation });
         type.typeArguments.forEach(this.visitType);
-        return;
-      case 'TupleType':
-        type.mappings.forEach(this.visitType);
         return;
       case 'FunctionType':
         type.argumentTypes.forEach(this.visitType);

--- a/samlang-core/checker/type-constraints-solver.ts
+++ b/samlang-core/checker/type-constraints-solver.ts
@@ -38,16 +38,6 @@ function solveTypeConstraintsInternal(
         );
       }
       return;
-    case 'TupleType':
-      if (
-        concreteType.type === 'TupleType' &&
-        concreteType.mappings.length === genericType.mappings.length
-      ) {
-        zip(concreteType.mappings, genericType.mappings).map(([c, g]) =>
-          solveTypeConstraintsInternal(c, g, typeParameters, partiallySolved)
-        );
-      }
-      return;
     case 'FunctionType':
       if (
         concreteType.type === 'FunctionType' &&

--- a/samlang-core/checker/type-resolver.ts
+++ b/samlang-core/checker/type-resolver.ts
@@ -3,7 +3,6 @@ import {
   SamlangUndecidedType,
   SourceFunctionType,
   SourceIdentifierType,
-  SourceTupleType,
 } from '../ast/samlang-nodes';
 
 export default function resolveType(
@@ -19,11 +18,6 @@ export default function resolveType(
         type.moduleReference,
         type.identifier,
         type.typeArguments.map((it) => resolveType(it, undecidedTypeResolver))
-      );
-    case 'TupleType':
-      return SourceTupleType(
-        type.reason,
-        type.mappings.map((it) => resolveType(it, undecidedTypeResolver))
       );
     case 'FunctionType':
       return SourceFunctionType(

--- a/samlang-core/checker/type-substitution.ts
+++ b/samlang-core/checker/type-substitution.ts
@@ -1,10 +1,5 @@
 import { DummySourceReason, ModuleReference } from '../ast/common-nodes';
-import {
-  SamlangType,
-  SourceFunctionType,
-  SourceIdentifierType,
-  SourceTupleType,
-} from '../ast/samlang-nodes';
+import { SamlangType, SourceFunctionType, SourceIdentifierType } from '../ast/samlang-nodes';
 import { assert } from '../utils';
 import type { MemberTypeInformation } from './typing-context';
 
@@ -24,11 +19,6 @@ export default function performTypeSubstitution(
         type.moduleReference,
         type.identifier,
         type.typeArguments.map((it) => performTypeSubstitution(it, mapping))
-      );
-    case 'TupleType':
-      return SourceTupleType(
-        type.reason,
-        type.mappings.map((it) => performTypeSubstitution(it, mapping))
       );
     case 'FunctionType':
       return SourceFunctionType(

--- a/samlang-core/checker/type-undecider.ts
+++ b/samlang-core/checker/type-undecider.ts
@@ -30,7 +30,7 @@ export function undecideTypeParameters(
  * Given a `typeMappings` and its `typeParameters`, replaces all references to type parameters to
  * freshly created undecided types.
  *
- * @return tuple(
+ * @return (
  *  `typeMappings` with `typeParameters` replaced with undecided types,
  *   generated undecided types
  * ).

--- a/samlang-core/checker/undecided-type-collector.ts
+++ b/samlang-core/checker/undecided-type-collector.ts
@@ -9,9 +9,6 @@ function collectUndecidedTypeIndicesVisitor(type: SamlangType, collector: Set<nu
         collectUndecidedTypeIndicesVisitor(typeArgument, collector)
       );
       return;
-    case 'TupleType':
-      type.mappings.forEach((oneType) => collectUndecidedTypeIndicesVisitor(oneType, collector));
-      return;
     case 'FunctionType':
       type.argumentTypes.forEach((typeArgument) =>
         collectUndecidedTypeIndicesVisitor(typeArgument, collector)

--- a/samlang-core/compiler/__tests__/hir-expression-lowering.test.ts
+++ b/samlang-core/compiler/__tests__/hir-expression-lowering.test.ts
@@ -26,7 +26,6 @@ import {
   SourceExpressionString,
   SourceExpressionThis,
   SourceExpressionTrue,
-  SourceExpressionTupleConstructor,
   SourceExpressionUnary,
   SourceExpressionVariable,
   SourceFunctionType,
@@ -34,7 +33,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import lowerSamlangExpression from '../hir-expression-lowering';
@@ -137,18 +135,6 @@ describe('hir-expression-lowering', () => {
       }),
       `closure type $SyntheticIDType0 = (int) -> int
 let _t0: $SyntheticIDType0 = Closure { fun: (___DUMMY___A_b_with_context: (int, int) -> int), context: 0 };
-return (_t0: $SyntheticIDType0);`
-    );
-  });
-
-  it('Lowering to StructConstructor works', () => {
-    expectCorrectlyLowered(
-      SourceExpressionTupleConstructor({
-        type: SourceTupleType(DummySourceReason, [DUMMY_IDENTIFIER_TYPE]),
-        expressions: [THIS],
-      }),
-      `object type $SyntheticIDType0 = [__DUMMY___Dummy]
-let _t0: $SyntheticIDType0 = [(_this: __DUMMY___Dummy)];
 return (_t0: $SyntheticIDType0);`
     );
   });
@@ -659,31 +645,6 @@ return (_t4: __DUMMY___Dummy);`
             statements: [
               {
                 location: Location.DUMMY,
-                pattern: {
-                  location: Location.DUMMY,
-                  type: 'TuplePattern',
-                  destructedNames: [
-                    { name: SourceId('ignored'), type: SourceIntType(DummySourceReason) },
-                    { type: SourceIntType(DummySourceReason) },
-                  ],
-                },
-                typeAnnotation: SourceTupleType(DummySourceReason, [
-                  SourceIntType(DummySourceReason),
-                  SourceIntType(DummySourceReason),
-                ]),
-                assignedExpression: SourceExpressionTupleConstructor({
-                  location: Location.DUMMY,
-                  type: SourceTupleType(DummySourceReason, [
-                    SourceIntType(DummySourceReason),
-                    SourceIntType(DummySourceReason),
-                  ]),
-                  associatedComments: [],
-                  expressions: [SourceExpressionInt(1), SourceExpressionInt(2)],
-                }),
-                associatedComments: [],
-              },
-              {
-                location: Location.DUMMY,
                 pattern: { location: Location.DUMMY, type: 'VariablePattern', name: 'a' },
                 typeAnnotation: SourceUnitType(DummySourceReason),
                 assignedExpression: SourceExpressionStatementBlock({
@@ -691,29 +652,6 @@ return (_t4: __DUMMY___Dummy);`
                   block: {
                     location: Location.DUMMY,
                     statements: [
-                      {
-                        location: Location.DUMMY,
-                        pattern: {
-                          location: Location.DUMMY,
-                          type: 'TuplePattern',
-                          destructedNames: [
-                            { name: SourceId('a'), type: SourceIntType(DummySourceReason) },
-                            { type: SourceIntType(DummySourceReason) },
-                          ],
-                        },
-                        typeAnnotation: SourceTupleType(DummySourceReason, [
-                          SourceIntType(DummySourceReason),
-                          SourceIntType(DummySourceReason),
-                        ]),
-                        assignedExpression: {
-                          ...THIS,
-                          type: SourceTupleType(DummySourceReason, [
-                            SourceIntType(DummySourceReason),
-                            SourceIntType(DummySourceReason),
-                          ]),
-                        },
-                        associatedComments: [],
-                      },
                       {
                         location: Location.DUMMY,
                         pattern: {
@@ -758,11 +696,7 @@ return (_t4: __DUMMY___Dummy);`
             ],
           },
         }),
-        `object type $SyntheticIDType0 = [int, int]
-let _t0: $SyntheticIDType0 = [1, 2];
-let ignored: int = (_t0: $SyntheticIDType0)[0];
-let a__depth_1__block_0: int = (_this: __DUMMY___Dummy)[0];
-let a__depth_1__block_0: int = (_this: __DUMMY___Dummy)[0];
+        `let a__depth_1__block_0: int = (_this: __DUMMY___Dummy)[0];
 let c__depth_1__block_0: int = (_this: __DUMMY___Dummy)[1];
 return 0;`
       );

--- a/samlang-core/compiler/__tests__/hir-toplevel-lowering.test.ts
+++ b/samlang-core/compiler/__tests__/hir-toplevel-lowering.test.ts
@@ -20,7 +20,6 @@ import {
   SourceId,
   SourceIdentifierType,
   SourceIntType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import compileSamlangSourcesToHighIRSources, {
@@ -226,12 +225,10 @@ describe('mir-toplevel-lowering', () => {
                 type: SourceFunctionType(
                   DummySourceReason,
                   [
-                    SourceTupleType(DummySourceReason, [
-                      SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A', [
-                        SourceIntType(DummySourceReason),
-                      ]),
-                      SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T'),
+                    SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A', [
+                      SourceIntType(DummySourceReason),
                     ]),
+                    SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T'),
                   ],
                   SourceIntType(DummySourceReason)
                 ),
@@ -252,12 +249,11 @@ describe('mir-toplevel-lowering', () => {
     expect(
       debugPrintHighIRSources(compileSamlangSourcesToHighIRSourcesWithGenericsPreserved(sources))
     ).toBe(
-      `closure type $SyntheticIDType1<T> = ($SyntheticIDType0<T>) -> int
+      `closure type $SyntheticIDType0<T> = (__DUMMY___A<int>, T) -> int
 object type __DUMMY___Main = []
 object type __DUMMY___Class1 = [int]
 variant type __DUMMY___Class2 = []
-object type __DUMMY___Class3<T> = [$SyntheticIDType1<T>]
-object type $SyntheticIDType0<T> = [__DUMMY___A<int>, T]
+object type __DUMMY___Class3<T> = [$SyntheticIDType0<T>]
 function ___DUMMY___Main_main_with_context(_context: int): int {
   let _ret: int = ___DUMMY___Main_main();
   return (_ret: int);
@@ -321,13 +317,13 @@ function ___DUMMY___Class1_factorial(n: int, acc: int): int {
   return (_t4: int);
 }
 
-function ___DUMMY___Class3_init<T>(_f0: $SyntheticIDType1<T>): __DUMMY___Class3<T> {
-  let _struct: __DUMMY___Class3<T> = [(_f0: $SyntheticIDType1<T>)];
+function ___DUMMY___Class3_init<T>(_f0: $SyntheticIDType0<T>): __DUMMY___Class3<T> {
+  let _struct: __DUMMY___Class3<T> = [(_f0: $SyntheticIDType0<T>)];
   return (_struct: __DUMMY___Class3<T>);
 }
 
-function ___DUMMY___Class3_init_with_context<T>(_context: int, _f0: $SyntheticIDType1<T>): __DUMMY___Class3<T> {
-  let _ret: __DUMMY___Class3<T> = ___DUMMY___Class3_init((_f0: $SyntheticIDType1<T>));
+function ___DUMMY___Class3_init_with_context<T>(_context: int, _f0: $SyntheticIDType0<T>): __DUMMY___Class3<T> {
+  let _ret: __DUMMY___Class3<T> = ___DUMMY___Class3_init((_f0: $SyntheticIDType0<T>));
   return (_ret: __DUMMY___Class3<T>);
 }
 

--- a/samlang-core/compiler/__tests__/hir-type-conversion.test.ts
+++ b/samlang-core/compiler/__tests__/hir-type-conversion.test.ts
@@ -17,7 +17,6 @@ import {
   SourceIdentifierType,
   SourceIntType,
   SourceStringType,
-  SourceTupleType,
   SourceUnitType,
 } from '../../ast/samlang-nodes';
 import {
@@ -276,27 +275,6 @@ describe('hir-type-conversion', () => {
     expect(
       prettyPrintHighIRType(
         new SamlangTypeLoweringManager(new Set(['T']), typeSynthesizer).lowerSamlangType(
-          SourceTupleType(DummySourceReason, [
-            SourceIntType(DummySourceReason),
-            SourceBoolType(DummySourceReason),
-          ])
-        )
-      )
-    ).toBe('$SyntheticIDType0');
-    expect(
-      prettyPrintHighIRType(
-        new SamlangTypeLoweringManager(new Set(['T']), typeSynthesizer).lowerSamlangType(
-          SourceTupleType(DummySourceReason, [
-            SourceIntType(DummySourceReason),
-            SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'T'),
-          ])
-        )
-      )
-    ).toBe('$SyntheticIDType1<T>');
-
-    expect(
-      prettyPrintHighIRType(
-        new SamlangTypeLoweringManager(new Set(['T']), typeSynthesizer).lowerSamlangType(
           SourceFunctionType(
             DummySourceReason,
             [
@@ -307,19 +285,16 @@ describe('hir-type-conversion', () => {
           )
         )
       )
-    ).toBe('$SyntheticIDType2<T>');
+    ).toBe('$SyntheticIDType0<T>');
 
     expect(() =>
       manager.lowerSamlangType({ type: 'UndecidedType', reason: DummySourceReason, index: 0 })
     ).toThrow();
 
-    expect(typeSynthesizer.synthesizedTupleTypes.map(prettyPrintHighIRTypeDefinition)).toEqual([
-      'object type $SyntheticIDType0 = [int, bool]',
-      'object type $SyntheticIDType1<T> = [int, T]',
-    ]);
+    expect(typeSynthesizer.synthesizedTupleTypes.map(prettyPrintHighIRTypeDefinition)).toEqual([]);
     expect(
       typeSynthesizer.synthesizedClosureTypes.map(prettyPrintHighIRClosureTypeDefinition)
-    ).toEqual(['closure type $SyntheticIDType2<T> = (T, bool) -> int']);
+    ).toEqual(['closure type $SyntheticIDType0<T> = (T, bool) -> int']);
   });
 
   it('SamlangTypeLoweringManager.lowerSamlangTypeDefinition() works', () => {

--- a/samlang-core/compiler/hir-type-conversion.ts
+++ b/samlang-core/compiler/hir-type-conversion.ts
@@ -277,20 +277,6 @@ export class SamlangTypeLoweringManager {
           encodeSamlangType(type.moduleReference, type.identifier),
           type.typeArguments.map(this.lowerSamlangType)
         );
-      case 'TupleType': {
-        const typeMappings = type.mappings.map(this.lowerSamlangType);
-        const typeParameters = Array.from(
-          collectUsedGenericTypes(HIR_FUNCTION_TYPE(typeMappings, HIR_BOOL_TYPE), this.genericTypes)
-        );
-        const typeDefinition = this.typeSynthesizer.synthesizeTupleType(
-          typeMappings,
-          typeParameters
-        );
-        return HIR_IDENTIFIER_TYPE(
-          typeDefinition.identifier,
-          typeParameters.map(HIR_IDENTIFIER_TYPE_WITHOUT_TYPE_ARGS)
-        );
-      }
       case 'FunctionType': {
         const rewrittenFunctionType = HIR_FUNCTION_TYPE(
           type.argumentTypes.map(this.lowerSamlangType),

--- a/samlang-core/interpreter/__tests__/expression-interpreter.test.ts
+++ b/samlang-core/interpreter/__tests__/expression-interpreter.test.ts
@@ -24,7 +24,6 @@ import {
   ObjectPatternDestucturedName,
   SamlangExpression,
   SamlangFunctionType,
-  SamlangTupleType,
   SamlangValStatement,
   SourceBoolType,
   SourceExpressionBinary,
@@ -41,7 +40,6 @@ import {
   SourceExpressionString,
   SourceExpressionThis,
   SourceExpressionTrue,
-  SourceExpressionTupleConstructor,
   SourceExpressionUnary,
   SourceExpressionVariable,
   SourceId,
@@ -50,7 +48,6 @@ import {
   SourceStringType,
   SourceUnitType,
   StatementBlock,
-  TuplePattern,
   VariablePattern,
   VariantPatternToExpression,
   WildCardPattern,
@@ -80,7 +77,6 @@ describe('expression-interpreter', () => {
     expect({ type: 'unit' }).not.toEqual({ type: 'bool', value: true });
     expect({ type: 'unit' }).not.toEqual({ type: 'int', value: 1 });
     expect({ type: 'unit' }).not.toEqual({ type: 'string', value: 'string' });
-    expect({ type: 'unit' }).not.toEqual({ type: 'tuple', tupleContent: [] });
     expect({ type: 'unit' }).not.toEqual({ type: 'object', objectContent: new Map() });
     expect({ type: 'unit' }).not.toEqual({ type: 'variant', tag: 'tag', data: { type: 'unit' } });
 
@@ -102,16 +98,6 @@ describe('expression-interpreter', () => {
     expect({ type: 'string', value: 'string' }).not.toEqual({
       type: 'string',
       value: 'not a string',
-    });
-
-    expect({ type: 'tuple', tupleContent: [] }).toEqual({ type: 'tuple', tupleContent: [] });
-    expect({ type: 'tuple', tupleContent: [] }).not.toEqual({
-      type: 'tuple',
-      tupleContent: [{ type: 'unit' }],
-    });
-    expect({ type: 'tuple', tupleContent: [{ type: 'unit' }] }).toEqual({
-      type: 'tuple',
-      tupleContent: [{ type: 'unit' }],
     });
 
     expect({ type: 'object', objectContent: new Map() }).toEqual({
@@ -305,35 +291,6 @@ describe('expression-interpreter', () => {
       classMemberFunction
     );
     expect(() => interpreter.eval(classMemberExpression)).toThrow('');
-  });
-
-  it('tuple expression evaluates correctly', () => {
-    const tupleExpression = SourceExpressionTupleConstructor({
-      location: exampleLocation,
-      type: {
-        type: 'TupleType',
-        reason: DummySourceReason,
-        mappings: [SourceIntType(DummySourceReason)],
-      },
-      expressions: [intLiteralExpression],
-    });
-    const tupleExpressionMultiple = SourceExpressionTupleConstructor({
-      location: exampleLocation,
-      type: {
-        type: 'TupleType',
-        reason: DummySourceReason,
-        mappings: [SourceIntType(DummySourceReason), SourceBoolType(DummySourceReason)],
-      },
-      expressions: [intLiteralExpression, boolLiteralExpression],
-    });
-    expect(interpreter.eval(tupleExpression)).toEqual({
-      type: 'tuple',
-      tupleContent: [intLiteralValue],
-    });
-    expect(interpreter.eval(tupleExpressionMultiple)).toEqual({
-      type: 'tuple',
-      tupleContent: [intLiteralValue, boolLiteralValue],
-    });
   });
 
   it('object constructor expression evaluates correctly', () => {
@@ -956,40 +913,6 @@ describe('expression-interpreter', () => {
   });
 
   it('statement block expression evalutes correctly', () => {
-    const tuplePattern: TuplePattern = {
-      location: exampleLocation,
-      type: 'TuplePattern',
-      destructedNames: [{ name: SourceId('tuple'), type: SourceIntType(DummySourceReason) }],
-    };
-    const tuplePatternNull: TuplePattern = {
-      location: exampleLocation,
-      type: 'TuplePattern',
-      destructedNames: [{ type: SourceIntType(DummySourceReason) }],
-    };
-    const tupleType: SamlangTupleType = {
-      type: 'TupleType',
-      reason: DummySourceReason,
-      mappings: [SourceIntType(DummySourceReason)],
-    };
-    const tupleExpression: SamlangExpression = SourceExpressionTupleConstructor({
-      location: exampleLocation,
-      type: tupleType,
-      expressions: [intLiteralExpression],
-    });
-    const tupleStatement: SamlangValStatement = {
-      associatedComments: [],
-      pattern: tuplePattern,
-      location: exampleLocation,
-      typeAnnotation: SourceIntType(DummySourceReason),
-      assignedExpression: tupleExpression,
-    };
-    const tupleStatementNull: SamlangValStatement = {
-      associatedComments: [],
-      pattern: tuplePatternNull,
-      location: exampleLocation,
-      typeAnnotation: SourceIntType(DummySourceReason),
-      assignedExpression: tupleExpression,
-    };
     const objectDestructedNames: ObjectPatternDestucturedName = {
       fieldName: SourceId('test'),
       type: SourceIntType(DummySourceReason),
@@ -1113,13 +1036,7 @@ describe('expression-interpreter', () => {
     };
     const statementBlock: StatementBlock = {
       location: exampleLocation,
-      statements: [
-        tupleStatement,
-        tupleStatementNull,
-        objectStatement,
-        variableStatement,
-        wildCardStatement,
-      ],
+      statements: [objectStatement, variableStatement, wildCardStatement],
     };
     const statementBlockWithExpression: StatementBlock = {
       location: exampleLocation,

--- a/samlang-core/interpreter/expression-interpreter.ts
+++ b/samlang-core/interpreter/expression-interpreter.ts
@@ -30,11 +30,6 @@ export default class ExpressionInterpreter {
             .get(expression.className.name)
             ?.functions?.get(expression.memberName.name) ?? this.blameTypeChecker()
         );
-      case 'TupleConstructorExpression':
-        return {
-          type: 'tuple',
-          tupleContent: expression.expressions.map((e) => this.eval(e, context)),
-        };
       case 'FieldAccessExpression': {
         const thisValue = this.eval(expression.expression, context) as ObjectValue;
         return thisValue.objectContent?.get(expression.fieldName.name) ?? this.blameTypeChecker();
@@ -199,18 +194,6 @@ export default class ExpressionInterpreter {
           const assignedValue = this.eval(statement.assignedExpression, contextForStatementBlock);
           const p = statement.pattern;
           switch (p.type) {
-            case 'TuplePattern': {
-              const { tupleContent } = assignedValue as TupleValue;
-              p.destructedNames.forEach((nameWithLocation, i) => {
-                if (nameWithLocation.name != null) {
-                  contextForStatementBlock.localValues.set(
-                    nameWithLocation.name.name,
-                    checkNotNull(tupleContent[i])
-                  );
-                }
-              });
-              break;
-            }
             case 'ObjectPattern': {
               const { objectContent } = assignedValue as ObjectValue;
               p.destructedNames.forEach(({ fieldName, alias }) => {
@@ -351,18 +334,12 @@ export type Value =
   | number
   | string
   | boolean
-  | TupleValue
   | ObjectValue
   | VariantValue
   | FunctionValue;
 
 export type UnitValue = {
   readonly type: 'unit';
-};
-
-export type TupleValue = {
-  readonly type: 'tuple';
-  readonly tupleContent: Value[];
 };
 
 export type ObjectValue = {

--- a/samlang-core/parser/__tests__/index.test.ts
+++ b/samlang-core/parser/__tests__/index.test.ts
@@ -26,8 +26,6 @@ describe('samlang-core/parser', () => {
     expectASTWithTheSameKind('SomeClass.foo', 'ClassMemberExpression');
     expectASTWithTheSameKind('SomeClass.<A,B>foo', 'ClassMemberExpression');
     expectASTWithTheSameKind('SomeClass.<A>foo', 'ClassMemberExpression');
-    expectASTWithTheSameKind('[3, true]', 'TupleConstructorExpression');
-    expectASTWithTheSameKind('[3, true, "Ah"]', 'TupleConstructorExpression');
     expectASTWithTheSameKind('V.Variant({})', 'FunctionCallExpression');
     expectASTWithTheSameKind('V.Variant(3)', 'FunctionCallExpression');
     expectASTWithTheSameKind('V.<T>Variant(3)', 'FunctionCallExpression');
@@ -66,11 +64,6 @@ describe('samlang-core/parser', () => {
     expectASTWithTheSameKind('{ val a: int = 3; }', 'StatementBlockExpression');
     expectASTWithTheSameKind('{ val a: unit = {}; }', 'StatementBlockExpression');
     expectASTWithTheSameKind('{ val {foo, bar as baz}: Type = 3; }', 'StatementBlockExpression');
-    expectASTWithTheSameKind('{ val [foo, _, bar] = 3; }', 'StatementBlockExpression');
-    expectASTWithTheSameKind(
-      '{ val [foo, _, bar]: [int * bool] = 3; }',
-      'StatementBlockExpression'
-    );
     expectASTWithTheSameKind('{ val _: Int<bool> = 3; }', 'StatementBlockExpression');
     expectASTWithTheSameKind('{ val _: HAHAHA = 3; }', 'StatementBlockExpression');
     expectASTWithTheSameKind('{ val _: (int, bool) -> string = 3; }', 'StatementBlockExpression');

--- a/samlang-core/printer/__tests__/printer-source-level.test.ts
+++ b/samlang-core/printer/__tests__/printer-source-level.test.ts
@@ -68,56 +68,6 @@ ClassName
       'ClassName /* a */ /* b */ .classMember'
     );
 
-    expect(reprintExpression('[1,2,3,4,5,6,7,8,9]')).toBe('[1, 2, 3, 4, 5, 6, 7, 8, 9]');
-    expect(reprintExpression('// a\n[/* a*/ 1,// abc\n2,3]')).toBe(`// a
-[
-  /* a */ 1,
-  // abc
-  2,
-  3
-]`);
-    expect(reprintExpression('[1,2,3,4,5,6,7,8,9,10,11,12,13,14]')).toBe(
-      `[
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14
-]`
-    );
-    expect(
-      reprintExpression(
-        '[/* a */ 1, /* a */ 2, /* a */ 3, /* a */ 4, /* a */ 5, /* a */ 6, /* a */ 7, ' +
-          '/* a */ 8, /* a */ 9, /* a */ 10, /* a */ 11, /* a */ 12, /* a */ 13, /* a */ 14]'
-      )
-    ).toBe(
-      `[
-  /* a */ 1,
-  /* a */ 2,
-  /* a */ 3,
-  /* a */ 4,
-  /* a */ 5,
-  /* a */ 6,
-  /* a */ 7,
-  /* a */ 8,
-  /* a */ 9,
-  /* a */ 10,
-  /* a */ 11,
-  /* a */ 12,
-  /* a */ 13,
-  /* a */ 14
-]`
-    );
-
     expect(reprintExpression('Test.VariantName(42)')).toBe('Test.VariantName(42)');
     expect(reprintExpression('Test.<T>VariantName(42)')).toBe('Test.<T>VariantName(42)');
     expect(reprintExpression('/* a */ Test./* b */ <T>/* c */ VariantName(42)')).toBe(
@@ -252,9 +202,8 @@ Test /* b */ /* c */ .<T>VariantName(42)`
   val _ = 0;
 }`
     );
-    expect(reprintExpression('{ val a:int=1;val [b,_]:[int*int]=2; 3 }')).toBe(`{
+    expect(reprintExpression('{ val a:int=1; 3 }')).toBe(`{
   val a: int = 1;
-  val [b, _]: [int * int] = 2;
   3
 }`);
     expect(reprintExpression('{ val {a, b as c}: int = 3 }')).toBe(`{

--- a/samlang-core/printer/printer-prettier-library.ts
+++ b/samlang-core/printer/printer-prettier-library.ts
@@ -36,9 +36,6 @@ export const createCommaSeparatedList = <E>(
 export const createParenthesisSurroundedDocument = (document: PrettierDocument): PrettierDocument =>
   PRETTIER_NO_SPACE_BRACKET('(', document, ')');
 
-export const createBracketSurroundedDocument = (document: PrettierDocument): PrettierDocument =>
-  PRETTIER_NO_SPACE_BRACKET('[', document, ']');
-
 export const createBracesSurroundedDocument = (document: PrettierDocument): PrettierDocument =>
   PRETTIER_SPACED_BRACKET('{', document, '}');
 

--- a/samlang-core/printer/printer-source-level.ts
+++ b/samlang-core/printer/printer-source-level.ts
@@ -23,7 +23,6 @@ import {
 import {
   createBracesSurroundedBlockDocument,
   createBracesSurroundedDocument,
-  createBracketSurroundedDocument,
   createCommaSeparatedList,
   createParenthesisSurroundedDocument,
 } from './printer-prettier-library';
@@ -129,13 +128,6 @@ function createPrettierDocumentFromSamlangExpression(
           optionalTypeArguments(expression.typeArguments) + expression.memberName.name
         );
       }
-      case 'TupleConstructorExpression':
-        return createBracketSurroundedDocument(
-          createCommaSeparatedList(
-            expression.expressions,
-            createPrettierDocumentFromSamlangExpression
-          )
-        );
       case 'FieldAccessExpression':
         return createDocumentDottedExpression(
           createDocumentForSubExpressionConsideringPrecedenceLevel(expression.expression),
@@ -241,13 +233,6 @@ function createPrettierDocumentFromSamlangExpression(
           .map(({ pattern, typeAnnotation, assignedExpression, associatedComments }) => {
             let patternDocument: PrettierDocument;
             switch (pattern.type) {
-              case 'TuplePattern':
-                patternDocument = createBracketSurroundedDocument(
-                  createCommaSeparatedList(pattern.destructedNames, (it) =>
-                    PRETTIER_TEXT(it.name?.name ?? '_')
-                  )
-                );
-                break;
               case 'ObjectPattern':
                 patternDocument = createBracesSurroundedDocument(
                   createCommaSeparatedList(pattern.destructedNames, (it) =>

--- a/samlang-core/services/__tests__/api.test.ts
+++ b/samlang-core/services/__tests__/api.test.ts
@@ -261,7 +261,7 @@ class Test2(val a: int) {
     const moduleReference2 = ModuleReference(['Test2']);
     const moduleReference3 = ModuleReference(['Test3']);
     const service = createSamlangLanguageService([
-      [moduleReference3, 'class ABC { function a(): unit = { val _ = [1,2]; } }'],
+      [moduleReference3, 'class ABC { function a(): unit = { val _ = 1; } }'],
       [moduleReference2, 'class TTT { method test(): int = this.test() }'],
       [
         moduleReference1,
@@ -276,6 +276,7 @@ class Test1(val a: int) {
     val _ = {
       val b = 3;
       val _ = b + 2;
+      val _ = c;
     }
   }
 }
@@ -283,7 +284,7 @@ class Test1(val a: int) {
       ],
     ]);
 
-    expect(service.state.allModulesWithError.map((it) => it.toString())).toEqual([]);
+    expect(service.state.allModulesWithError.map((it) => it.toString())).toEqual(['Test1']);
 
     expect(service.queryDefinitionLocation(moduleReference1, Position(100, 100))).toBeNull();
     expect(service.queryDefinitionLocation(moduleReference1, Position(4, 46))).toBeNull();
@@ -292,7 +293,7 @@ class Test1(val a: int) {
 
     const actualLocation0 = service.queryDefinitionLocation(moduleReference1, Position(4, 34));
     expect(actualLocation0?.toString()).toEqual(
-      new Location(moduleReference1, Position(2, 0), Position(13, 1)).toString()
+      new Location(moduleReference1, Position(2, 0), Position(14, 1)).toString()
     );
 
     const actualLocation1 = service.queryDefinitionLocation(moduleReference1, Position(4, 40));
@@ -312,12 +313,12 @@ class Test1(val a: int) {
 
     const actualLocation3 = service.queryDefinitionLocation(moduleReference1, Position(5, 30));
     expect(actualLocation3?.toString()).toEqual(
-      new Location(moduleReference3, Position(0, 0), Position(0, 53)).toString()
+      new Location(moduleReference3, Position(0, 0), Position(0, 49)).toString()
     );
 
     const actualLocation4 = service.queryDefinitionLocation(moduleReference1, Position(6, 28));
     expect(actualLocation4?.toString()).toEqual(
-      new Location(moduleReference1, Position(2, 0), Position(13, 1)).toString()
+      new Location(moduleReference1, Position(2, 0), Position(14, 1)).toString()
     );
 
     expect(service.queryDefinitionLocation(moduleReference1, Position(6, 35))).toBeNull();
@@ -331,6 +332,8 @@ class Test1(val a: int) {
     expect(actualLocation6?.toString()).toEqual(
       new Location(moduleReference1, Position(9, 10), Position(9, 11)).toString()
     );
+    const actualLocation7 = service.queryDefinitionLocation(moduleReference1, Position(11, 15));
+    expect(actualLocation7).toBeNull();
   });
 
   it('LanguageServices.queryDefinitionLocation test 2', () => {
@@ -357,11 +360,12 @@ class Test1(val a: int) {
       [
         testModuleReference,
         `
-class List<T>(Nil(unit), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B) {}
+class List<T>(Nil(unit), Cons(Pair<T, List<T>>)) {
   function <T> of(t: T): List<T> =
-    Cons([t, Nil({})])
+    Cons(Pair.init(t, Nil({})))
   method cons(t: T): List<T> =
-    Cons([t, this])
+    Cons(Pair.init(t, this))
 }
 class Developer(
   val name: string, val github: string,
@@ -382,13 +386,14 @@ class Main {
     expect(
       service.queryFoldingRanges(testModuleReference)?.map((loc) => loc.toString())
     ).toMatchObject([
-      new Location(testModuleReference, Position(2, 2), Position(3, 22)).toString(),
-      new Location(testModuleReference, Position(4, 2), Position(5, 19)).toString(),
-      new Location(testModuleReference, Position(1, 0), Position(6, 1)).toString(),
-      new Location(testModuleReference, Position(11, 2), Position(15, 3)).toString(),
-      new Location(testModuleReference, Position(7, 0), Position(16, 1)).toString(),
-      new Location(testModuleReference, Position(18, 2), Position(18, 46)).toString(),
-      new Location(testModuleReference, Position(17, 0), Position(19, 1)).toString(),
+      new Location(testModuleReference, Position(1, 0), Position(1, 39)).toString(),
+      new Location(testModuleReference, Position(3, 2), Position(4, 31)).toString(),
+      new Location(testModuleReference, Position(5, 2), Position(6, 28)).toString(),
+      new Location(testModuleReference, Position(2, 0), Position(7, 1)).toString(),
+      new Location(testModuleReference, Position(12, 2), Position(16, 3)).toString(),
+      new Location(testModuleReference, Position(8, 0), Position(17, 1)).toString(),
+      new Location(testModuleReference, Position(19, 2), Position(19, 46)).toString(),
+      new Location(testModuleReference, Position(18, 0), Position(20, 1)).toString(),
     ]);
     expect(service.queryFoldingRanges(ModuleReference(['dsafadfasd']))).toBe(null);
   });
@@ -399,11 +404,12 @@ class Main {
       [
         testModuleReference,
         `
-class List<T>(Nil(unit), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B) {}
+class List<T>(Nil(unit), Cons(Pair<T, List<T>>)) {
   function <T> of(t: T): List<T> =
-    Cons([t, Nil({})])
+    Cons(Pair.init(t, Nil({})))
   method cons(t: T): List<T> =
-    Cons([t, this])
+    Cons(Pair.init(t, this))
 }
 class Developer(
   val name: string, val github: string,
@@ -421,8 +427,8 @@ class Main {
 `,
       ],
     ]);
-    expect(service.autoComplete(testModuleReference, Position(3, 5))).toEqual([]);
-    expect(service.autoComplete(testModuleReference, Position(12, 17))).toEqual([
+    expect(service.autoComplete(testModuleReference, Position(4, 5))).toEqual([]);
+    expect(service.autoComplete(testModuleReference, Position(13, 17))).toEqual([
       {
         insertTextFormat: InsertTextFormats.Snippet,
         kind: CompletionItemKinds.FUNCTION,
@@ -440,12 +446,12 @@ class Main {
       {
         insertTextFormat: InsertTextFormats.Snippet,
         kind: CompletionItemKinds.FUNCTION,
-        detail: '<_T0>(([_T0 * List<_T0>]) -> List<_T0>)',
+        detail: '<_T0>((Pair<_T0, List<_T0>>) -> List<_T0>)',
         insertText: 'Cons($0)$1',
-        label: 'Cons(a0: [_T0 * List<_T0>]): List<_T0>',
+        label: 'Cons(a0: Pair<_T0, List<_T0>>): List<_T0>',
       },
     ]);
-    expect(service.autoComplete(testModuleReference, Position(12, 31))).toEqual([
+    expect(service.autoComplete(testModuleReference, Position(13, 31))).toEqual([
       {
         insertTextFormat: InsertTextFormats.Snippet,
         kind: CompletionItemKinds.METHOD,
@@ -454,7 +460,7 @@ class Main {
         detail: '(T) -> List<T>',
       },
     ]);
-    expect(service.autoComplete(testModuleReference, Position(14, 46))).toEqual([
+    expect(service.autoComplete(testModuleReference, Position(15, 46))).toEqual([
       {
         insertTextFormat: InsertTextFormats.PlainText,
         kind: CompletionItemKinds.FIELD,
@@ -477,7 +483,7 @@ class Main {
         detail: 'List<string>',
       },
     ]);
-    expect(service.autoComplete(testModuleReference, Position(18, 41))).toEqual([
+    expect(service.autoComplete(testModuleReference, Position(19, 41))).toEqual([
       {
         insertTextFormat: InsertTextFormats.PlainText,
         kind: CompletionItemKinds.FUNCTION,
@@ -501,12 +507,12 @@ class Main {
       [
         testModuleReference,
         `
-class List<T>(Nil(unit), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B) {}
+class List<T>(Nil(unit), Cons(Pair<T, List<T>>)) {
   function <T> of(t: T): List<T> =
-    Cons([t, Nil({})])
+    Cons(Pair.init(t, Nil({})))
   method cons(t: T): List<T> =
-    Cons([t, this])
-  private test(): unit = {}
+    Cons(Pair.init(t, this))
 }
 class Developer(
   val name: string, val github: string,
@@ -515,7 +521,7 @@ class Developer(
   function sam(): Developer = {
     val l = List.of("SAMLANG").cons("...")
     val github = "SamChou19815"
-    { name: "Sam Zhou", github, projects: l }.
+    Developer.init("Sam Zhou", github, l).
   }
 }
 class Main {
@@ -525,13 +531,27 @@ class Main {
       ],
     ]);
 
-    expect(service.autoComplete(testModuleReference, Position(13, 31))).toEqual([
+    expect(service.autoComplete(testModuleReference, Position(15, 43))).toEqual([
       {
-        insertTextFormat: InsertTextFormats.Snippet,
-        kind: CompletionItemKinds.METHOD,
-        label: 'cons(a0: T): List<T>',
-        insertText: 'cons($0)$1',
-        detail: '(T) -> List<T>',
+        insertTextFormat: InsertTextFormats.PlainText,
+        kind: CompletionItemKinds.FIELD,
+        label: 'name',
+        insertText: 'name',
+        detail: 'string',
+      },
+      {
+        insertTextFormat: InsertTextFormats.PlainText,
+        kind: CompletionItemKinds.FIELD,
+        label: 'github',
+        insertText: 'github',
+        detail: 'string',
+      },
+      {
+        insertTextFormat: InsertTextFormats.PlainText,
+        kind: CompletionItemKinds.FIELD,
+        label: 'projects',
+        insertText: 'projects',
+        detail: 'List<string>',
       },
     ]);
   });

--- a/samlang-core/services/__tests__/location-service.test.ts
+++ b/samlang-core/services/__tests__/location-service.test.ts
@@ -60,7 +60,7 @@ describe('location-service', () => {
     function valExample(): int = {
       val a: int = 1;
       val b = 2;
-      val [_, c] = ["dd", 3]; // c = 3
+      val c = 3; // c = 3
       val { e as d } = Obj.init(5, 4); // d = 4
       val f = Obj.init(5, 4); // d = 4
       val g = Obj.init(d, 4); // d = 4
@@ -96,7 +96,6 @@ describe('location-service', () => {
         }; // c = 4
         c
       }; // 4
-      val [e, b, _] = [1, "bool", true];
       a + 1 // 5
     }
 

--- a/samlang-core/services/__tests__/variable-definition-service.test.ts
+++ b/samlang-core/services/__tests__/variable-definition-service.test.ts
@@ -55,7 +55,6 @@ class Main {
 class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val {f, g as h} = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -83,34 +82,28 @@ class Main {
       uses: [],
     });
     expect(
-      query(lookup, new Location(ModuleReference.DUMMY, Position(4, 9), Position(4, 10)))
+      query(lookup, new Location(ModuleReference.DUMMY, Position(7, 12), Position(7, 13)))
     ).toEqual({
-      definition: '5:10-5:11',
-      uses: [],
+      definition: '6:10-6:11',
+      uses: ['8:13-8:14', '9:59-9:60'],
     });
     expect(
-      query(lookup, new Location(ModuleReference.DUMMY, Position(8, 12), Position(8, 13)))
+      query(lookup, new Location(ModuleReference.DUMMY, Position(7, 16), Position(7, 17)))
     ).toEqual({
-      definition: '7:10-7:11',
-      uses: ['9:13-9:14', '10:59-10:60'],
+      definition: '6:18-6:19',
+      uses: ['7:24-7:25', '8:17-8:18', '9:45-9:46', '9:75-9:76', '10:24-10:25'],
     });
     expect(
-      query(lookup, new Location(ModuleReference.DUMMY, Position(8, 16), Position(8, 17)))
+      query(lookup, new Location(ModuleReference.DUMMY, Position(8, 22), Position(8, 23)))
     ).toEqual({
-      definition: '7:18-7:19',
-      uses: ['8:24-8:25', '9:17-9:18', '10:45-10:46', '10:75-10:76', '11:24-11:25'],
+      definition: '9:23-9:24',
+      uses: ['9:37-9:38'],
     });
     expect(
-      query(lookup, new Location(ModuleReference.DUMMY, Position(9, 22), Position(9, 23)))
+      query(lookup, new Location(ModuleReference.DUMMY, Position(11, 19), Position(11, 21)))
     ).toEqual({
-      definition: '10:23-10:24',
-      uses: ['10:37-10:38'],
-    });
-    expect(
-      query(lookup, new Location(ModuleReference.DUMMY, Position(12, 19), Position(12, 21)))
-    ).toEqual({
-      definition: '13:14-13:16',
-      uses: ['13:20-13:22'],
+      definition: '12:14-12:16',
+      uses: ['12:20-12:22'],
     });
   });
 
@@ -122,7 +115,6 @@ class Main {
 class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val {f, g as h} = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -170,7 +162,6 @@ class Main {
       `class Main {
   function test(renAmeD: int, b: bool): unit = {
     val c = renAmeD;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f, g as h } = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -191,7 +182,6 @@ class Main {
       `class Main {
   function test(a: int, b: bool): unit = {
     val renAmeD = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f, g as h } = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -208,53 +198,10 @@ class Main {
 `
     );
     assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(4, 9), Position(4, 10)),
+      new Location(ModuleReference(['Test']), Position(5, 35), Position(5, 36)),
       `class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [renAmeD, _] = [b, 2];
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if (x + y * 3 > h) then panic(
-      f
-    ) else println(h);
-    match (lambda1(3, !h)) {
-      | None _ -> 1.d
-      | Some dd -> dd
-    }
-  }
-}
-`
-    );
-    assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(4, 18), Position(4, 19)),
-      `class Main {
-  function test(a: int, renAmeD: bool): unit = {
-    val c = a;
-    val [e, _] = [renAmeD, 2];
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if (x + y * 3 > h) then panic(
-      f
-    ) else println(h);
-    match (lambda1(3, !h)) {
-      | None _ -> 1.d
-      | Some dd -> dd
-    }
-  }
-}
-`
-    );
-    assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(6, 35), Position(6, 36)),
-      `class Main {
-  function test(a: int, b: bool): unit = {
-    val c = a;
-    val [e, _] = [b, 2];
     val renAmeD = 3;
     val { f, g as h } = Main.init(3, renAmeD);
     val _ = Obj.Tagged(h);
@@ -271,11 +218,10 @@ class Main {
 `
     );
     assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(8, 12), Position(8, 13)),
+      new Location(ModuleReference(['Test']), Position(7, 12), Position(7, 13)),
       `class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f as renAmeD, g as h } = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -292,11 +238,10 @@ class Main {
 `
     );
     assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(8, 16), Position(8, 17)),
+      new Location(ModuleReference(['Test']), Position(7, 16), Position(7, 17)),
       `class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f, g as renAmeD } = Main.init(3, g);
     val _ = Obj.Tagged(renAmeD);
@@ -313,11 +258,10 @@ class Main {
 `
     );
     assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(9, 22), Position(9, 23)),
+      new Location(ModuleReference(['Test']), Position(8, 22), Position(8, 23)),
       `class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f, g as h } = Main.init(3, g);
     val _ = Obj.Tagged(h);
@@ -334,11 +278,10 @@ class Main {
 `
     );
     assertCorrectlyRewritten(
-      new Location(ModuleReference(['Test']), Position(12, 19), Position(12, 21)),
+      new Location(ModuleReference(['Test']), Position(11, 19), Position(11, 21)),
       `class Main {
   function test(a: int, b: bool): unit = {
     val c = a;
-    val [e, _] = [b, 2];
     val g = 3;
     val { f, g as h } = Main.init(3, g);
     val _ = Obj.Tagged(h);

--- a/samlang-core/services/api.ts
+++ b/samlang-core/services/api.ts
@@ -322,7 +322,6 @@ class LanguageServicesImpl implements LanguageServices {
     switch (expression.__type__) {
       case 'LiteralExpression':
       case 'ThisExpression':
-      case 'TupleConstructorExpression':
         return null;
       case 'VariableExpression': {
         if (

--- a/samlang-core/services/location-service.ts
+++ b/samlang-core/services/location-service.ts
@@ -130,10 +130,6 @@ export class SamlangExpressionLocationLookupBuilder {
         this.buildSingleExpression(expression);
         return;
       }
-      case 'TupleConstructorExpression':
-        expression.expressions.forEach((it) => this.buildRecursively(it));
-        this.buildSingleExpression(expression);
-        return;
       case 'FieldAccessExpression':
       case 'MethodAccessExpression':
       case 'UnaryExpression':
@@ -170,14 +166,6 @@ export class SamlangExpressionLocationLookupBuilder {
           this.buildRecursively(assignedExpression);
           const assignedExpressionType = assignedExpression.type;
           switch (pattern.type) {
-            case 'TuplePattern': {
-              pattern.destructedNames.forEach(({ name, type }) => {
-                if (name != null) {
-                  this.buildSingleExpression(SourceExpressionVariable({ ...name, type }));
-                }
-              });
-              return;
-            }
             case 'ObjectPattern':
               return;
             case 'VariablePattern':

--- a/samlang-core/services/variable-definition-service.ts
+++ b/samlang-core/services/variable-definition-service.ts
@@ -51,11 +51,6 @@ export class ModuleScopedVariableDefinitionLookup {
       case 'VariableExpression':
         this.addDefinitionAndUse(manager.getLocalValueType(expression.name), expression.location);
         return;
-      case 'TupleConstructorExpression':
-        expression.expressions.map((it) =>
-          this.collectDefinitionAndUseWithDefinitionManager(it, manager)
-        );
-        return;
       case 'FieldAccessExpression':
       case 'MethodAccessExpression':
       case 'UnaryExpression':
@@ -102,11 +97,6 @@ export class ModuleScopedVariableDefinitionLookup {
           statements.forEach(({ pattern, assignedExpression }) => {
             this.collectDefinitionAndUseWithDefinitionManager(assignedExpression, manager);
             switch (pattern.type) {
-              case 'TuplePattern':
-                pattern.destructedNames.forEach(({ name }) => {
-                  if (name != null) this.defineVariable(name.name, name.location, manager);
-                });
-                return;
               case 'ObjectPattern':
                 pattern.destructedNames.forEach((name) => {
                   if (name.alias == null) {
@@ -192,13 +182,6 @@ function applyExpressionRenamingWithDefinitionAndUse(
   switch (expression.__type__) {
     case 'VariableExpression':
       return { ...expression, name: newName };
-    case 'TupleConstructorExpression':
-      return {
-        ...expression,
-        expressions: expression.expressions.map((it) =>
-          applyExpressionRenamingWithDefinitionAndUse(it, definitionAndUses, newName)
-        ),
-      };
     case 'FieldAccessExpression':
     case 'MethodAccessExpression':
     case 'UnaryExpression':
@@ -303,21 +286,6 @@ function applyExpressionRenamingWithDefinitionAndUse(
             );
             let pattern: Pattern;
             switch (statement.pattern.type) {
-              case 'TuplePattern':
-                pattern = {
-                  ...statement.pattern,
-                  destructedNames: statement.pattern.destructedNames.map(({ name, type }) => ({
-                    name:
-                      name == null
-                        ? undefined
-                        : name.location.toString() ===
-                          definitionAndUses.definitionLocation.toString()
-                        ? { ...name, name: newName }
-                        : name,
-                    type,
-                  })),
-                };
-                break;
               case 'ObjectPattern':
                 pattern = {
                   ...statement.pattern,

--- a/samlang-core/test-programs.ts
+++ b/samlang-core/test-programs.ts
@@ -322,11 +322,12 @@ class Main {
   {
     testName: 'sam-in-samlang-list',
     sourceCode: `
-class List<T>(Nil(unit), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B) {}
+class List<T>(Nil(unit), Cons(Pair<T, List<T>>)) {
   function <T> of(t: T): List<T> =
-    List.Cons([t, List.Nil({})])
+    List.Cons(Pair.init(t, List.Nil({})))
   method cons(t: T): List<T> =
-    List.Cons([t, this])
+    List.Cons(Pair.init(t, this))
 }
 class Developer(
   val name: string, val github: string,
@@ -599,7 +600,9 @@ class Main {
     testCaseName: 'CreateVariants',
     expectedStandardOut: 'hello\n',
     sourceCode: `
-class List(Nil(unit), Cons([int * List])) { function of(i: int): List = List.Cons([i, List.Nil({  })])  }
+class Pair<A, B>(val a: A, val b: B) {}
+
+class List(Nil(unit), Cons(Pair<int, List>)) { function of(i: int): List = List.Cons(Pair.init(i, List.Nil({  })))  }
 
 class Main { function main(): unit = { val _: List = List.of(1); Builtins.println("hello") }  }
 `,
@@ -853,7 +856,7 @@ class Obj(private val d: int, val e: int) {
   function valExample(): int = {
     val a: int = 1;
     val b = 2;
-    val [_, c] = ["dd", 3]; // c = 3
+    val c = 3;
     val { e as d } = Obj.init(5, 4); // d = 4
     val _ = 42;
     // 1 + 2 * 3 / 4 = 1 + 6/4 = 1 + 1 = 2
@@ -887,7 +890,6 @@ class Main {
       }; // c = 4
       c
     }; // 4
-    val [e, b, _] = [1, "bool", true];
     a + 1 // 5
   }
 
@@ -1168,7 +1170,7 @@ class Main(val a: int, val b: bool) {
     val c = a - 3;
     val d = c * 7
     val b = true;
-    val [_, e] = [a, c]
+    val e = c;
     val _ = Main.init(e, b)
     val finalValue = a + c + d + (if (b) then 0 else Builtins.panic("")) + e; // 2 + (-1) + (-7) + (-1) = -7
     Builtins.println(Builtins.intToString(finalValue))
@@ -1390,11 +1392,13 @@ class Option<T>(Some(T), None(bool)) {
   }
 }
 
-class List<T>(Nil(bool), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B) {}
+
+class List<T>(Nil(bool), Cons(Pair<T, List<T>>)) {
   function <T> of(t: T): List<T> =
-    List.Cons([t, List.Nil(true)])
+    List.Cons(Pair.init(t, List.Nil(true)))
   method cons(t: T): List<T> =
-    List.Cons([t, this])
+    List.Cons(Pair.init(t, this))
 }
 
 class Main {

--- a/tests/DifferentExpressionDemo.sam
+++ b/tests/DifferentExpressionDemo.sam
@@ -8,7 +8,7 @@ class Obj(val d: int, val e: int) {
   function valExample(): int = {
     val a: int = 1;
     val b: int = 2;
-    val [_, c]: [string * int] = ["dd", 3];
+    val c = 3;
     val { e as d }: Obj = Obj.init(5, 4);
     val _: int = 42;
     a + b * c / d
@@ -62,7 +62,6 @@ class DifferentExpressionDemo {
       };
       c
     };
-    val [e, b, _]: [int * string * bool] = [1, "bool", true];
     a + 1
   }
 

--- a/tests/StdLib.sam
+++ b/tests/StdLib.sam
@@ -1,24 +1,26 @@
-class List<T>(Nil(unit), Cons([T * List<T>])) {
+class Pair<A, B>(val a: A, val b: B)
+
+class List<T>(Nil(unit), Cons(Pair<T, List<T>>)) {
   function <T> nil(): List<T> = List.Nil({  })
 
-  function <T> of(t: T): List<T> = List.Cons([t, List.Nil({  })])
+  function <T> of(t: T): List<T> = List.Cons(Pair.init(t, List.Nil({  })))
 
-  method cons(t: T): List<T> = List.Cons([t, this])
+  method cons(t: T): List<T> = List.Cons(Pair.init(t, this))
 
   method <R> map(f: (T) -> R): List<R> =
     match (this) {
       | Nil _ -> List.Nil({  })
-      | Cons tuple -> {
-        val [v, rest] = tuple;
-        List.Cons([f(v), rest.map(f)])
+      | Cons pair -> {
+        val {a as v, b as rest} = pair;
+        List.Cons(Pair.init(f(v), rest.map(f)))
       }
     }
 
   method iter(f: (T) -> unit): unit =
     match (this) {
       | Nil _ -> {  }
-      | Cons tuple -> {
-        val [v, rest] = tuple;
+      | Cons pair -> {
+        val {a as v, b as rest} = pair;
         val _ = f(v);
         rest.iter(f)
       }
@@ -27,9 +29,9 @@ class List<T>(Nil(unit), Cons([T * List<T>])) {
   private method reverseWithAccumulator(acc: List<T>): List<T> =
     match (this) {
       | Nil _ -> acc
-      | Cons tuple -> {
-        val [v, rest] = tuple;
-        rest.reverseWithAccumulator(List.Cons([v, acc]))
+      | Cons pair -> {
+        val {a as v, b as rest} = pair;
+        rest.reverseWithAccumulator(List.Cons(Pair.init(v, acc)))
       }
     }
 


### PR DESCRIPTION
Tuples are structurally typed and it's an annoyance to work with. It's much easier to provide tuple types in standard library like Pair and Triple like what kotlin does.

## Summary

Title

## Test Plan

```
pnpm test
pnpm test:integration
```
