### PR TITLE
[checker] Make SSA builder handle this typing

### DIFF
--- a/samlang-core/__tests__/checker-integration-test.test.ts
+++ b/samlang-core/__tests__/checker-integration-test.test.ts
@@ -32,6 +32,7 @@ const expectedErrors: readonly string[] = [
   'illegal-shadow.sam:22:9-22:10: [Collision]: Name `a` collides with a previously defined name.',
   'illegal-shadow.sam:3:7-3:8: [Collision]: Name `A` collides with a previously defined name.',
   'illegal-shadow.sam:7:12-7:16: [Collision]: Name `test` collides with a previously defined name.',
+  'illegal-this.sam:5:13-5:17: [UnresolvedName]: Name `this` is not resolved.',
   'insufficient-type-info-none.sam:8:13-8:26: [InsufficientTypeInferenceContext]: There is not enough context information to decide the type of this expression.',
   'insufficient-type-info.sam:5:13-5:47: [InsufficientTypeInferenceContext]: There is not enough context information to decide the type of this expression.',
   'invalid-property-declaration-syntax.sam:2:12-2:13: [SyntaxError]: Expected: val, actual: a.',

--- a/samlang-core/__tests__/errors.test.ts
+++ b/samlang-core/__tests__/errors.test.ts
@@ -19,7 +19,6 @@ describe('samlang-core/errors', () => {
     reporter.reportInsufficientTypeInferenceContextError(Location.DUMMY);
     reporter.reportCollisionError(Location.DUMMY, 'a');
     reporter.reportIllegalOtherClassMatch(Location.DUMMY);
-    reporter.reportIllegalThisError(Location.DUMMY);
     reporter.reportNonExhausiveMatchError(Location.DUMMY, ['A', 'B']);
     reporter.reportMissingDefinitionsError(Location.DUMMY, ['foo', 'bar']);
     reporter.reportCyclicTypeDefinitionError(AstBuilder.IntType);
@@ -40,7 +39,6 @@ describe('samlang-core/errors', () => {
       '[InsufficientTypeInferenceContext]: There is not enough context information to decide the type of this expression.',
       '[Collision]: Name `a` collides with a previously defined name.',
       "[IllegalOtherClassMatch]: It is illegal to match on a value of other class's type.",
-      '[IllegalThis]: Keyword `this` cannot be used in this context.',
       '[NonExhausiveMatch]: The following tags are not considered in the match: [A, B].',
       '[MissingDefinitions]: Missing definitions for [foo, bar].',
       '[CyclicTypeDefinition]: Type `int` has a cyclic definition.',

--- a/samlang-core/checker/__tests__/expression-type-checker.test.ts
+++ b/samlang-core/checker/__tests__/expression-type-checker.test.ts
@@ -302,7 +302,7 @@ function typeCheckInSandbox(
 
   // Type Check
   const ssaAnalysisResult = performSSAAnalysisOnSamlangExpression(parsedExpression);
-  const localTypingContext = new LocationBasedLocalTypingContext(ssaAnalysisResult, null);
+  const localTypingContext = new LocationBasedLocalTypingContext(ssaAnalysisResult);
   const checkedExpression = typeCheckExpression(
     parsedExpression,
     errorReporter,
@@ -377,9 +377,8 @@ describe('expression-type-checker', () => {
   });
 
   it('This', () => {
-    assertTypeErrors('this', int, [
-      '__DUMMY__.sam:1:1-1:5: [IllegalThis]: Keyword `this` cannot be used in this context.',
-    ]);
+    // Should already errored during SSA analysis
+    assertTypeChecks('this', int);
   });
 
   it('Variable', () => {

--- a/samlang-core/checker/expression-type-checker.ts
+++ b/samlang-core/checker/expression-type-checker.ts
@@ -116,17 +116,9 @@ class ExpressionTypeChecker {
   }
 
   private typeCheckThis(expression: ThisExpression, hint: SamlangType | null): SamlangExpression {
-    const typeFromContext = this.localTypingContext.thisType;
-    let type: SamlangType;
-    if (typeFromContext == null) {
-      this.errorReporter.reportIllegalThisError(expression.location);
-      type = this.bestEffortUnknownType(hint, expression);
-    } else {
-      type = this.typeMeet(hint, typeFromContext);
-    }
     return SourceExpressionThis({
       location: expression.location,
-      type,
+      type: this.typeMeet(hint, this.localTypingContext.read(expression.location)),
       associatedComments: expression.associatedComments,
     });
   }

--- a/samlang-core/checker/typing-context.ts
+++ b/samlang-core/checker/typing-context.ts
@@ -19,7 +19,7 @@ import {
   typeReposition,
 } from '../ast/samlang-nodes';
 import type { DefaultBuiltinClasses } from '../parser';
-import { assert, ReadonlyHashMap, zip } from '../utils';
+import { assert, checkNotNull, ReadonlyHashMap, zip } from '../utils';
 import type { SsaAnalysisResult } from './ssa-analysis';
 import performTypeSubstitution from './type-substitution';
 
@@ -289,16 +289,16 @@ export class AccessibleGlobalTypingContext {
 export class LocationBasedLocalTypingContext {
   private typeMap = LocationCollections.hashMapOf<SamlangType>();
 
-  constructor(
-    private readonly ssaAnalysisResult: SsaAnalysisResult,
-    public readonly thisType: SamlangType | null,
-  ) {}
+  constructor(private readonly ssaAnalysisResult: SsaAnalysisResult) {}
 
   read(location: Location): SamlangType {
     const definitionLocation = this.ssaAnalysisResult.useDefineMap.get(location);
     // When the name is unbound, we treat itself as definition.
     if (definitionLocation == null) return SourceUnknownType(SourceReason(location, null));
-    return typeReposition(this.typeMap.forceGet(definitionLocation), location);
+    return typeReposition(
+      checkNotNull(this.typeMap.get(definitionLocation), definitionLocation.toString()),
+      location,
+    );
   }
 
   write(location: Location, type: SamlangType): void {

--- a/samlang-core/errors.ts
+++ b/samlang-core/errors.ts
@@ -135,12 +135,6 @@ export class IllegalOtherClassMatch extends CompileTimeError {
   }
 }
 
-export class IllegalThisError extends CompileTimeError {
-  constructor(location: Location) {
-    super('IllegalThis', location, 'Keyword `this` cannot be used in this context.');
-  }
-}
-
 export class NonExhausiveMatchError extends CompileTimeError {
   constructor(location: Location, missingTags: readonly string[]) {
     super(
@@ -246,10 +240,6 @@ export class GlobalErrorReporter {
 
   reportIllegalOtherClassMatch(location: Location): void {
     this.collectorDelegate.reportError(new IllegalOtherClassMatch(location));
-  }
-
-  reportIllegalThisError(location: Location): void {
-    this.collectorDelegate.reportError(new IllegalThisError(location));
   }
 
   reportNonExhausiveMatchError(location: Location, missingTags: readonly string[]): void {

--- a/samlang-core/test-programs.ts
+++ b/samlang-core/test-programs.ts
@@ -182,6 +182,17 @@ class Main {
 `,
   },
   {
+    testName: 'illegal-this',
+    sourceCode: `
+
+class Main {
+  function main(): unit = {
+    val _ = this;
+  }
+}
+`,
+  },
+  {
     testName: 'insufficient-type-info',
     sourceCode: `
 class NotEnoughTypeInfo {


### PR DESCRIPTION
## Summary

Make the context usage code even simpler.

## Test Plan

```
pnpm test
pnpm test:integration
```
