### PR TITLE
[repo] Switch location of type related import

### DIFF
--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -1,7 +1,8 @@
-use super::{loc::Location, reason::Reason};
-use crate::common::{Heap, ModuleReference, PStr};
-use enum_as_inner::EnumAsInner;
-use itertools::join;
+use super::loc::Location;
+use crate::{
+  checker::type_::{FunctionType, ISourceType, IdType, Type},
+  common::{Heap, ModuleReference, PStr},
+};
 use std::{collections::HashMap, rc::Rc};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -80,209 +81,6 @@ impl Literal {
       Self::Bool(false) => "false".to_string(),
       Self::Int(i) => i.to_string(),
       Self::String(s) => format!("\"{}\"", s.as_str(heap)),
-    }
-  }
-}
-
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub(crate) enum PrimitiveTypeKind {
-  Unit,
-  Bool,
-  Int,
-  String,
-}
-
-impl ToString for PrimitiveTypeKind {
-  fn to_string(&self) -> String {
-    match self {
-      Self::Unit => "unit".to_string(),
-      Self::Bool => "bool".to_string(),
-      Self::Int => "int".to_string(),
-      Self::String => "string".to_string(),
-    }
-  }
-}
-
-pub(crate) trait ISourceType {
-  fn pretty_print(&self, heap: &Heap) -> String;
-  fn is_the_same_type(&self, other: &Self) -> bool;
-}
-
-#[derive(Clone)]
-pub(crate) struct IdType {
-  pub(crate) reason: Reason,
-  pub(crate) module_reference: ModuleReference,
-  pub(crate) id: PStr,
-  pub(crate) type_arguments: Vec<Rc<Type>>,
-}
-
-impl ISourceType for IdType {
-  fn pretty_print(&self, heap: &Heap) -> String {
-    let IdType { reason: _, module_reference: _, id, type_arguments } = self;
-    if type_arguments.is_empty() {
-      id.as_str(heap).to_string()
-    } else {
-      format!(
-        "{}<{}>",
-        id.as_str(heap),
-        join(type_arguments.iter().map(|t| t.pretty_print(heap)), ", ")
-      )
-    }
-  }
-
-  fn is_the_same_type(&self, other: &Self) -> bool {
-    let IdType { module_reference: mod_ref1, id: id1, type_arguments: targs1, .. } = self;
-    let IdType { module_reference: mod_ref2, id: id2, type_arguments: targs2, .. } = other;
-    mod_ref1 == mod_ref2
-      && id1 == id2
-      && targs1.len() == targs2.len()
-      && targs1.iter().zip(targs2.iter()).all(|(a, b)| a.is_the_same_type(b))
-  }
-}
-
-impl IdType {
-  pub(crate) fn reposition(self, use_loc: Location) -> IdType {
-    IdType {
-      reason: self.reason.to_use_reason(use_loc),
-      module_reference: self.module_reference,
-      id: self.id,
-      type_arguments: self.type_arguments,
-    }
-  }
-}
-
-#[derive(Clone)]
-pub(crate) struct FunctionType {
-  pub(crate) reason: Reason,
-  pub(crate) argument_types: Vec<Rc<Type>>,
-  pub(crate) return_type: Rc<Type>,
-}
-
-impl ISourceType for FunctionType {
-  fn pretty_print(&self, heap: &Heap) -> String {
-    let FunctionType { reason: _, argument_types, return_type } = self;
-    format!(
-      "({}) -> {}",
-      join(argument_types.iter().map(|t| t.pretty_print(heap)), ", "),
-      return_type.pretty_print(heap)
-    )
-  }
-
-  fn is_the_same_type(&self, other: &Self) -> bool {
-    let FunctionType { reason: _, argument_types: arguments1, return_type: return_t1 } = self;
-    let FunctionType { reason: _, argument_types: arguments2, return_type: return_t2 } = other;
-    arguments1.len() == arguments2.len()
-      && arguments1.iter().zip(arguments2.iter()).all(|(a, b)| a.is_the_same_type(b))
-      && return_t1.is_the_same_type(return_t2)
-  }
-}
-
-impl FunctionType {
-  pub(crate) fn reposition(self, use_loc: Location) -> FunctionType {
-    FunctionType {
-      reason: self.reason.to_use_reason(use_loc),
-      argument_types: self.argument_types,
-      return_type: self.return_type,
-    }
-  }
-}
-
-#[derive(Clone, EnumAsInner)]
-pub(crate) enum Type {
-  Unknown(Reason),
-  Primitive(Reason, PrimitiveTypeKind),
-  Id(IdType),
-  Fn(FunctionType),
-}
-
-impl ISourceType for Type {
-  fn pretty_print(&self, heap: &Heap) -> String {
-    match self {
-      Self::Unknown(_) => String::from("unknown"),
-      Self::Primitive(_, p) => p.to_string(),
-      Self::Id(id_type) => id_type.pretty_print(heap),
-      Self::Fn(fn_type) => fn_type.pretty_print(heap),
-    }
-  }
-
-  fn is_the_same_type(&self, other: &Self) -> bool {
-    match (self, other) {
-      (Self::Unknown(_), Self::Unknown(_)) => true,
-      (Self::Primitive(_, p1), Self::Primitive(_, p2)) => *p1 == *p2,
-      (Self::Id(id1), Self::Id(id2)) => id1.is_the_same_type(id2),
-      (Self::Fn(f1), Self::Fn(f2)) => f1.is_the_same_type(f2),
-      _ => false,
-    }
-  }
-}
-
-impl Type {
-  pub(crate) fn unit_type(reason: Reason) -> Type {
-    Type::Primitive(reason, PrimitiveTypeKind::Unit)
-  }
-  pub(crate) fn bool_type(reason: Reason) -> Type {
-    Type::Primitive(reason, PrimitiveTypeKind::Bool)
-  }
-  pub(crate) fn int_type(reason: Reason) -> Type {
-    Type::Primitive(reason, PrimitiveTypeKind::Int)
-  }
-  pub(crate) fn string_type(reason: Reason) -> Type {
-    Type::Primitive(reason, PrimitiveTypeKind::String)
-  }
-
-  pub(crate) fn get_reason(&self) -> &Reason {
-    match self {
-      Self::Unknown(reason) => reason,
-      Self::Primitive(reason, _) => reason,
-      Self::Id(IdType { reason, .. }) => reason,
-      Self::Fn(FunctionType { reason, .. }) => reason,
-    }
-  }
-
-  pub(crate) fn mod_reason<F: FnOnce(&Reason) -> Reason>(&self, f: F) -> Type {
-    match self {
-      Self::Unknown(reason) => Type::Unknown(f(reason)),
-      Self::Primitive(reason, p) => Type::Primitive(f(reason), *p),
-      Self::Id(IdType { reason, module_reference, id, type_arguments }) => Type::Id(IdType {
-        reason: f(reason),
-        module_reference: *module_reference,
-        id: *id,
-        type_arguments: type_arguments.clone(),
-      }),
-      Self::Fn(FunctionType { reason, argument_types, return_type }) => Type::Fn(FunctionType {
-        reason: f(reason),
-        argument_types: argument_types.clone(),
-        return_type: return_type.clone(),
-      }),
-    }
-  }
-
-  pub(crate) fn reposition(&self, use_loc: Location) -> Type {
-    self.mod_reason(|r| r.to_use_reason(use_loc))
-  }
-}
-
-#[derive(Clone)]
-pub(crate) struct TypeParameterSignature {
-  pub(crate) name: PStr,
-  pub(crate) bound: Option<Rc<IdType>>,
-}
-
-impl TypeParameterSignature {
-  pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
-    match &self.bound {
-      Option::None => self.name.as_str(heap).to_string(),
-      Option::Some(id_type) => {
-        format!("{} : {}", self.name.as_str(heap), id_type.pretty_print(heap))
-      }
-    }
-  }
-
-  pub(crate) fn pretty_print_list(list: &Vec<TypeParameterSignature>, heap: &Heap) -> String {
-    if list.is_empty() {
-      "".to_string()
-    } else {
-      format!("<{}>", list.iter().map(|t| t.pretty_print(heap)).collect::<Vec<_>>().join(", "))
     }
   }
 }
