### PR TITLE
[checker] Type validator considering tparams in context

### DIFF
--- a/samlang-core/checker/__tests__/builtins.test.ts
+++ b/samlang-core/checker/__tests__/builtins.test.ts
@@ -1,0 +1,22 @@
+import { AstBuilder } from '../../ast/samlang-nodes';
+import { memberTypeInformationToString } from '../typing-context';
+
+describe('builtins', () => {
+  it('memberTypeInformationToString tests', () => {
+    expect(
+      memberTypeInformationToString('foo', {
+        isPublic: false,
+        typeParameters: [],
+        type: AstBuilder.FunType([], AstBuilder.IntType),
+      }),
+    ).toBe('private foo() -> int');
+
+    expect(
+      memberTypeInformationToString('bar', {
+        isPublic: true,
+        typeParameters: [{ name: 'T', bound: AstBuilder.IdType('A') }],
+        type: AstBuilder.FunType([], AstBuilder.IntType),
+      }),
+    ).toBe('public bar<T: A>() -> int');
+  });
+});

--- a/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
+++ b/samlang-core/checker/__tests__/global-typing-context-builder.test.ts
@@ -107,7 +107,6 @@ describe('global-typing-context-builder', () => {
       createGlobalErrorCollector().getErrorReporter(),
       {
         typeDefinitions: new Map(),
-        classes: new Map(),
         interfaces: new Map(),
       },
     );
@@ -115,8 +114,7 @@ describe('global-typing-context-builder', () => {
 
     expect(actualGlobalTypingContext.get(module0Reference)).toStrictEqual({
       typeDefinitions: new Map([['Class0', { type: 'object', names: [], mappings: new Map() }]]),
-      interfaces: new Map(),
-      classes: new Map([
+      interfaces: new Map([
         [
           'Class0',
           {
@@ -145,8 +143,7 @@ describe('global-typing-context-builder', () => {
         ['Class1', { type: 'object', names: [], mappings: new Map() }],
         ['Class2', { type: 'object', names: [], mappings: new Map() }],
       ]),
-      interfaces: new Map(),
-      classes: new Map([
+      interfaces: new Map([
         [
           'Class1',
           {

--- a/samlang-core/checker/__tests__/main-type-checker.test.ts
+++ b/samlang-core/checker/__tests__/main-type-checker.test.ts
@@ -3,10 +3,10 @@ import { AstBuilder, SamlangExpression, SamlangType } from '../../ast/samlang-no
 import { createGlobalErrorCollector } from '../../errors';
 import { parseSamlangExpressionFromText } from '../../parser';
 import { checkNotNull } from '../../utils';
+import { DEFAULT_BUILTIN_TYPING_CONTEXT } from '../builtins';
 import { typeCheckExpression } from '../main-type-checker';
 import { performSSAAnalysisOnSamlangExpression } from '../ssa-analysis';
 import {
-  DEFAULT_BUILTIN_TYPING_CONTEXT,
   InterfaceTypingContext,
   LocationBasedLocalTypingContext,
   ModuleTypingContext,
@@ -120,8 +120,7 @@ function typeCheckInSandbox(
               },
             ],
           ]),
-          interfaces: new Map(),
-          classes: new Map<string, InterfaceTypingContext>([
+          interfaces: new Map<string, InterfaceTypingContext>([
             [
               'Test',
               {
@@ -302,6 +301,7 @@ function typeCheckInSandbox(
     errorReporter,
     ModuleReference.DUMMY,
     currentClass ?? 'Test',
+    /* availableTypeParameters */ [],
   );
 
   // Type Check

--- a/samlang-core/checker/builtins.ts
+++ b/samlang-core/checker/builtins.ts
@@ -1,0 +1,74 @@
+import { BuiltinReason, Location, ModuleReference } from '../ast/common-nodes';
+import { CustomizedReasonAstBuilder, SamlangType } from '../ast/samlang-nodes';
+import type {
+  InterfaceTypingContext,
+  MemberTypeInformation,
+  TypeDefinitionTypingContext,
+} from './typing-context';
+
+const AST = new CustomizedReasonAstBuilder(BuiltinReason, ModuleReference.ROOT);
+
+function createCustomBuiltinFunction(
+  name: string,
+  isPublic: boolean,
+  typeParameters: readonly string[],
+  argumentTypes: readonly SamlangType[],
+  returnType: SamlangType,
+): readonly [string, MemberTypeInformation] {
+  return [
+    name,
+    {
+      isPublic,
+      typeParameters: typeParameters.map((it) => ({ name: it, bound: null })),
+      type: AST.FunType(argumentTypes, returnType),
+    },
+  ];
+}
+
+export function createBuiltinFunction(
+  name: string,
+  argumentTypes: readonly SamlangType[],
+  returnType: SamlangType,
+  typeParameters: readonly string[] = [],
+): readonly [string, MemberTypeInformation] {
+  return createCustomBuiltinFunction(name, true, typeParameters, argumentTypes, returnType);
+}
+
+export function createPrivateBuiltinFunction(
+  name: string,
+  argumentTypes: readonly SamlangType[],
+  returnType: SamlangType,
+  typeParameters: readonly string[] = [],
+): readonly [string, MemberTypeInformation] {
+  return createCustomBuiltinFunction(name, false, typeParameters, argumentTypes, returnType);
+}
+
+export const DEFAULT_BUILTIN_TYPING_CONTEXT: {
+  readonly typeDefinitions: ReadonlyMap<string, TypeDefinitionTypingContext>;
+  readonly interfaces: ReadonlyMap<string, InterfaceTypingContext>;
+} = {
+  typeDefinitions: new Map(),
+  interfaces: new Map([
+    [
+      'Builtins',
+      {
+        typeParameters: [],
+        typeDefinition: {
+          location: Location.DUMMY,
+          type: 'object',
+          names: [],
+          mappings: new Map(),
+        },
+        extendsOrImplements: null,
+        superTypes: [],
+        functions: new Map([
+          createBuiltinFunction('stringToInt', [AST.StringType], AST.IntType),
+          createBuiltinFunction('intToString', [AST.IntType], AST.StringType),
+          createBuiltinFunction('println', [AST.StringType], AST.UnitType),
+          createBuiltinFunction('panic', [AST.StringType], AST.IdType('T'), ['T']),
+        ]),
+        methods: new Map(),
+      },
+    ],
+  ]),
+};

--- a/samlang-core/checker/global-typing-context-builder.ts
+++ b/samlang-core/checker/global-typing-context-builder.ts
@@ -20,9 +20,9 @@ import {
 } from '../ast/samlang-nodes';
 import type { GlobalErrorReporter } from '../errors';
 import { checkNotNull, HashMap, ReadonlyHashMap, zip } from '../utils';
+import { DEFAULT_BUILTIN_TYPING_CONTEXT } from './builtins';
 import performTypeSubstitution from './type-substitution';
-import {
-  DEFAULT_BUILTIN_TYPING_CONTEXT,
+import type {
   GlobalTypingContext,
   InterfaceTypingContext,
   MemberTypeInformation,
@@ -257,7 +257,6 @@ function optimizeGlobalTypingContextWithInterfaceConformanceChecking(
     const moduleTypingContext = unoptimizedGlobalTypingContext.forceGet(moduleReference);
     const optimizedModuleTypingContext = {
       typeDefinitions: moduleTypingContext.typeDefinitions,
-      classes: new Map<string, InterfaceTypingContext>(),
       interfaces: new Map<string, InterfaceTypingContext>(),
     };
     samlangModule.classes.forEach((declaration) => {
@@ -270,7 +269,7 @@ function optimizeGlobalTypingContextWithInterfaceConformanceChecking(
       const unoptimizedClassTypingContext = checkNotNull(
         moduleTypingContext.classes.get(declaration.name.name),
       );
-      optimizedModuleTypingContext.classes.set(declaration.name.name, {
+      optimizedModuleTypingContext.interfaces.set(declaration.name.name, {
         functions: unoptimizedClassTypingContext.functions,
         methods: unoptimizedClassTypingContext.methods,
         typeParameters: unoptimizedClassTypingContext.typeParameters,

--- a/samlang-core/services/api.ts
+++ b/samlang-core/services/api.ts
@@ -358,7 +358,7 @@ class LanguageServicesImpl implements LanguageServices {
     }
     const relevantInterfaceType = this.state.globalTypingContext
       .get(type.moduleReference)
-      ?.classes?.get(type.identifier);
+      ?.interfaces?.get(type.identifier);
     const relevantTypeDefinition = this.state.globalTypingContext
       .get(type.moduleReference)
       ?.typeDefinitions?.get(type.identifier);
@@ -394,7 +394,7 @@ class LanguageServicesImpl implements LanguageServices {
     moduleReference: ModuleReference,
     className: string,
   ): InterfaceTypingContext | undefined {
-    return this.state.globalTypingContext.get(moduleReference)?.classes?.get(className);
+    return this.state.globalTypingContext.get(moduleReference)?.interfaces?.get(className);
   }
 
   private static getCompletionResultFromTypeInformation(


### PR DESCRIPTION
Add support for validating the instantiation of an identifier type. It's not connected to production yet, but it implements all of the required checks, and it's aware of the scope of type parameters.