### PR TITLE
[checker] Non-destructive type checking

### DIFF
--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -188,7 +188,7 @@ pub(crate) mod expr {
       }
     }
 
-    pub(crate) fn with_new_type<NT: Clone>(self, type_: NT) -> ExpressionCommon<NT> {
+    pub(crate) fn with_new_type<NT: Clone>(&self, type_: NT) -> ExpressionCommon<NT> {
       ExpressionCommon { loc: self.loc, associated_comments: self.associated_comments, type_ }
     }
   }

--- a/crates/samlang-core/src/checker.rs
+++ b/crates/samlang-core/src/checker.rs
@@ -25,17 +25,17 @@ mod typing_context_tests;
 pub(crate) use ssa_analysis::{perform_ssa_analysis_on_module, SsaAnalysisResult};
 
 pub(crate) fn type_check_sources(
-  sources: HashMap<ModuleReference, Module<()>>,
+  sources: &HashMap<ModuleReference, Module<()>>,
   heap: &mut Heap,
   error_set: &mut ErrorSet,
 ) -> (HashMap<ModuleReference, Module<std::rc::Rc<type_::Type>>>, type_::GlobalSignature) {
   let builtin_cx = type_::create_builtin_module_signature(heap);
-  let global_cx = global_signature::build_global_signature(&sources, heap, builtin_cx);
+  let global_cx = global_signature::build_global_signature(sources, heap, builtin_cx);
   let mut checked_sources = HashMap::new();
   for (module_reference, module) in sources {
     let checked =
-      main_checker::type_check_module(module_reference, module, &global_cx, heap, error_set);
-    checked_sources.insert(module_reference, checked);
+      main_checker::type_check_module(*module_reference, module, &global_cx, heap, error_set);
+    checked_sources.insert(*module_reference, checked);
   }
   (checked_sources, global_cx)
 }

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -50,7 +50,7 @@ mod tests {
     type_check_expression(
       &mut cx,
       &heap,
-      expr::E::MethodAccess(expr::MethodAccess {
+      &expr::E::MethodAccess(expr::MethodAccess {
         common: expr::ExpressionCommon {
           loc: Location::dummy(),
           associated_comments: NO_COMMENT_REFERENCE,
@@ -519,7 +519,7 @@ mod tests {
       /* availableTypeParameters */ vec![],
     );
 
-    type_check_expression(&mut cx, heap, parsed, Some(expected_type));
+    type_check_expression(&mut cx, heap, &parsed, Some(expected_type));
     error_set.error_messages(heap)
   }
 
@@ -1443,7 +1443,7 @@ mod tests {
       let parsed = parse_source_module_from_text(source, mod_ref, &mut heap, &mut error_set);
       unchecked_sources.insert(mod_ref, parsed);
     }
-    type_check_sources(unchecked_sources, &mut heap, &mut error_set);
+    type_check_sources(&unchecked_sources, &mut heap, &mut error_set);
     assert_eq!(expected_errors, error_set.error_messages(&heap));
   }
 

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -523,7 +523,7 @@ class Main {
         (mod_ref, parse_source_module_from_text(it.source_code, mod_ref, heap, &mut error_set))
       })
       .collect::<HashMap<_, _>>();
-    type_check_sources(sources, heap, &mut error_set);
+    type_check_sources(&sources, heap, &mut error_set);
     let actual_errors =
       error_set.into_errors().iter().map(|it| it.pretty_print(heap)).collect_vec();
     assert_eq!(expected_errors, actual_errors);
@@ -1692,7 +1692,7 @@ class Main {
       let parsed_module =
         parse_source_module_from_text(source_code, mod_ref, &mut heap, &mut error_set);
       let (checked_sources, _) =
-        type_check_sources(HashMap::from([(mod_ref, parsed_module)]), &mut heap, &mut error_set);
+        type_check_sources(&HashMap::from([(mod_ref, parsed_module)]), &mut heap, &mut error_set);
       let actual_std =
         interpreter::run_source_module(&mut heap, checked_sources.get(&mod_ref).unwrap());
       assert_eq!(expected_std, actual_std);
@@ -1716,7 +1716,7 @@ class Main {
       let raw = printer::pretty_print_source_module(heap, 100, &module);
       let mut error_set = ErrorSet::new();
       let (checked_sources, _) = type_check_sources(
-        HashMap::from([(
+        &HashMap::from([(
           mod_ref,
           parse_source_module_from_text(&raw, mod_ref, heap, &mut error_set),
         )]),
@@ -1742,7 +1742,7 @@ class Main {
         (mod_ref, parse_source_module_from_text(it.source_code, mod_ref, heap, &mut error_set))
       })
       .collect::<HashMap<_, _>>();
-    let (checked_sources, _) = type_check_sources(sources, heap, &mut error_set);
+    let (checked_sources, _) = type_check_sources(&sources, heap, &mut error_set);
     assert!(error_set.into_errors().is_empty());
     let unoptimized_hir_sources = compiler::compile_sources_to_hir(heap, &checked_sources);
     let optimized_hir_sources = optimization::optimize_sources(

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -646,7 +646,7 @@ mod tests {
       &mut error_set,
     );
     let checked =
-      type_check_sources(HashMap::from([(mod_ref, parsed_module)]), &mut heap, &mut error_set).0;
+      type_check_sources(&HashMap::from([(mod_ref, parsed_module)]), &mut heap, &mut error_set).0;
     run(&mut heap, checked.get(&mod_ref).unwrap());
   }
 }

--- a/crates/samlang-core/src/lib.rs
+++ b/crates/samlang-core/src/lib.rs
@@ -58,7 +58,7 @@ pub fn compile_sources(
     }
   });
   let checked_sources = measure_time(enable_profiling, "Type checking", || {
-    checker::type_check_sources(parsed_sources, heap, &mut error_set).0
+    checker::type_check_sources(&parsed_sources, heap, &mut error_set).0
   });
   let mut errors = error_set.into_errors().iter().map(|it| it.pretty_print(heap)).collect_vec();
   for module_reference in &entry_module_references {

--- a/crates/samlang-core/src/services/api.rs
+++ b/crates/samlang-core/src/services/api.rs
@@ -98,7 +98,7 @@ impl LanguageServices {
     let mut error_set = ErrorSet::new();
     let (checked_modules, global_cx) = measure_time(self.enable_profiling, "Recheck", || {
       type_check_sources(
-        self
+        &self
           .raw_sources
           .iter()
           .map(|(mod_ref, text)| {

--- a/crates/samlang-core/src/services/gc.rs
+++ b/crates/samlang-core/src/services/gc.rs
@@ -315,8 +315,11 @@ mod tests {
       heap,
       &mut error_set,
     );
-    let (checked_sources, _) =
-      type_check_sources(HashMap::from([(ModuleReference::dummy(), parsed)]), heap, &mut error_set);
+    let (checked_sources, _) = type_check_sources(
+      &HashMap::from([(ModuleReference::dummy(), parsed)]),
+      heap,
+      &mut error_set,
+    );
     super::perform_gc_after_recheck(heap, &checked_sources, vec![ModuleReference::root()]);
     super::perform_gc_after_recheck(heap, &checked_sources, vec![ModuleReference::dummy()]);
     assert_eq!("", heap.debug_unmarked_strings());

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -296,7 +296,7 @@ mod tests {
       &mut error_set,
     );
     let (checked_sources, _) =
-      type_check_sources(HashMap::from([(mod_ref, parsed)]), heap, &mut error_set);
+      type_check_sources(&HashMap::from([(mod_ref, parsed)]), heap, &mut error_set);
     assert!(error_set.into_errors().is_empty());
     for m in checked_sources.values() {
       for i in 0..80 {


### PR DESCRIPTION
[checker] Non-destructive type checking
This diff makes type checking takes in a reference of parsed source, so that in the services, we can keep both.