@@ -374,6 +172,15 @@ pub(crate) mod expr {
   }
 
   impl ExpressionCommon {
+    #[cfg(test)]
+    pub(crate) fn dummy(type_: Rc<Type>) -> ExpressionCommon {
+      ExpressionCommon {
+        loc: Location::dummy(),
+        associated_comments: super::NO_COMMENT_REFERENCE,
+        type_,
+      }
+    }
+
     pub(crate) fn with_new_type(self, type_: Rc<Type>) -> ExpressionCommon {
       ExpressionCommon { loc: self.loc, associated_comments: self.associated_comments, type_ }
     }
@@ -914,89 +721,6 @@ pub(crate) mod test_builder {
         argument_types,
         return_type: Box::new(return_type),
       })
-    }
-
-    pub(crate) fn unit_type(&self) -> Rc<Type> {
-      Rc::new(Type::unit_type(self.reason.clone()))
-    }
-    pub(crate) fn bool_type(&self) -> Rc<Type> {
-      Rc::new(Type::bool_type(self.reason.clone()))
-    }
-    pub(crate) fn int_type(&self) -> Rc<Type> {
-      Rc::new(Type::int_type(self.reason.clone()))
-    }
-    pub(crate) fn string_type(&self) -> Rc<Type> {
-      Rc::new(Type::string_type(self.reason.clone()))
-    }
-
-    pub(crate) fn simple_id_type_unwrapped(&self, id: PStr) -> IdType {
-      IdType {
-        reason: self.reason.clone(),
-        module_reference: self.module_reference,
-        id,
-        type_arguments: vec![],
-      }
-    }
-
-    pub(crate) fn general_id_type_unwrapped(
-      &self,
-      id: PStr,
-      type_arguments: Vec<Rc<Type>>,
-    ) -> IdType {
-      IdType {
-        reason: self.reason.clone(),
-        module_reference: self.module_reference,
-        id,
-        type_arguments,
-      }
-    }
-
-    pub(crate) fn simple_id_type(&self, id: PStr) -> Rc<Type> {
-      Rc::new(Type::Id(self.simple_id_type_unwrapped(id)))
-    }
-
-    pub(crate) fn general_id_type(&self, id: PStr, type_arguments: Vec<Rc<Type>>) -> Rc<Type> {
-      Rc::new(Type::Id(self.general_id_type_unwrapped(id, type_arguments)))
-    }
-
-    pub(crate) fn fun_type(
-      &self,
-      argument_types: Vec<Rc<Type>>,
-      return_type: Rc<Type>,
-    ) -> Rc<Type> {
-      Rc::new(Type::Fn(FunctionType { reason: self.reason.clone(), argument_types, return_type }))
-    }
-
-    pub(crate) fn expr_common(&self, type_: Rc<Type>) -> expr::ExpressionCommon {
-      expr::ExpressionCommon {
-        loc: Location::dummy(),
-        associated_comments: NO_COMMENT_REFERENCE,
-        type_,
-      }
-    }
-
-    pub(crate) fn true_expr(&self) -> expr::E {
-      expr::E::Literal(self.expr_common(self.bool_type()), Literal::Bool(true))
-    }
-
-    pub(crate) fn false_expr(&self) -> expr::E {
-      expr::E::Literal(self.expr_common(self.bool_type()), Literal::Bool(false))
-    }
-
-    pub(crate) fn zero_expr(&self) -> expr::E {
-      self.int_lit(0)
-    }
-
-    pub(crate) fn int_lit(&self, value: i32) -> expr::E {
-      expr::E::Literal(self.expr_common(self.int_type()), Literal::Int(value))
-    }
-
-    pub(crate) fn string_expr(&self, s: PStr) -> expr::E {
-      expr::E::Literal(self.expr_common(self.string_type()), Literal::string_literal(s))
-    }
-
-    pub(crate) fn id_expr(&self, id: PStr, type_: Rc<Type>) -> expr::E {
-      expr::E::Id(self.expr_common(type_), Id::from(id))
     }
   }
 

