### PR TITLE
[perf] Centralize comments store

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: cargo-build-debug-${{ hashFiles('**/Cargo.lock') }}
+      - name: Format Check
+        run: cargo fmt --all -- --check
+      - name: Build Tests
+        run: cargo build --tests
+      - name: Lint
+        run: cargo lint
       - name: Build and Validate
         run: ./compile-repository.sh
   test:
@@ -44,11 +50,5 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: cargo-test-${{ hashFiles('**/Cargo.lock') }}
-      - name: Format Check
-        run: cargo fmt --all -- --check
-      - name: Build Tests
-        run: cargo build --tests
-      - name: Lint
-        run: cargo lint
       - name: Run Tests
         run: cargo tc

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -6,4 +6,4 @@ echo "Compiling samlang CLI..."
 cargo b -p samlang-cli --release
 echo "Compiled samlang CLI!"
 
-time BENCHMARK_REPEAT=1000 ./target/release/samlang-cli
+time BENCHMARK_REPEAT=10000 ./target/release/samlang-cli

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -10,6 +10,10 @@ mod comments_tests {
       Comment { kind: CommentKind::BLOCK, text: Heap::new().alloc_str("d") }.clone().text
     )
     .is_empty());
+    assert!(!format!("{:?}", CommentStore::new().clone().create_comment_reference(vec![]).clone())
+      .is_empty());
+    assert!(CommentStore::new().clone().get(NO_COMMENT_REFERENCE).is_empty());
+    assert!(CommentStore::new().clone().get_mut(NO_COMMENT_REFERENCE).is_empty());
   }
 }
 
