### PR TITLE
[ast][source] Add annotation nodes

### DIFF
--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -34,6 +34,37 @@ mod literal_tests {
 }
 
 #[cfg(test)]
+mod annotation_tests {
+  use super::super::source::*;
+  use crate::Heap;
+
+  #[test]
+  fn primitive_type_kind_to_string_tests() {
+    assert_eq!("unit", annotation::PrimitiveTypeKind::Unit.to_string());
+    assert_eq!("bool", annotation::PrimitiveTypeKind::Bool.to_string());
+    assert_eq!("int", annotation::PrimitiveTypeKind::Int.to_string());
+    assert_eq!("string", annotation::PrimitiveTypeKind::String.to_string());
+  }
+
+  #[test]
+  fn build_and_clone_tests() {
+    let builder = test_builder::create();
+    let heap = &mut Heap::new();
+    let _ = builder
+      .fn_annot(
+        vec![
+          builder.unit_annot(),
+          builder.bool_annot(),
+          builder.int_annot(),
+          builder.string_annot(),
+        ],
+        builder.simple_id_annot(heap.alloc_str("str")),
+      )
+      .clone();
+  }
+}
+
+#[cfg(test)]
 mod type_tests {
   use super::super::source::*;
   use crate::ast::loc::Location;


### PR DESCRIPTION
[ast][source] Add annotation nodes
This diff adds the AST nodes for annotations, which is the first step necessary to separate external annotation language and the internal type language.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/938).
* #940
* #939
* __->__ #938