--- a/crates/samlang-core/src/checker.rs
+++ b/crates/samlang-core/src/checker.rs
@@ -25,7 +25,7 @@ mod main_checker;
 mod ssa_analysis;
 mod ssa_analysis_tests;
 /// Definition of internal type language.
-mod type_;
+pub(crate) mod type_;
 /// All the typing context in one place.
 mod typing_context;
 mod typing_context_tests;

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -2,15 +2,13 @@
 mod tests {
   use crate::{
     ast::{
-      source::{
-        expr, test_builder, FieldType, FunctionType, Id, Type, TypeParameterSignature,
-        NO_COMMENT_REFERENCE,
-      },
+      source::{expr, FieldType, Id, Literal, NO_COMMENT_REFERENCE},
       Location, Reason,
     },
     checker::{
       main_checker::type_check_expression,
       ssa_analysis::{perform_ssa_analysis_on_expression, SsaAnalysisResult},
+      type_::{test_type_builder, FunctionType, Type, TypeParameterSignature},
       type_check_single_module_source, type_check_source_handles, type_check_sources,
       typing_context::{
         create_builtin_module_typing_context, GlobalTypingContext, InterfaceTypingContext,
@@ -52,7 +50,7 @@ mod tests {
       /* availableTypeParameters */ vec![],
     );
 
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     type_check_expression(
       &mut cx,
       &heap,
@@ -63,7 +61,10 @@ mod tests {
           type_: builder.bool_type(),
         },
         type_arguments: vec![],
-        object: Box::new(builder.true_expr()),
+        object: Box::new(expr::E::Literal(
+          expr::ExpressionCommon::dummy(builder.bool_type()),
+          Literal::Bool(true),
+        )),
         method_name: Id {
           loc: Location::dummy(),
           associated_comments: NO_COMMENT_REFERENCE,
@@ -75,7 +76,7 @@ mod tests {
   }
 
   fn sandbox_global_cx(heap: &mut Heap) -> GlobalTypingContext {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     HashMap::from([
       (ModuleReference::root(), create_builtin_module_typing_context(heap)),
@@ -587,7 +588,7 @@ mod tests {
   #[test]
   fn simple_expressions_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(heap, "true", &builder.bool_type());
     assert_checks(heap, "false", &builder.bool_type());
@@ -631,7 +632,7 @@ mod tests {
   #[test]
   fn class_members_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(
       heap,
@@ -699,7 +700,7 @@ mod tests {
   #[test]
   fn ctors_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     let test_str = heap.alloc_str("Test");
     let test2_str = heap.alloc_str("Test2");
@@ -788,7 +789,7 @@ mod tests {
   #[test]
   fn field_and_method_access_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(heap, "Test.init(true, 3).foo", &builder.bool_type());
     assert_checks(heap, "Test.init(true, 3).bar", &builder.int_type());
@@ -930,7 +931,7 @@ mod tests {
   #[test]
   fn function_call_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(heap, "Builtins.panic(\"\")", &builder.unit_type());
     assert_checks(heap, "Builtins.panic(\"\")", &builder.bool_type());
@@ -1003,7 +1004,7 @@ mod tests {
   #[test]
   fn unary_binary_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(heap, "-(1)", &builder.int_type());
     assert_checks(heap, "!true", &builder.bool_type());
@@ -1256,7 +1257,7 @@ mod tests {
   #[test]
   fn control_flow_expressions_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(heap, "if true then false else true", &builder.bool_type());
     assert_checks(heap, "if false then 1 else 0", &builder.int_type());
@@ -1345,7 +1346,7 @@ mod tests {
   #[test]
   fn lambdas_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(
       heap,
@@ -1371,7 +1372,7 @@ mod tests {
   #[test]
   fn blocks_checker_test() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_errors_with_class(
       heap,
@@ -1420,7 +1421,7 @@ mod tests {
 
   #[test]
   fn function_call_integration_test() {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_errors(
       &mut Heap::new(),
@@ -1450,7 +1451,7 @@ mod tests {
 
   #[test]
   fn checker_simple_integration_test() {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_checks(
       &mut Heap::new(),

--- a/crates/samlang-core/src/checker/checker_utils.rs
+++ b/crates/samlang-core/src/checker/checker_utils.rs
@@ -1,8 +1,6 @@
 use crate::{
-  ast::{
-    source::{FunctionType, ISourceType, IdType, Type, TypeParameterSignature},
-    Reason,
-  },
+  ast::Reason,
+  checker::type_::{FunctionType, ISourceType, IdType, Type, TypeParameterSignature},
   common::{Heap, PStr},
   errors::ErrorSet,
 };

--- a/crates/samlang-core/src/checker/checker_utils_tests.rs
+++ b/crates/samlang-core/src/checker/checker_utils_tests.rs
@@ -1,14 +1,9 @@
 #[cfg(test)]
 mod tests {
   use super::super::checker_utils::*;
-  use crate::{
-    ast::{
-      source::{test_builder, ISourceType, Type, TypeParameterSignature},
-      Reason,
-    },
-    common::Heap,
-    errors::ErrorSet,
-  };
+  use super::super::type_::{ISourceType, Type, TypeParameterSignature};
+  use crate::checker::type_::test_type_builder;
+  use crate::{ast::Reason, common::Heap, errors::ErrorSet};
   use pretty_assertions::assert_eq;
   use std::{collections::HashMap, rc::Rc};
 
@@ -25,7 +20,7 @@ mod tests {
   #[test]
   fn contextual_type_meet_tests() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_eq!(meet(&builder.unit_type(), &builder.unit_type(), heap), "unit");
     assert_eq!(meet(&builder.unit_type(), &builder.int_type(), heap), "FAILED_MEET");
@@ -161,7 +156,7 @@ mod tests {
   #[test]
   fn type_substitution_tests() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     assert_eq!(
       "(A<int, C<int>>, int, E<F>, int) -> int",
@@ -208,7 +203,7 @@ mod tests {
   #[test]
   fn id_type_substitution_panic_test() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     perform_id_type_substitution_asserting_id_type_return(
       &builder.simple_id_type_unwrapped(heap.alloc_str("A")),
@@ -243,7 +238,7 @@ mod tests {
   #[test]
   fn type_constrain_solver_tests() {
     let heap = &mut Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     // primitive types
     solver_test(
@@ -356,7 +351,7 @@ mod tests {
   fn type_constrain_solver_integration_test_1() {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     let TypeConstraintSolution {
       solved_substitution: _,
@@ -403,7 +398,7 @@ mod tests {
   fn type_constrain_solver_integration_test_2() {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     let TypeConstraintSolution {
       solved_substitution: _,

--- a/crates/samlang-core/src/checker/global_typing_context_builder.rs
+++ b/crates/samlang-core/src/checker/global_typing_context_builder.rs
@@ -2,6 +2,7 @@ use super::{
   checker_utils::{
     perform_fn_type_substitution, perform_id_type_substitution_asserting_id_type_return,
   },
+  type_::{FunctionType, ISourceType, IdType, Type, TypeParameterSignature},
   typing_context::{
     GlobalTypingContext, InterfaceTypingContext, MemberTypeInformation, ModuleTypingContext,
     TypeDefinitionTypingContext,
@@ -9,10 +10,7 @@ use super::{
 };
 use crate::{
   ast::{
-    source::{
-      ClassMemberDeclaration, FieldType, FunctionType, ISourceType, IdType, Module, Toplevel, Type,
-      TypeParameter, TypeParameterSignature,
-    },
+    source::{ClassMemberDeclaration, FieldType, Module, Toplevel, TypeParameter},
     Reason,
   },
   common::{Heap, ModuleReference, PStr},
@@ -564,12 +562,12 @@ mod tests {
   use crate::{
     ast::{
       source::{
-        test_builder, ClassMemberDefinition, CommentStore, Id, InterfaceDeclarationCommon,
+        expr, ClassMemberDefinition, CommentStore, Id, InterfaceDeclarationCommon, Literal,
         ModuleMembersImport, TypeDefinition, NO_COMMENT_REFERENCE,
       },
       Location,
     },
-    checker::typing_context::create_builtin_module_typing_context,
+    checker::{type_::test_type_builder, typing_context::create_builtin_module_typing_context},
     common::Heap,
   };
   use pretty_assertions::assert_eq;
@@ -578,7 +576,7 @@ mod tests {
   fn check_class_member_conformance_with_ast_tests() {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     check_class_member_conformance_with_ast(
       false,
@@ -805,7 +803,7 @@ mod tests {
   #[test]
   fn get_fully_inlined_multiple_interface_context_tests() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let unoptimized_global_cx = HashMap::from([(
       ModuleReference::dummy(),
       UnoptimizedModuleTypingContext {
@@ -1124,7 +1122,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
   #[test]
   fn check_module_member_interface_conformance_tests() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let unoptimized_global_cx = HashMap::from([(
       ModuleReference::dummy(),
       UnoptimizedModuleTypingContext {
@@ -1223,7 +1221,10 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
               },
               parameters: Rc::new(vec![]),
             },
-            body: builder.false_expr(),
+            body: expr::E::Literal(
+              expr::ExpressionCommon::dummy(builder.bool_type()),
+              Literal::Bool(false),
+            ),
           },
           ClassMemberDefinition {
             decl: ClassMemberDeclaration {
@@ -1240,7 +1241,10 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
               },
               parameters: Rc::new(vec![]),
             },
-            body: builder.false_expr(),
+            body: expr::E::Literal(
+              expr::ExpressionCommon::dummy(builder.bool_type()),
+              Literal::Bool(false),
+            ),
           },
         ],
       }),
@@ -1254,7 +1258,7 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
     let mut heap = Heap::new();
     let m0_ref = heap.alloc_module_reference_from_string_vec(vec!["Module0".to_string()]);
     let m1_ref = heap.alloc_module_reference_from_string_vec(vec!["Module1".to_string()]);
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     let test_sources = HashMap::from([
       (
@@ -1331,7 +1335,10 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
                     },
                     parameters: Rc::new(vec![]),
                   },
-                  body: builder.false_expr(),
+                  body: expr::E::Literal(
+                    expr::ExpressionCommon::dummy(builder.bool_type()),
+                    Literal::Bool(false),
+                  ),
                 },
                 ClassMemberDefinition {
                   decl: ClassMemberDeclaration {
@@ -1348,7 +1355,10 @@ super_types: IBase<int, int>, ILevel1<A, int>, ILevel2
                     },
                     parameters: Rc::new(vec![]),
                   },
-                  body: builder.false_expr(),
+                  body: expr::E::Literal(
+                    expr::ExpressionCommon::dummy(builder.bool_type()),
+                    Literal::Bool(false),
+                  ),
                 },
               ],
             }),

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -4,15 +4,15 @@ use super::{
     solve_multiple_type_constrains, TypeConstraint, TypeConstraintSolution,
   },
   ssa_analysis::perform_ssa_analysis_on_module,
+  type_::{FunctionType, ISourceType, IdType, PrimitiveTypeKind, Type, TypeParameterSignature},
   typing_context::{GlobalTypingContext, LocalTypingContext, TypingContext},
 };
 use crate::{
   ast::{
     source::{
       expr::{self, ObjectPatternDestucturedName},
-      ClassMemberDefinition, FunctionType, ISourceType, Id, IdType, InterfaceDeclarationCommon,
-      Literal, Module, OptionallyAnnotatedId, PrimitiveTypeKind, Toplevel, Type, TypeParameter,
-      TypeParameterSignature,
+      ClassMemberDefinition, Id, InterfaceDeclarationCommon, Literal, Module,
+      OptionallyAnnotatedId, Toplevel, TypeParameter,
     },
     Reason,
   },

--- a/crates/samlang-core/src/checker/ssa_analysis.rs
+++ b/crates/samlang-core/src/checker/ssa_analysis.rs
@@ -2,10 +2,11 @@ use crate::{
   ast::{
     source::{
       expr::{self, DeclarationStatement},
-      ClassMemberDeclaration, FunctionType, IdType, Module, OptionallyAnnotatedId, Toplevel, Type,
+      ClassMemberDeclaration, Module, OptionallyAnnotatedId, Toplevel,
     },
     Location,
   },
+  checker::type_::{FunctionType, IdType, Type},
   common::{Heap, LocalStackedContext, PStr},
   errors::ErrorSet,
 };

--- a/crates/samlang-core/src/checker/typing_context.rs
+++ b/crates/samlang-core/src/checker/typing_context.rs
@@ -1,14 +1,10 @@
 use super::{
   checker_utils::{perform_fn_type_substitution, perform_type_substitution},
   ssa_analysis::SsaAnalysisResult,
+  type_::{FunctionType, ISourceType, IdType, PrimitiveTypeKind, Type, TypeParameterSignature},
 };
 use crate::{
-  ast::{
-    source::{
-      FieldType, FunctionType, ISourceType, IdType, PrimitiveTypeKind, Type, TypeParameterSignature,
-    },
-    Location, Reason,
-  },
+  ast::{source::FieldType, Location, Reason},
   common::{Heap, ModuleReference, PStr},
   errors::ErrorSet,
 };

--- a/crates/samlang-core/src/checker/typing_context_tests.rs
+++ b/crates/samlang-core/src/checker/typing_context_tests.rs
@@ -1,12 +1,10 @@
 #[cfg(test)]
 mod tests {
   use crate::{
-    ast::{
-      source::{test_builder, FieldType, FunctionType, ISourceType, Type, TypeParameterSignature},
-      Location, Reason,
-    },
+    ast::{source::FieldType, Location, Reason},
     checker::{
       ssa_analysis::SsaAnalysisResult,
+      type_::{test_type_builder, FunctionType, ISourceType, Type, TypeParameterSignature},
       typing_context::{
         create_builtin_module_typing_context, InterfaceTypingContext, LocalTypingContext,
         MemberTypeInformation, ModuleTypingContext, TypeDefinitionTypingContext, TypingContext,
@@ -112,7 +110,7 @@ m2: public () -> unknown
       .to_string(&heap)
     );
 
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     assert_eq!(
       "a:bool, b:(private) bool",
       TypeDefinitionTypingContext {
@@ -155,7 +153,7 @@ m2: public () -> unknown
   #[test]
   fn is_subtype_tests() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let mut local_cx = empty_local_typing_context();
     let mut error_set = ErrorSet::new();
     let global_cx = HashMap::from([(
@@ -222,7 +220,7 @@ m2: public () -> unknown
 
   #[test]
   fn validate_type_instantiation_tests() {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let mut local_cx = empty_local_typing_context();
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
@@ -314,7 +312,7 @@ __DUMMY__.sam:0:0-0:0: [UnexpectedTypeKind]: Expected kind: `non-abstract type`,
 
   #[test]
   fn get_members_test() {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let mut local_cx = empty_local_typing_context();
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
@@ -620,7 +618,7 @@ __DUMMY__.sam:0:0-0:0: [UnexpectedTypeKind]: Expected kind: `non-abstract type`,
 
   #[test]
   fn resolve_type_definitions_test() {
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let mut local_cx = empty_local_typing_context();
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();

--- a/crates/samlang-core/src/errors.rs
+++ b/crates/samlang-core/src/errors.rs
@@ -184,7 +184,7 @@ impl ErrorSet {
 mod tests {
   use super::*;
   use crate::{
-    ast::source::{test_builder, ISourceType},
+    checker::type_::{test_type_builder, ISourceType},
     common::Heap,
   };
   use pretty_assertions::assert_eq;
@@ -225,7 +225,7 @@ mod tests {
   fn error_message_tests() {
     let heap = Heap::new();
     let mut error_set = ErrorSet::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
 
     error_set.report_syntax_error(Location::dummy(), "bad code".to_string());
     error_set.report_unexpected_type_error(

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -485,10 +485,10 @@ mod tests {
   use super::*;
   use crate::{
     ast::{
-      source::{CommentStore, Id, InterfaceDeclarationCommon, Type, NO_COMMENT_REFERENCE},
+      source::{CommentStore, Id, InterfaceDeclarationCommon, NO_COMMENT_REFERENCE},
       Location, Reason,
     },
-    checker::type_check_single_module_source,
+    checker::{type_::Type, type_check_single_module_source},
     common::Heap,
     errors::ErrorSet,
     parser::parse_source_module_from_text,
@@ -510,11 +510,7 @@ mod tests {
   }
 
   fn dummy_expr_common() -> expr::ExpressionCommon {
-    expr::ExpressionCommon {
-      loc: Location::dummy(),
-      associated_comments: NO_COMMENT_REFERENCE,
-      type_: Rc::new(Type::int_type(Reason::dummy())),
-    }
+    expr::ExpressionCommon::dummy(Rc::new(Type::int_type(Reason::dummy())))
   }
 
   fn eval_expr_simple(heap: &mut Heap, expr: &expr::E) -> Value {

--- a/crates/samlang-core/src/parser/source_parser.rs
+++ b/crates/samlang-core/src/parser/source_parser.rs
@@ -1,6 +1,7 @@
 use super::lexer::{Keyword, Token, TokenContent, TokenOp};
 use crate::{
   ast::{source::*, Location, Position, Reason},
+  checker::type_::{FunctionType, IdType, Type},
   common::{Heap, ModuleReference, PStr},
   errors::ErrorSet,
 };

--- a/crates/samlang-core/src/printer/source_printer.rs
+++ b/crates/samlang-core/src/printer/source_printer.rs
@@ -1,9 +1,10 @@
 use super::prettier::Document;
 use crate::{
   ast::source::{
-    expr, ClassDefinition, ClassMemberDeclaration, CommentKind, CommentReference, CommentStore,
-    ISourceType, Id, IdType, InterfaceDeclaration, Module, Toplevel, Type, TypeParameter,
+    expr, ClassDefinition, ClassMemberDeclaration, CommentKind, CommentReference, CommentStore, Id,
+    InterfaceDeclaration, Module, Toplevel, TypeParameter,
   },
+  checker::type_::{ISourceType, IdType, Type},
   common::{rc_pstr, rc_string, rcs, Heap},
   ModuleReference,
 };
@@ -829,7 +830,8 @@ pub(super) fn source_module_to_document(heap: &Heap, module: &Module) -> Documen
 #[cfg(test)]
 mod tests {
   use crate::{
-    ast::source::{expr, test_builder, CommentStore, Id},
+    ast::source::{expr, CommentStore, Id},
+    checker::type_::test_type_builder,
     common::{Heap, ModuleReference},
     errors::ErrorSet,
     parser::{parse_source_expression_from_text, parse_source_module_from_text},
@@ -930,7 +932,7 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
 
     assert_reprint_expr("foo.bar", "foo.bar");
 
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     let empty_comment_store = CommentStore::new();
     let mut heap = Heap::new();
     assert_eq!(
@@ -938,9 +940,12 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
       prettier::pretty_print(
         40,
         expr::E::MethodAccess(expr::MethodAccess {
-          common: builder.expr_common(builder.int_type()),
+          common: expr::ExpressionCommon::dummy(builder.int_type()),
           type_arguments: vec![],
-          object: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.int_type())),
+          object: Box::new(expr::E::Id(
+            expr::ExpressionCommon::dummy(builder.int_type()),
+            Id::from(heap.alloc_str("foo"))
+          )),
           method_name: Id::from(heap.alloc_str("bar"))
         })
         .create_doc(&heap, &empty_comment_store)
@@ -952,9 +957,12 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
       prettier::pretty_print(
         40,
         expr::E::MethodAccess(expr::MethodAccess {
-          common: builder.expr_common(builder.int_type()),
+          common: expr::ExpressionCommon::dummy(builder.int_type()),
           type_arguments: vec![builder.int_type()],
-          object: Box::new(builder.id_expr(heap.alloc_str("foo"), builder.int_type())),
+          object: Box::new(expr::E::Id(
+            expr::ExpressionCommon::dummy(builder.int_type()),
+            Id::from(heap.alloc_str("foo"))
+          )),
           method_name: Id::from(heap.alloc_str("bar"))
         })
         .create_doc(&heap, &empty_comment_store)

--- a/crates/samlang-core/src/services/api.rs
+++ b/crates/samlang-core/src/services/api.rs
@@ -6,13 +6,13 @@ use super::{
 use crate::{
   ast::{
     source::{
-      expr, ClassMemberDeclaration, CommentKind, CommentReference, CommentStore, ISourceType,
-      Module, Toplevel,
+      expr, ClassMemberDeclaration, CommentKind, CommentReference, CommentStore, Module, Toplevel,
     },
     Location, Position,
   },
   checker::{
-    type_check_sources, GlobalTypingContext, InterfaceTypingContext, MemberTypeInformation,
+    type_::ISourceType, type_check_sources, GlobalTypingContext, InterfaceTypingContext,
+    MemberTypeInformation,
   },
   common::{Heap, ModuleReference, PStr},
   errors::{CompileTimeError, ErrorSet},

--- a/crates/samlang-core/src/services/gc.rs
+++ b/crates/samlang-core/src/services/gc.rs
@@ -1,5 +1,6 @@
 use crate::{
-  ast::source::{expr, FunctionType, Id, IdType, Module, Toplevel, Type, TypeParameter},
+  ast::source::{expr, Id, Module, Toplevel, TypeParameter},
+  checker::type_::{FunctionType, IdType, Type},
   Heap, ModuleReference,
 };
 use std::{collections::HashMap, rc::Rc};

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -1,8 +1,9 @@
 use crate::{
   ast::{
-    source::{expr, Module, Toplevel, Type},
+    source::{expr, Module, Toplevel},
     Location, Position,
   },
+  checker::type_::Type,
   common::PStr,
   ModuleReference,
 };
@@ -165,10 +166,10 @@ pub(super) fn search_module(
 mod tests {
   use crate::{
     ast::{
-      source::{expr, Id, Type, NO_COMMENT_REFERENCE},
+      source::{expr, Id, NO_COMMENT_REFERENCE},
       Location, Position, Reason,
     },
-    checker::type_check_source_handles,
+    checker::{type_::Type, type_check_source_handles},
     Heap, ModuleReference,
   };
   use std::rc::Rc;

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -297,9 +297,10 @@ mod tests {
   use super::{apply_expr_renaming, apply_renaming, DefinitionAndUses, VariableDefinitionLookup};
   use crate::{
     ast::{
-      source::{expr, test_builder, Id, Module},
+      source::{expr, Id, Literal, Module},
       Location, Position,
     },
+    checker::type_::test_type_builder,
     common::{Heap, ModuleReference},
     errors::ErrorSet,
     parser::parse_source_module_from_text,
@@ -311,12 +312,15 @@ mod tests {
   #[test]
   fn coverage_booster_tests() {
     let mut heap = Heap::new();
-    let builder = test_builder::create();
+    let builder = test_type_builder::create();
     apply_expr_renaming(
       &expr::E::MethodAccess(expr::MethodAccess {
-        common: builder.expr_common(builder.int_type()),
+        common: expr::ExpressionCommon::dummy(builder.int_type()),
         type_arguments: vec![],
-        object: Box::new(builder.zero_expr()),
+        object: Box::new(expr::E::Literal(
+          expr::ExpressionCommon::dummy(builder.int_type()),
+          Literal::Int(0),
+        )),
         method_name: Id::from(heap.alloc_str("")),
       }),
       &DefinitionAndUses {


### PR DESCRIPTION
[repo] Switch location of type related import
This diff makes the type nodes in the checker package be the canonical representation of the internal type language. All imports are updated to reflect that.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/940).
* __->__ #940