@@ -106,7 +110,7 @@ mod type_tests {
       "A",
       TypeParameter {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         name: Id::from(heap.alloc_str("A")),
         bound: Option::None
       }
@@ -116,7 +120,7 @@ mod type_tests {
       "A: B",
       TypeParameter {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         name: Id::from(heap.alloc_str("A")),
         bound: Option::Some(Rc::new(builder.simple_id_type_unwrapped(heap.alloc_str("B"))))
       }
@@ -331,7 +335,7 @@ mod expressions_tests {
     .precedence();
     E::Binary(Binary {
       common: common.clone(),
-      operator_preceding_comments: vec![],
+      operator_preceding_comments: NO_COMMENT_REFERENCE,
       operator: BinaryOperator::AND,
       e1: Box::new(builder.zero_expr()),
       e2: Box::new(builder.zero_expr()),
@@ -420,7 +424,7 @@ mod expressions_tests {
     .common();
     E::Binary(Binary {
       common: common.clone(),
-      operator_preceding_comments: vec![],
+      operator_preceding_comments: NO_COMMENT_REFERENCE,
       operator: BinaryOperator::AND,
       e1: Box::new(builder.zero_expr()),
       e2: Box::new(builder.zero_expr()),
@@ -467,7 +471,7 @@ mod expressions_tests {
       common: common.clone(),
       statements: vec![DeclarationStatement {
         loc: Location::dummy(),
-        associated_comments: vec![],
+        associated_comments: NO_COMMENT_REFERENCE,
         pattern: Pattern::Object(
           Location::dummy(),
           vec![ObjectPatternDestucturedName {
@@ -505,7 +509,7 @@ mod toplevel_tests {
       "name",
       TypeParameter {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         name: Id::from(heap.alloc_str("name")),
         bound: None
       }
@@ -542,14 +546,14 @@ mod toplevel_tests {
 
     assert!(InterfaceDeclaration {
       loc: Location::dummy(),
-      associated_comments: Rc::new(vec![]),
+      associated_comments: NO_COMMENT_REFERENCE,
       name: Id::from(heap.alloc_str("")),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
       type_definition: (),
       members: vec![ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: true,
         name: Id::from(heap.alloc_str("")),
@@ -586,7 +590,7 @@ mod toplevel_tests {
 
     let class = Toplevel::Class(InterfaceDeclarationCommon {
       loc: Location::dummy(),
-      associated_comments: Rc::new(vec![]),
+      associated_comments: NO_COMMENT_REFERENCE,
       name: Id::from(heap.alloc_str("name")),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
@@ -599,7 +603,7 @@ mod toplevel_tests {
       members: vec![ClassMemberDefinition {
         decl: ClassMemberDeclaration {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           is_public: true,
           is_method: true,
           name: Id::from(heap.alloc_str("")),
@@ -620,14 +624,14 @@ mod toplevel_tests {
     assert!(class.is_class());
     let interface = Toplevel::Interface(InterfaceDeclarationCommon {
       loc: Location::dummy(),
-      associated_comments: Rc::new(vec![]),
+      associated_comments: NO_COMMENT_REFERENCE,
       name: Id::from(heap.alloc_str("name")),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
       type_definition: (),
       members: vec![ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: true,
         name: Id::from(heap.alloc_str("")),

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -2,7 +2,10 @@
 mod tests {
   use crate::{
     ast::{
-      source::{expr, test_builder, FieldType, FunctionType, Id, Type, TypeParameterSignature},
+      source::{
+        expr, test_builder, FieldType, FunctionType, Id, Type, TypeParameterSignature,
+        NO_COMMENT_REFERENCE,
+      },
       Location, Reason,
     },
     checker::{
@@ -56,14 +59,14 @@ mod tests {
       expr::E::MethodAccess(expr::MethodAccess {
         common: expr::ExpressionCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           type_: builder.bool_type(),
         },
         type_arguments: vec![],
         object: Box::new(builder.true_expr()),
         method_name: Id {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: test_str,
         },
       }),
@@ -530,7 +533,7 @@ mod tests {
   ) -> Vec<String> {
     let mut error_set = ErrorSet::new();
 
-    let parsed =
+    let (_, parsed) =
       parse_source_expression_from_text(source, ModuleReference::dummy(), heap, &mut error_set);
     assert_eq!(Vec::<String>::new(), error_set.error_messages(heap));
 

--- a/crates/samlang-core/src/checker/global_typing_context_builder.rs
+++ b/crates/samlang-core/src/checker/global_typing_context_builder.rs
@@ -450,7 +450,7 @@ pub(super) fn build_global_typing_context(
 ) -> GlobalTypingContext {
   let mut unoptimized_global_typing_context = HashMap::new();
 
-  for (module_reference, Module { imports: _, toplevels }) in sources {
+  for (module_reference, Module { comment_store: _, imports: _, toplevels }) in sources {
     let mut interfaces = BTreeMap::new();
     let mut classes = BTreeMap::new();
     let mut type_definitions = BTreeMap::new();
@@ -564,8 +564,8 @@ mod tests {
   use crate::{
     ast::{
       source::{
-        test_builder, ClassMemberDefinition, Id, InterfaceDeclarationCommon, ModuleMembersImport,
-        TypeDefinition,
+        test_builder, ClassMemberDefinition, CommentStore, Id, InterfaceDeclarationCommon,
+        ModuleMembersImport, TypeDefinition, NO_COMMENT_REFERENCE,
       },
       Location,
     },
@@ -593,7 +593,7 @@ mod tests {
       },
       &ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: true,
         name: Id::from(heap.alloc_str("")),
@@ -621,7 +621,7 @@ mod tests {
       },
       &ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: false,
         name: Id::from(heap.alloc_str("")),
@@ -649,7 +649,7 @@ mod tests {
       },
       &ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: false,
         is_method: true,
         name: Id::from(heap.alloc_str("")),
@@ -680,13 +680,13 @@ mod tests {
       },
       &ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: false,
         is_method: true,
         name: Id::from(heap.alloc_str("")),
         type_parameters: Rc::new(vec![TypeParameter {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: Id::from(heap.alloc_str("A")),
           bound: Some(Rc::new(builder.simple_id_type_unwrapped(heap.alloc_str("B")))),
         }]),
@@ -724,26 +724,26 @@ mod tests {
       },
       &ClassMemberDeclaration {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         is_public: false,
         is_method: true,
         name: Id::from(heap.alloc_str("")),
         type_parameters: Rc::new(vec![
           TypeParameter {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             name: Id::from(heap.alloc_str("B")),
             bound: None,
           },
           TypeParameter {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             name: Id::from(heap.alloc_str("C")),
             bound: None,
           },
           TypeParameter {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             name: Id::from(heap.alloc_str("D")),
             bound: Some(Rc::new(builder.simple_id_type_unwrapped(heap.alloc_str("B")))),
           },
@@ -1197,7 +1197,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
       &unoptimized_global_cx,
       &Toplevel::Class(InterfaceDeclarationCommon {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         name: Id::from(heap.alloc_str("A")),
         type_parameters: vec![],
         extends_or_implements_nodes: vec![builder.simple_id_type_unwrapped(heap.alloc_str("IBase"))],
@@ -1211,7 +1211,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
           ClassMemberDefinition {
             decl: ClassMemberDeclaration {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               is_public: true,
               is_method: false,
               name: Id::from(heap.alloc_str("f1")),
@@ -1228,7 +1228,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
           ClassMemberDefinition {
             decl: ClassMemberDeclaration {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               is_public: true,
               is_method: true,
               name: Id::from(heap.alloc_str("m1")),
@@ -1260,14 +1260,15 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
       (
         m0_ref.clone(),
         Module {
+          comment_store: CommentStore::new(),
           imports: vec![],
           toplevels: vec![Toplevel::Class(InterfaceDeclarationCommon {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             name: Id::from(heap.alloc_str("Class0")),
             type_parameters: vec![TypeParameter {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               name: Id::from(heap.alloc_str("T")),
               bound: None,
             }],
@@ -1288,6 +1289,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
       (
         m1_ref.clone(),
         Module {
+          comment_store: CommentStore::new(),
           imports: vec![ModuleMembersImport {
             loc: Location::dummy(),
             imported_members: vec![
@@ -1300,7 +1302,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
           toplevels: vec![
             Toplevel::Class(InterfaceDeclarationCommon {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               name: Id::from(heap.alloc_str("Class1")),
               type_parameters: vec![],
               extends_or_implements_nodes: vec![],
@@ -1317,7 +1319,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
                 ClassMemberDefinition {
                   decl: ClassMemberDeclaration {
                     loc: Location::dummy(),
-                    associated_comments: Rc::new(vec![]),
+                    associated_comments: NO_COMMENT_REFERENCE,
                     is_public: true,
                     is_method: true,
                     name: Id::from(heap.alloc_str("m1")),
@@ -1334,7 +1336,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
                 ClassMemberDefinition {
                   decl: ClassMemberDeclaration {
                     loc: Location::dummy(),
-                    associated_comments: Rc::new(vec![]),
+                    associated_comments: NO_COMMENT_REFERENCE,
                     is_public: false,
                     is_method: false,
                     name: Id::from(heap.alloc_str("f1")),
@@ -1352,7 +1354,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
             }),
             Toplevel::Interface(InterfaceDeclarationCommon {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               name: Id::from(heap.alloc_str("Interface2")),
               type_parameters: vec![],
               extends_or_implements_nodes: vec![],
@@ -1361,14 +1363,14 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
             }),
             Toplevel::Interface(InterfaceDeclarationCommon {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               name: Id::from(heap.alloc_str("Interface3")),
               type_parameters: vec![],
               extends_or_implements_nodes: vec![],
               type_definition: (),
               members: vec![ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: false,
                 name: Id::from(heap.alloc_str("m1")),
@@ -1383,7 +1385,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
             }),
             Toplevel::Class(InterfaceDeclarationCommon {
               loc: Location::dummy(),
-              associated_comments: Rc::new(vec![]),
+              associated_comments: NO_COMMENT_REFERENCE,
               name: Id::from(heap.alloc_str("Class2")),
               type_parameters: vec![],
               extends_or_implements_nodes: vec![

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -1410,5 +1410,9 @@ pub(super) fn type_check_module(
     checked_toplevels.push(checked);
   }
 
-  Module { imports: module.imports, toplevels: checked_toplevels }
+  Module {
+    comment_store: module.comment_store,
+    imports: module.imports,
+    toplevels: checked_toplevels,
+  }
 }

--- a/crates/samlang-core/src/checker/ssa_analysis_tests.rs
+++ b/crates/samlang-core/src/checker/ssa_analysis_tests.rs
@@ -51,7 +51,7 @@ mod tests {
   val {o1, o2 as o3} = {};
   o1 + o3
 }"#;
-    let expr = parser::parse_source_expression_from_text(
+    let (_, expr) = parser::parse_source_expression_from_text(
       expr_str,
       ModuleReference::dummy(),
       &mut heap,

--- a/crates/samlang-core/src/checker/undefined_imports_checker.rs
+++ b/crates/samlang-core/src/checker/undefined_imports_checker.rs
@@ -35,7 +35,10 @@ pub(super) fn check_undefined_imports_error(
 mod tests {
   use crate::{
     ast::{
-      source::{Id, InterfaceDeclarationCommon, Module, ModuleMembersImport, Toplevel},
+      source::{
+        CommentStore, Id, InterfaceDeclarationCommon, Module, ModuleMembersImport, Toplevel,
+        NO_COMMENT_REFERENCE,
+      },
       Location,
     },
     common::{Heap, ModuleReference, PStr},
@@ -43,12 +46,12 @@ mod tests {
   };
   use itertools::Itertools;
   use pretty_assertions::assert_eq;
-  use std::{collections::HashMap, rc::Rc, vec};
+  use std::collections::HashMap;
 
   fn mock_class(name: PStr) -> Toplevel {
     Toplevel::Interface(InterfaceDeclarationCommon {
       loc: Location::dummy(),
-      associated_comments: Rc::new(vec![]),
+      associated_comments: NO_COMMENT_REFERENCE,
       name: Id::from(name),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
@@ -66,6 +69,7 @@ mod tests {
     (
       heap.alloc_module_reference_from_string_vec(vec![name.to_string()]),
       Module {
+        comment_store: CommentStore::new(),
         imports: imports
           .into_iter()
           .map(|(imported_mod_name, imported_member_strs)| {
@@ -76,7 +80,7 @@ mod tests {
             for m in imported_member_strs {
               imported_members.push(Id {
                 loc: loc.clone(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 name: heap.alloc_str(m),
               });
             }

--- a/crates/samlang-core/src/compiler/hir_lowering.rs
+++ b/crates/samlang-core/src/compiler/hir_lowering.rs
@@ -1333,7 +1333,11 @@ pub(crate) fn compile_sources_to_hir(
 #[cfg(test)]
 mod tests {
   use crate::{
-    ast::{hir, source, Location, Reason},
+    ast::{
+      hir,
+      source::{self, CommentStore, NO_COMMENT_REFERENCE},
+      Location, Reason,
+    },
     common::{Heap, ModuleReference},
     compiler::{
       hir_lowering::ExpressionLoweringManager,
@@ -1678,7 +1682,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.int_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::PLUS,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1690,7 +1694,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.int_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::MINUS,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1702,7 +1706,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.int_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::MUL,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1714,7 +1718,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.int_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::DIV,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1726,7 +1730,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.int_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::MOD,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1738,7 +1742,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::LT,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1750,7 +1754,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::LE,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1762,7 +1766,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::GT,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1774,7 +1778,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments:NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::GE,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1786,7 +1790,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::EQ,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1798,7 +1802,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::NE,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1811,7 +1815,7 @@ return 0;"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::AND,
         e1: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.bool_type())),
         e2: Box::new(builder.id_expr(heap.alloc_str("bar"), builder.bool_type())),
@@ -1829,7 +1833,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::AND,
         e1: Box::new(builder.true_expr()),
         e2: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.int_type())),
@@ -1841,7 +1845,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::AND,
         e1: Box::new(builder.false_expr()),
         e2: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.int_type())),
@@ -1854,7 +1858,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::OR,
         e1: Box::new(builder.true_expr()),
         e2: Box::new(builder.int_lit(65536)),
@@ -1866,7 +1870,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::OR,
         e1: Box::new(builder.false_expr()),
         e2: Box::new(builder.int_lit(65536)),
@@ -1878,7 +1882,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.bool_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::OR,
         e1: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.bool_type())),
         e2: Box::new(builder.id_expr(heap.alloc_str("bar"), builder.bool_type())),
@@ -1897,7 +1901,7 @@ return (_t14: bool);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.string_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::CONCAT,
         e1: Box::new(dummy_source_this(heap)),
         e2: Box::new(dummy_source_this(heap)),
@@ -1910,7 +1914,7 @@ return (_t16: string);"#,
     assert_expr_correctly_lowered(
       &source::expr::E::Binary(source::expr::Binary {
         common: builder.expr_common(builder.string_type()),
-        operator_preceding_comments: vec![],
+        operator_preceding_comments: NO_COMMENT_REFERENCE,
         operator: source::expr::BinaryOperator::CONCAT,
         e1: Box::new(builder.string_expr(heap.alloc_str("hello "))),
         e2: Box::new(builder.string_expr(heap.alloc_str("world"))),
@@ -2146,7 +2150,7 @@ return (_t23: __DUMMY___Dummy);"#,
         common: builder.expr_common(builder.unit_type()),
         statements: vec![source::expr::DeclarationStatement {
           loc: Location::dummy(),
-          associated_comments: vec![],
+          associated_comments: NO_COMMENT_REFERENCE,
           pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("a")),
           annotation: Some(builder.unit_type()),
           assigned_expression: Box::new(source::expr::E::Block(source::expr::Block {
@@ -2154,7 +2158,7 @@ return (_t23: __DUMMY___Dummy);"#,
             statements: vec![
               source::expr::DeclarationStatement {
                 loc: Location::dummy(),
-                associated_comments: vec![],
+                associated_comments: NO_COMMENT_REFERENCE,
                 pattern: source::expr::Pattern::Object(
                   Location::dummy(),
                   vec![
@@ -2179,7 +2183,7 @@ return (_t23: __DUMMY___Dummy);"#,
               },
               source::expr::DeclarationStatement {
                 loc: Location::dummy(),
-                associated_comments: vec![],
+                associated_comments: NO_COMMENT_REFERENCE,
                 pattern: source::expr::Pattern::Wildcard(Location::dummy()),
                 annotation: Some(Rc::new(dummy_source_id_type(heap))),
                 assigned_expression: Box::new(dummy_source_this(heap)),
@@ -2203,7 +2207,7 @@ return 0;"#,
         statements: vec![
           source::expr::DeclarationStatement {
             loc: Location::dummy(),
-            associated_comments: vec![],
+            associated_comments: NO_COMMENT_REFERENCE,
             pattern: source::expr::Pattern::Object(
               Location::dummy(),
               vec![
@@ -2228,7 +2232,7 @@ return 0;"#,
           },
           source::expr::DeclarationStatement {
             loc: Location::dummy(),
-            associated_comments: vec![],
+            associated_comments: NO_COMMENT_REFERENCE,
             pattern: source::expr::Pattern::Wildcard(Location::dummy()),
             annotation: Some(Rc::new(dummy_source_id_type(heap))),
             assigned_expression: Box::new(dummy_source_this(heap)),
@@ -2248,7 +2252,7 @@ return 0;"#,
         common: builder.expr_common(builder.unit_type()),
         statements: vec![source::expr::DeclarationStatement {
           loc: Location::dummy(),
-          associated_comments: vec![],
+          associated_comments: NO_COMMENT_REFERENCE,
           pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("a")),
           annotation: Some(builder.int_type()),
           assigned_expression: Box::new(source::expr::E::Call(source::expr::Call {
@@ -2279,14 +2283,14 @@ return 0;"#,
         statements: vec![
           source::expr::DeclarationStatement {
             loc: Location::dummy(),
-            associated_comments: vec![],
+            associated_comments: NO_COMMENT_REFERENCE,
             pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("a")),
             annotation: Some(builder.unit_type()),
             assigned_expression: Box::new(builder.string_expr(heap.alloc_str("foo"))),
           },
           source::expr::DeclarationStatement {
             loc: Location::dummy(),
-            associated_comments: vec![],
+            associated_comments: NO_COMMENT_REFERENCE,
             pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("b")),
             annotation: Some(builder.unit_type()),
             assigned_expression: Box::new(
@@ -2306,14 +2310,14 @@ return 0;"#,
         common: builder.expr_common(builder.unit_type()),
         statements: vec![source::expr::DeclarationStatement {
           loc: Location::dummy(),
-          associated_comments: vec![],
+          associated_comments: NO_COMMENT_REFERENCE,
           pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("a")),
           annotation: Some(builder.unit_type()),
           assigned_expression: Box::new(source::expr::E::Block(source::expr::Block {
             common: builder.expr_common(builder.unit_type()),
             statements: vec![source::expr::DeclarationStatement {
               loc: Location::dummy(),
-              associated_comments: vec![],
+              associated_comments: NO_COMMENT_REFERENCE,
               pattern: source::expr::Pattern::Id(Location::dummy(), heap.alloc_str("a")),
               annotation: Some(builder.int_type()),
               assigned_expression: Box::new(dummy_source_this(heap)),
@@ -2339,11 +2343,12 @@ return 0;"#,
     );
 
     let source_module = source::Module {
+      comment_store: CommentStore::new(),
       imports: vec![],
       toplevels: vec![
         source::Toplevel::Interface(source::InterfaceDeclarationCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: source::Id::from(heap.alloc_str("I")),
           type_parameters: vec![],
           extends_or_implements_nodes: vec![],
@@ -2352,7 +2357,7 @@ return 0;"#,
         }),
         source::Toplevel::Class(source::InterfaceDeclarationCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: source::Id::from(heap.alloc_str("Main")),
           type_parameters: vec![],
           extends_or_implements_nodes: vec![],
@@ -2366,7 +2371,7 @@ return 0;"#,
             source::ClassMemberDefinition {
               decl: source::ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: false,
                 name: source::Id::from(heap.alloc_str("main")),
@@ -2393,13 +2398,13 @@ return 0;"#,
             source::ClassMemberDefinition {
               decl: source::ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: false,
                 name: source::Id::from(heap.alloc_str("loopy")),
                 type_parameters: Rc::new(vec![source::TypeParameter {
                   loc: Location::dummy(),
-                  associated_comments: Rc::new(vec![]),
+                  associated_comments: NO_COMMENT_REFERENCE,
                   name: source::Id::from(heap.alloc_str("T")),
                   bound: None,
                 }]),
@@ -2426,7 +2431,7 @@ return 0;"#,
         }),
         source::Toplevel::Class(source::InterfaceDeclarationCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: source::Id::from(heap.alloc_str("Class1")),
           type_parameters: vec![],
           extends_or_implements_nodes: vec![],
@@ -2443,7 +2448,7 @@ return 0;"#,
             source::ClassMemberDefinition {
               decl: source::ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: true,
                 name: source::Id::from(heap.alloc_str("foo")),
@@ -2463,7 +2468,7 @@ return 0;"#,
             source::ClassMemberDefinition {
               decl: source::ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: false,
                 name: source::Id::from(heap.alloc_str("infiniteLoop")),
@@ -2490,7 +2495,7 @@ return 0;"#,
             source::ClassMemberDefinition {
               decl: source::ClassMemberDeclaration {
                 loc: Location::dummy(),
-                associated_comments: Rc::new(vec![]),
+                associated_comments: NO_COMMENT_REFERENCE,
                 is_public: true,
                 is_method: false,
                 name: source::Id::from(heap.alloc_str("factorial")),
@@ -2515,7 +2520,7 @@ return 0;"#,
                 common: builder.expr_common(builder.int_type()),
                 condition: Box::new(source::expr::E::Binary(source::expr::Binary {
                   common: builder.expr_common(builder.int_type()),
-                  operator_preceding_comments: vec![],
+                  operator_preceding_comments: NO_COMMENT_REFERENCE,
                   operator: source::expr::BinaryOperator::EQ,
                   e1: Box::new(builder.id_expr(heap.alloc_str("n"), builder.int_type())),
                   e2: Box::new(builder.zero_expr()),
@@ -2536,14 +2541,14 @@ return 0;"#,
                   arguments: vec![
                     source::expr::E::Binary(source::expr::Binary {
                       common: builder.expr_common(builder.int_type()),
-                      operator_preceding_comments: vec![],
+                      operator_preceding_comments: NO_COMMENT_REFERENCE,
                       operator: source::expr::BinaryOperator::MINUS,
                       e1: Box::new(builder.id_expr(heap.alloc_str("n"), builder.int_type())),
                       e2: Box::new(builder.int_lit(1)),
                     }),
                     source::expr::E::Binary(source::expr::Binary {
                       common: builder.expr_common(builder.int_type()),
-                      operator_preceding_comments: vec![],
+                      operator_preceding_comments: NO_COMMENT_REFERENCE,
                       operator: source::expr::BinaryOperator::MUL,
                       e1: Box::new(builder.id_expr(heap.alloc_str("n"), builder.int_type())),
                       e2: Box::new(builder.id_expr(heap.alloc_str("acc"), builder.int_type())),
@@ -2556,7 +2561,7 @@ return 0;"#,
         }),
         source::Toplevel::Class(source::InterfaceDeclarationCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: source::Id::from(heap.alloc_str("Class2")),
           type_parameters: vec![],
           extends_or_implements_nodes: vec![],
@@ -2573,11 +2578,11 @@ return 0;"#,
         }),
         source::Toplevel::Class(source::InterfaceDeclarationCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: source::Id::from(heap.alloc_str("Class3")),
           type_parameters: vec![source::TypeParameter {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             name: source::Id::from(heap.alloc_str("T")),
             bound: None,
           }],
@@ -2608,7 +2613,7 @@ return 0;"#,
       (ModuleReference::dummy(), source_module),
       (
         heap.alloc_module_reference_from_string_vec(vec!["Foo".to_string()]),
-        source::Module { imports: vec![], toplevels: vec![] },
+        source::Module { comment_store: CommentStore::new(), imports: vec![], toplevels: vec![] },
       ),
     ]);
 

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -485,7 +485,7 @@ mod tests {
   use super::*;
   use crate::{
     ast::{
-      source::{Id, InterfaceDeclarationCommon, Type},
+      source::{CommentStore, Id, InterfaceDeclarationCommon, Type, NO_COMMENT_REFERENCE},
       Location, Reason,
     },
     checker::type_check_single_module_source,
@@ -512,7 +512,7 @@ mod tests {
   fn dummy_expr_common() -> expr::ExpressionCommon {
     expr::ExpressionCommon {
       loc: Location::dummy(),
-      associated_comments: Rc::new(vec![]),
+      associated_comments: NO_COMMENT_REFERENCE,
       type_: Rc::new(Type::int_type(Reason::dummy())),
     }
   }
@@ -609,10 +609,11 @@ mod tests {
   fn run_without_main_test() {
     let mut heap = Heap::new();
     let module = Module {
+      comment_store: CommentStore::new(),
       imports: vec![],
       toplevels: vec![Toplevel::Interface(InterfaceDeclarationCommon {
         loc: Location::dummy(),
-        associated_comments: Rc::new(vec![]),
+        associated_comments: NO_COMMENT_REFERENCE,
         name: Id::from(heap.alloc_str("")),
         type_parameters: vec![],
         extends_or_implements_nodes: vec![],

--- a/crates/samlang-core/src/parser.rs
+++ b/crates/samlang-core/src/parser.rs
@@ -20,7 +20,7 @@ pub(crate) fn parse_source_module_from_text(
   error_set: &mut ErrorSet,
 ) -> source::Module {
   let builtins = builtin_classes(heap);
-  let mut parser = source_parser::SourceParser::new(
+  let parser = source_parser::SourceParser::new(
     lexer::lex_source_program(text, module_reference, heap, error_set),
     heap,
     error_set,
@@ -35,16 +35,16 @@ pub(crate) fn parse_source_expression_from_text(
   module_reference: ModuleReference,
   heap: &mut Heap,
   error_set: &mut ErrorSet,
-) -> source::expr::E {
+) -> (source::CommentStore, source::expr::E) {
   let builtins = builtin_classes(heap);
-  let mut parser = source_parser::SourceParser::new(
+  let parser = source_parser::SourceParser::new(
     lexer::lex_source_program(text, module_reference, heap, error_set),
     heap,
     error_set,
     module_reference,
     builtins,
   );
-  parser.parse_expression()
+  parser.parse_expression_with_comment_store()
 }
 
 #[cfg(test)]

--- a/crates/samlang-core/src/parser/lexer_test.rs
+++ b/crates/samlang-core/src/parser/lexer_test.rs
@@ -6,6 +6,7 @@ mod tests {
     common::{Heap, ModuleReference},
     errors::ErrorSet,
   };
+  use pretty_assertions::assert_eq;
 
   #[test]
   fn boilterplate() {
@@ -629,13 +630,13 @@ class Main {
 
   #[test]
   fn good_test_3() {
-    let expected = vec![".sam:1:2-1:12: /* comm */"];
+    let expected = vec![".sam:1:2-1:12: comm"];
     assert_eq!(expected, lex(r#" /* comm */"#));
   }
 
   #[test]
   fn line_comment_edge_case() {
-    assert_eq!(vec![".sam:1:1-1:6: // ss"], lex("// ss"));
+    assert_eq!(vec![".sam:1:1-1:6: ss"], lex("// ss"));
   }
 
   #[test]
@@ -681,16 +682,14 @@ class Main {
       ".sam:5:16-5:17: =",
       ".sam:5:18-5:19: 2",
       ".sam:5:19-5:20: ;",
-      r#".sam:6:5-8:13: /* block comment lol
-    ol ol
-    0000l */"#,
+      ".sam:6:5-8:13: block comment lol ol ol 0000l",
       ".sam:9:5-9:6: /",
       ".sam:9:7-9:10: not",
       ".sam:9:11-9:12: a",
       ".sam:9:13-9:17: line",
       ".sam:9:18-9:25: comment",
-      ".sam:10:5-10:25: // line comment haha",
-      ".sam:11:5-11:19: /** foo bar */",
+      ".sam:10:5-10:25: line comment haha",
+      ".sam:11:5-11:19: foo bar",
       ".sam:12:5-12:6: /",
       ".sam:12:6-12:7: *",
       ".sam:13:3-13:4: }",

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -165,7 +165,7 @@ pub(super) fn search_module(
 mod tests {
   use crate::{
     ast::{
-      source::{expr, Id, Type},
+      source::{expr, Id, Type, NO_COMMENT_REFERENCE},
       Location, Position, Reason,
     },
     checker::type_check_source_handles,
@@ -180,14 +180,14 @@ mod tests {
       &expr::E::MethodAccess(expr::MethodAccess {
         common: expr::ExpressionCommon {
           loc: Location::dummy(),
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           type_: Rc::new(Type::Unknown(Reason::dummy())),
         },
         type_arguments: vec![],
         object: Box::new(expr::E::Id(
           expr::ExpressionCommon {
             loc: Location::dummy(),
-            associated_comments: Rc::new(vec![]),
+            associated_comments: NO_COMMENT_REFERENCE,
             type_: Rc::new(Type::Unknown(Reason::dummy())),
           },
           Id::from(heap.alloc_str("id")),
@@ -198,7 +198,7 @@ mod tests {
             start: Position(10, 10),
             end: Position(10, 20),
           },
-          associated_comments: Rc::new(vec![]),
+          associated_comments: NO_COMMENT_REFERENCE,
           name: heap.alloc_str("meth")
         },
       }),

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -53,7 +53,7 @@ fn get_relevant_in_ranges(
 }
 
 fn mod_id(id: &Id, new_name: PStr) -> Id {
-  Id { loc: id.loc, associated_comments: id.associated_comments.clone(), name: new_name }
+  Id { loc: id.loc, associated_comments: id.associated_comments, name: new_name }
 }
 
 fn mod_def_id(id: &Id, definition_and_uses: &DefinitionAndUses, new_name: PStr) -> Id {
@@ -105,7 +105,7 @@ fn apply_expr_renaming(
     }),
     expr::E::Binary(e) => expr::E::Binary(expr::Binary {
       common: e.common.clone(),
-      operator_preceding_comments: e.operator_preceding_comments.clone(),
+      operator_preceding_comments: e.operator_preceding_comments,
       operator: e.operator,
       e1: Box::new(apply_expr_renaming(&e.e1, definition_and_uses, new_name)),
       e2: Box::new(apply_expr_renaming(&e.e2, definition_and_uses, new_name)),
@@ -162,7 +162,7 @@ fn apply_expr_renaming(
              assigned_expression,
            }| expr::DeclarationStatement {
             loc: *loc,
-            associated_comments: associated_comments.clone(),
+            associated_comments: *associated_comments,
             pattern: match pattern {
               expr::Pattern::Object(l, names) => expr::Pattern::Object(
                 *l,
@@ -226,11 +226,12 @@ fn apply_expr_renaming(
 }
 
 pub(super) fn apply_renaming(
-  Module { imports, toplevels }: &Module,
+  Module { comment_store, imports, toplevels }: &Module,
   definition_and_uses: &DefinitionAndUses,
   new_name: PStr,
 ) -> Module {
   Module {
+    comment_store: comment_store.clone(),
     imports: imports.clone(),
     toplevels: toplevels
       .iter()
@@ -238,7 +239,7 @@ pub(super) fn apply_renaming(
         Toplevel::Interface(i) => Toplevel::Interface(i.clone()),
         Toplevel::Class(c) => Toplevel::Class(ClassDefinition {
           loc: c.loc,
-          associated_comments: c.associated_comments.clone(),
+          associated_comments: c.associated_comments,
           name: c.name.clone(),
           type_parameters: c.type_parameters.clone(),
           extends_or_implements_nodes: c.extends_or_implements_nodes.clone(),
@@ -264,7 +265,7 @@ pub(super) fn apply_renaming(
                 ClassMemberDefinition {
                   decl: ClassMemberDeclaration {
                     loc: *loc,
-                    associated_comments: associated_comments.clone(),
+                    associated_comments: *associated_comments,
                     is_public: *is_public,
                     is_method: *is_method,
                     name: name.clone(),


### PR DESCRIPTION
Comments are only parsed and stored for IDE and formatting purposes. Therefore, it's better to store them as references that's managed by a module, and only leave IDs in AST nodes' slots, to avoid RC cost.

As a result of this diff, we got another 5% perf improvement