### PR TITLE
[checker] Completely encapsulate unoptimized global context details

### DIFF
--- a/samlang-core/checker/__tests__/expression-type-checker.test.ts
+++ b/samlang-core/checker/__tests__/expression-type-checker.test.ts
@@ -65,7 +65,6 @@ function typeCheckInSandbox(
                       bar: { isPublic: false, type: int },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [
@@ -134,7 +133,6 @@ function typeCheckInSandbox(
                       Bar: { isPublic: true, type: int },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [
@@ -181,7 +179,6 @@ function typeCheckInSandbox(
                       bar: { isPublic: false, type: int },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map(),
                   methods: new Map(),
@@ -203,7 +200,6 @@ function typeCheckInSandbox(
                       Bar: { isPublic: true, type: int },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [
@@ -251,7 +247,6 @@ function typeCheckInSandbox(
                       b: { isPublic: false, type: bool },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [
@@ -283,7 +278,6 @@ function typeCheckInSandbox(
                       b: { isPublic: false, type: bool },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [
@@ -315,7 +309,6 @@ function typeCheckInSandbox(
                       b: { isPublic: true, type: bool },
                     },
                   },
-                  extendsOrImplements: null,
                   superTypes: [],
                   functions: new Map([
                     [

--- a/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
+++ b/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
@@ -4,7 +4,12 @@ import {
   ModuleReference,
   ModuleReferenceCollections,
 } from '../../ast/common-nodes';
-import type { SamlangModule, SourceClassDefinition } from '../../ast/samlang-nodes';
+import type {
+  SamlangModule,
+  SourceClassDefinition,
+  TypeDefinition,
+  TypeParameterSignature,
+} from '../../ast/samlang-nodes';
 import {
   prettyPrintType,
   SamlangIdentifierType,
@@ -19,7 +24,8 @@ import {
   buildGlobalTypingContext,
   getFullyInlinedInterfaceContext,
 } from '../global-typing-context-builder';
-import { GlobalTypingContext, memberTypeInformationToString } from '../typing-context';
+import type { MemberTypeInformation } from '../typing-context';
+import { memberTypeInformationToString } from '../typing-context';
 
 const module0Reference = ModuleReference(['Module0']);
 const module1Reference = ModuleReference(['Module1']);
@@ -118,7 +124,6 @@ describe('global-typing-context-builder', () => {
           {
             typeParameters: [],
             typeDefinition,
-            extendsOrImplements: null,
             superTypes: [],
             functions: new Map([
               [
@@ -147,7 +152,6 @@ describe('global-typing-context-builder', () => {
           {
             typeParameters: [],
             typeDefinition,
-            extendsOrImplements: null,
             superTypes: [],
             functions: new Map([
               [
@@ -188,7 +192,6 @@ describe('global-typing-context-builder', () => {
           {
             typeParameters: [],
             typeDefinition,
-            extendsOrImplements: null,
             superTypes: [],
             functions: new Map([
               [
@@ -212,162 +215,173 @@ describe('global-typing-context-builder', () => {
   });
 
   it('getFullyInlinedInterfaceContext tests', () => {
-    const globalTypingContext: GlobalTypingContext = ModuleReferenceCollections.hashMapOf([
-      ModuleReference.DUMMY,
-      {
-        interfaces: new Map([
-          [
-            'IUseNonExistent',
-            {
-              typeParameters: [
-                { name: 'A', bound: null },
-                { name: 'B', bound: null },
-              ],
-              extendsOrImplements: SourceIdentifierType(
-                DummySourceReason,
-                ModuleReference.DUMMY,
-                'not_exist',
-              ),
-              superTypes: [],
-              functions: new Map(),
-              methods: new Map(),
-            },
-          ],
-          [
-            'IBase',
-            {
-              typeParameters: [
-                { name: 'A', bound: null },
-                { name: 'B', bound: null },
-              ],
-              extendsOrImplements: null,
-              superTypes: [],
-              functions: new Map(),
-              methods: new Map([
-                [
-                  'm1',
-                  {
-                    isPublic: true,
-                    typeParameters: [{ name: 'C', bound: null }],
-                    type: SourceFunctionType(
-                      DummySourceReason,
-                      [
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
-                      ],
-                      SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
-                    ),
-                  },
+    interface UnoptimizedInterfaceTypingContext {
+      readonly functions: ReadonlyMap<string, MemberTypeInformation>;
+      readonly methods: ReadonlyMap<string, MemberTypeInformation>;
+      readonly typeParameters: readonly TypeParameterSignature[];
+      readonly extendsOrImplements: SamlangIdentifierType | null;
+    }
+
+    interface UnoptimizedClassTypingContext extends UnoptimizedInterfaceTypingContext {
+      readonly typeDefinition: TypeDefinition;
+    }
+
+    interface UnoptimizedModuleTypingContext {
+      readonly interfaces: ReadonlyMap<string, UnoptimizedInterfaceTypingContext>;
+      readonly classes: ReadonlyMap<string, UnoptimizedClassTypingContext>;
+    }
+
+    const globalTypingContext =
+      ModuleReferenceCollections.hashMapOf<UnoptimizedModuleTypingContext>([
+        ModuleReference.DUMMY,
+        {
+          interfaces: new Map([
+            [
+              'IUseNonExistent',
+              {
+                typeParameters: [
+                  { name: 'A', bound: null },
+                  { name: 'B', bound: null },
                 ],
-              ]),
-            },
-          ],
-          [
-            'ILevel1',
-            {
-              typeParameters: [
-                { name: 'A', bound: null },
-                { name: 'B', bound: null },
-              ],
-              extendsOrImplements: SourceIdentifierType(
-                DummySourceReason,
-                ModuleReference.DUMMY,
-                'IBase',
-                [
-                  SourceIntType(DummySourceReason),
-                  SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
+                extendsOrImplements: SourceIdentifierType(
+                  DummySourceReason,
+                  ModuleReference.DUMMY,
+                  'not_exist',
+                ),
+                functions: new Map(),
+                methods: new Map(),
+              },
+            ],
+            [
+              'IBase',
+              {
+                typeParameters: [
+                  { name: 'A', bound: null },
+                  { name: 'B', bound: null },
                 ],
-              ),
-              superTypes: [],
-              functions: new Map([
-                [
-                  'f1',
-                  {
-                    isPublic: true,
-                    typeParameters: [{ name: 'C', bound: null }],
-                    type: SourceFunctionType(
-                      DummySourceReason,
-                      [
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
-                      ],
-                      SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
-                    ),
-                  },
+                extendsOrImplements: null,
+                functions: new Map(),
+                methods: new Map([
+                  [
+                    'm1',
+                    {
+                      isPublic: true,
+                      typeParameters: [{ name: 'C', bound: null }],
+                      type: SourceFunctionType(
+                        DummySourceReason,
+                        [
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
+                        ],
+                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
+                      ),
+                    },
+                  ],
+                ]),
+              },
+            ],
+            [
+              'ILevel1',
+              {
+                typeParameters: [
+                  { name: 'A', bound: null },
+                  { name: 'B', bound: null },
                 ],
-              ]),
-              methods: new Map(),
-            },
-          ],
-          [
-            'ILevel2',
-            {
-              typeParameters: [
-                { name: 'A', bound: null },
-                { name: 'B', bound: null },
-              ],
-              extendsOrImplements: SourceIdentifierType(
-                DummySourceReason,
-                ModuleReference.DUMMY,
-                'ILevel1',
-                [
-                  SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
-                  SourceIntType(DummySourceReason),
+                extendsOrImplements: SourceIdentifierType(
+                  DummySourceReason,
+                  ModuleReference.DUMMY,
+                  'IBase',
+                  [
+                    SourceIntType(DummySourceReason),
+                    SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
+                  ],
+                ),
+                functions: new Map([
+                  [
+                    'f1',
+                    {
+                      isPublic: true,
+                      typeParameters: [{ name: 'C', bound: null }],
+                      type: SourceFunctionType(
+                        DummySourceReason,
+                        [
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
+                        ],
+                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
+                      ),
+                    },
+                  ],
+                ]),
+                methods: new Map(),
+              },
+            ],
+            [
+              'ILevel2',
+              {
+                typeParameters: [
+                  { name: 'A', bound: null },
+                  { name: 'B', bound: null },
                 ],
-              ),
-              superTypes: [],
-              functions: new Map(),
-              methods: new Map([
-                [
-                  'm2',
-                  {
-                    isPublic: true,
-                    typeParameters: [{ name: 'C', bound: null }],
-                    type: SourceFunctionType(
-                      DummySourceReason,
-                      [
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
-                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
-                      ],
-                      SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
-                    ),
-                  },
-                ],
-              ]),
-            },
-          ],
-          [
-            'ICyclic1',
-            {
-              typeParameters: [],
-              extendsOrImplements: SourceIdentifierType(
-                DummySourceReason,
-                ModuleReference.DUMMY,
-                'ICyclic2',
-              ),
-              superTypes: [],
-              functions: new Map(),
-              methods: new Map(),
-            },
-          ],
-          [
-            'ICyclic2',
-            {
-              typeParameters: [],
-              extendsOrImplements: SourceIdentifierType(
-                DummySourceReason,
-                ModuleReference.DUMMY,
-                'ICyclic1',
-              ),
-              superTypes: [],
-              functions: new Map(),
-              methods: new Map(),
-            },
-          ],
-        ]),
-        classes: new Map(),
-      },
-    ]);
+                extendsOrImplements: SourceIdentifierType(
+                  DummySourceReason,
+                  ModuleReference.DUMMY,
+                  'ILevel1',
+                  [
+                    SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
+                    SourceIntType(DummySourceReason),
+                  ],
+                ),
+                functions: new Map(),
+                methods: new Map([
+                  [
+                    'm2',
+                    {
+                      isPublic: true,
+                      typeParameters: [{ name: 'C', bound: null }],
+                      type: SourceFunctionType(
+                        DummySourceReason,
+                        [
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'A'),
+                          SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'B'),
+                        ],
+                        SourceIdentifierType(DummySourceReason, ModuleReference.DUMMY, 'C'),
+                      ),
+                    },
+                  ],
+                ]),
+              },
+            ],
+            [
+              'ICyclic1',
+              {
+                typeParameters: [],
+                extendsOrImplements: SourceIdentifierType(
+                  DummySourceReason,
+                  ModuleReference.DUMMY,
+                  'ICyclic2',
+                ),
+                functions: new Map(),
+                methods: new Map(),
+              },
+            ],
+            [
+              'ICyclic2',
+              {
+                typeParameters: [],
+                extendsOrImplements: SourceIdentifierType(
+                  DummySourceReason,
+                  ModuleReference.DUMMY,
+                  'ICyclic1',
+                ),
+                functions: new Map(),
+                methods: new Map(),
+              },
+            ],
+          ]),
+          classes: new Map(),
+        },
+      ]);
 
     function inlinedContextFromType(idType: SamlangIdentifierType) {
       const { functions, methods, superTypes } = getFullyInlinedInterfaceContext(

--- a/samlang-core/checker/__tests__/typing-context.test.ts
+++ b/samlang-core/checker/__tests__/typing-context.test.ts
@@ -81,7 +81,6 @@ describe('typing-context', () => {
                     },
                   },
                 },
-                extendsOrImplements: null,
                 superTypes: [],
                 functions: new Map([
                   [
@@ -153,7 +152,6 @@ describe('typing-context', () => {
                   names: [],
                   mappings: {},
                 },
-                extendsOrImplements: null,
                 superTypes: [],
                 functions: new Map([
                   [

--- a/samlang-core/checker/typing-context.ts
+++ b/samlang-core/checker/typing-context.ts
@@ -47,14 +47,10 @@ export function memberTypeInformationToString(
   return `${accessString} ${name}${tparamString}${prettyPrintType(type)}`;
 }
 
-export interface InterfaceTypingContextInstantiatedMembers {
+export interface InterfaceTypingContext {
   readonly functions: ReadonlyMap<string, MemberTypeInformation>;
   readonly methods: ReadonlyMap<string, MemberTypeInformation>;
-}
-
-export interface InterfaceTypingContext extends InterfaceTypingContextInstantiatedMembers {
   readonly typeParameters: readonly TypeParameterSignature[];
-  readonly extendsOrImplements: SamlangIdentifierType | null;
   readonly superTypes: readonly SamlangIdentifierType[];
 }
 


### PR DESCRIPTION
## Summary

This diff aims to provide a much stronger guarantee of what can be read from the global typing context.

## Test Plan

```
pnpm test
pnpm test:integration
```
