### PR TITLE
[perf][lexer][checker] Avoid unnecessary allocations

### DIFF
--- a/crates/samlang-cli/src/main.rs
+++ b/crates/samlang-cli/src/main.rs
@@ -463,46 +463,51 @@ mod runners {
     }
   }
 
-  fn compile_single() {
-    let configuration = utils::get_configuration();
-    let heap = &mut samlang_core::Heap::new();
-    let entry_module_references = configuration
-      .entry_points
-      .iter()
-      .map(|entry_point| {
-        heap.alloc_module_reference_from_string_vec(
-          entry_point.split('.').map(|s| s.to_string()).collect(),
-        )
-      })
-      .collect::<Vec<_>>();
-    let enable_profiling = std::env::var("PROFILE").is_ok();
-    let collected_sources =
-      samlang_core::measure_time(enable_profiling, "Collecting sources", || {
-        utils::collect_sources(&configuration, heap)
-      });
-    match samlang_core::compile_sources(
-      heap,
-      collected_sources,
-      entry_module_references,
-      enable_profiling,
-    ) {
-      Ok(samlang_core::SourcesCompilationResult { text_code_results, wasm_file }) => {
-        if fs::create_dir_all(&configuration.output_directory).is_ok() {
-          for (file, content) in text_code_results {
-            fs::write(PathBuf::from(&configuration.output_directory).join(file), content).unwrap();
-          }
-          fs::write(PathBuf::from(&configuration.output_directory).join("__all__.wasm"), wasm_file)
+  fn compile_single(enable_profiling: bool) {
+    samlang_core::measure_time(enable_profiling, "Full run", || {
+      let configuration = utils::get_configuration();
+      let heap = &mut samlang_core::Heap::new();
+      let entry_module_references = configuration
+        .entry_points
+        .iter()
+        .map(|entry_point| {
+          heap.alloc_module_reference_from_string_vec(
+            entry_point.split('.').map(|s| s.to_string()).collect(),
+          )
+        })
+        .collect::<Vec<_>>();
+      let collected_sources =
+        samlang_core::measure_time(enable_profiling, "Collecting sources", || {
+          utils::collect_sources(&configuration, heap)
+        });
+      match samlang_core::compile_sources(
+        heap,
+        collected_sources,
+        entry_module_references,
+        enable_profiling,
+      ) {
+        Ok(samlang_core::SourcesCompilationResult { text_code_results, wasm_file }) => {
+          if fs::create_dir_all(&configuration.output_directory).is_ok() {
+            for (file, content) in text_code_results {
+              fs::write(PathBuf::from(&configuration.output_directory).join(file), content)
+                .unwrap();
+            }
+            fs::write(
+              PathBuf::from(&configuration.output_directory).join("__all__.wasm"),
+              wasm_file,
+            )
             .unwrap();
+          }
+        }
+        Err(errors) => {
+          eprintln!("Found {} error(s).", errors.len());
+          for e in errors {
+            eprintln!("{e}");
+          }
+          std::process::exit(1)
         }
       }
-      Err(errors) => {
-        eprintln!("Found {} error(s).", errors.len());
-        for e in errors {
-          eprintln!("{e}");
-        }
-        std::process::exit(1)
-      }
-    }
+    });
   }
 
   pub(super) fn compile(need_help: bool) {
@@ -511,8 +516,9 @@ mod runners {
     } else {
       let benchmark_repeat =
         std::env::var("BENCHMARK_REPEAT").ok().and_then(|s| s.parse::<usize>().ok()).unwrap_or(1);
+      let enable_profiling = std::env::var("PROFILE").is_ok();
       for _ in 0..benchmark_repeat {
-        compile_single();
+        compile_single(enable_profiling);
       }
     }
   }

--- a/crates/samlang-core/src/compiler/wasm_lowering.rs
+++ b/crates/samlang-core/src/compiler/wasm_lowering.rs
@@ -3,7 +3,7 @@ use crate::{
   common::{Heap, PStr},
 };
 use itertools::Itertools;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 #[derive(Clone)]
 struct LoopContext {
@@ -262,9 +262,8 @@ pub(super) fn compile_mir_to_wasm(heap: &mut Heap, sources: &mir::Sources) -> wa
       .functions
       .iter()
       .map(|it| it.parameters.len())
-      .collect::<HashSet<_>>()
+      .collect::<BTreeSet<_>>()
       .into_iter()
-      .sorted()
       .collect_vec(),
     global_variables,
     exported_functions: sources.main_function_names.clone(),

--- a/crates/samlang-core/src/lib.rs
+++ b/crates/samlang-core/src/lib.rs
@@ -55,8 +55,7 @@ pub fn compile_sources(
   } = measure_time(enable_profiling, "Type checking", || {
     checker::type_check_source_handles(heap, source_handles)
   });
-  let mut errors =
-    compile_time_errors.iter().sorted().map(|it| it.pretty_print(heap)).collect_vec();
+  let mut errors = compile_time_errors.iter().map(|it| it.pretty_print(heap)).collect_vec();
   for module_reference in &entry_module_references {
     if !checked_sources.contains_key(module_reference) {
       errors.insert(

--- a/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
+++ b/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
@@ -3,14 +3,13 @@ use crate::{
   ast::hir::{Binary, Function, Statement},
   Heap,
 };
-use itertools::Itertools;
 use std::collections::BTreeSet;
 
 fn intersection_of(
   set1: BTreeSet<BindedValue>,
   others: Vec<BTreeSet<BindedValue>>,
 ) -> Vec<BindedValue> {
-  set1.into_iter().filter(|e| others.iter().all(|it| it.contains(e))).sorted().collect()
+  set1.into_iter().filter(|e| others.iter().all(|it| it.contains(e))).collect()
 }
 
 fn produce_hoisted_stmt(heap: &mut Heap, value: BindedValue) -> Statement {

--- a/crates/samlang-core/src/optimization/conditional_constant_propagation.rs
+++ b/crates/samlang-core/src/optimization/conditional_constant_propagation.rs
@@ -296,7 +296,7 @@ fn optimize_stmt(
           optimized_final_assignments.push((*n, t.clone(), e1, e2));
         }
       }
-      if_else_or_null(condition, s1, s2, optimized_final_assignments)
+      if_else_or_null(condition, s1, s2, optimized_final_assignments).into_iter().collect()
     }
 
     Statement::SingleIf { condition, invert_condition, statements } => {

--- a/crates/samlang-core/src/optimization/optimization_common.rs
+++ b/crates/samlang-core/src/optimization/optimization_common.rs
@@ -76,11 +76,11 @@ pub(super) fn if_else_or_null(
   s1: Vec<Statement>,
   s2: Vec<Statement>,
   final_assignments: Vec<(PStr, Type, Expression, Expression)>,
-) -> Vec<Statement> {
+) -> Option<Statement> {
   if s1.is_empty() && s2.is_empty() && final_assignments.is_empty() {
-    vec![]
+    None
   } else {
-    vec![Statement::IfElse { condition, s1, s2, final_assignments }]
+    Some(Statement::IfElse { condition, s1, s2, final_assignments })
   }
 }
 
@@ -102,8 +102,8 @@ mod tests {
 
   #[test]
   fn boilterplate() {
-    assert!(if_else_or_null(ZERO, vec![], vec![], vec![]).is_empty());
-    assert!(!if_else_or_null(ZERO, vec![], vec![Statement::Break(ZERO)], vec![]).is_empty());
+    assert!(if_else_or_null(ZERO, vec![], vec![], vec![]).is_none());
+    assert!(if_else_or_null(ZERO, vec![], vec![Statement::Break(ZERO)], vec![]).is_some());
     assert!(single_if_or_null(ZERO, false, vec![]).is_empty());
     assert!(!single_if_or_null(ZERO, false, vec![Statement::Break(ZERO)]).is_empty());
 
@@ -118,6 +118,8 @@ mod tests {
     bv2.dump_to_string();
     let _ = bv1.clone();
     let _ = bv2.clone();
+    assert_eq!(Some(std::cmp::Ordering::Equal), bv1.partial_cmp(&bv1));
+    assert_eq!(Some(std::cmp::Ordering::Equal), bv2.partial_cmp(&bv2));
     assert!(bv1.eq(&bv1));
     assert!(bv2.eq(&bv2));
   }

--- a/crates/samlang-core/src/parser/source_parser.rs
+++ b/crates/samlang-core/src/parser/source_parser.rs
@@ -141,11 +141,7 @@ impl<'a> SourceParser<'a> {
     }
     self.report(
       location,
-      format!(
-        "Expected: {}, actual: {}.",
-        expected_kind.to_string(),
-        content.pretty_print(self.heap)
-      ),
+      format!("Expected: {}, actual: {}.", expected_kind.as_str(), content.pretty_print(self.heap)),
     );
     location
   }
@@ -161,11 +157,7 @@ impl<'a> SourceParser<'a> {
     }
     self.report(
       location,
-      format!(
-        "Expected: {}, actual: {}.",
-        expected_kind.to_string(),
-        content.pretty_print(self.heap)
-      ),
+      format!("Expected: {}, actual: {}.", expected_kind.as_str(), content.pretty_print(self.heap)),
     );
     location
   }

--- a/sconfig.json
+++ b/sconfig.json
@@ -1,4 +1,4 @@
 {
   "entryPoints": ["tests.AllTests"],
-  "ignores": [".git", "coverage", "crates", "samlang-", "target", "jest-", "node_modules"]
+  "ignores": [".git", ".sl", "crates", "packages", "runtime", "target", "out", "node_modules"]
 }


### PR DESCRIPTION
[perf][lexer][checker] Avoid unnecessary allocations
Lexer optimization: avoid string traversal and allocation
Checker: removed a bunch of clones

4m35s -> 3m40s: 20% pref improvement

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/943).
* __->__ #943
