### PR TITLE
[vscode] Support restarting client

### DIFF
--- a/packages/samlang-vscode/package.json
+++ b/packages/samlang-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-samlang",
   "displayName": "vscode-samlang",
   "description": "samlang for VSCode",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "publisher": "dev-sam",
   "repository": {
     "url": "https://github.com/SamChou19815/samlang"
@@ -38,6 +38,13 @@
         "language": "samlang",
         "scopeName": "text.samlang",
         "path": "./syntaxes/samlang.json"
+      }
+    ],
+    "commands": [
+      {
+        "title": "Restart Client",
+        "category": "samlang",
+        "command": "samlang.restartClient"
       }
     ],
     "snippets": [

--- a/packages/samlang-vscode/src/extension.ts
+++ b/packages/samlang-vscode/src/extension.ts
@@ -1,30 +1,43 @@
-import * as fs from "fs";
-import * as path from "path";
-import * as vscode from "vscode";
-import { LanguageClient, TransportKind } from "vscode-languageclient/node";
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { LanguageClient, TransportKind } from 'vscode-languageclient/node';
 
 let languageClient: LanguageClient | undefined;
 
-export function activate(): void {
-  const serverModule = vscode.workspace.getConfiguration().get("samlang.programPath");
-  if (typeof serverModule !== "string") {
+function createLanguageClient(absoluteServerModule: string) {
+  return new LanguageClient(
+    'samlang',
+    'samlang Language Client',
+    { command: absoluteServerModule, args: ['lsp'], transport: TransportKind.stdio },
+    { documentSelector: [{ scheme: 'file', language: 'samlang' }] }
+  );
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const serverModule = vscode.workspace.getConfiguration().get('samlang.programPath');
+  if (typeof serverModule !== 'string') {
     throw new Error(`Invalid LSP program path: ${serverModule}.`);
   }
   const resolvedServerModules = (vscode.workspace.workspaceFolders ?? [])
     .map((folder) => path.join(folder.uri.fsPath, serverModule))
     .filter((it) => fs.existsSync(it));
-  if (resolvedServerModules.length > 1) throw new Error("Too many samlang LSP programs found.");
+  if (resolvedServerModules.length > 1) throw new Error('Too many samlang LSP programs found.');
   const absoluteServerModule = resolvedServerModules[0];
-  if (absoluteServerModule == null) throw new Error("No valid samlang LSP program found.");
+  if (absoluteServerModule == null) throw new Error('No valid samlang LSP program found.');
 
-  languageClient = new LanguageClient(
-    "samlang",
-    "samlang Language Client",
-    { command: absoluteServerModule, args: ["lsp"], transport: TransportKind.stdio },
-    { documentSelector: [{ scheme: "file", language: "samlang" }] },
-  );
+  languageClient = createLanguageClient(absoluteServerModule);
 
   languageClient.start();
+  context.subscriptions.push(
+    vscode.commands.registerCommand('samlang.restartClient', async () => {
+      console.info('Restarting client...');
+      await languageClient?.stop();
+      languageClient = createLanguageClient(absoluteServerModule);
+      await languageClient.start();
+      console.info('Client restarted');
+    })
+  );
   // eslint-disable-next-line no-console
   console.info('Congratulations, your extension "vscode-samlang" is now active!');
 }
@@ -36,6 +49,6 @@ export function deactivate(): void {
       // eslint-disable-next-line no-console
       .catch((error) => console.error(error))
       // eslint-disable-next-line no-console
-      .then(() => console.error("samlang client dead."));
+      .then(() => console.error('samlang client dead.'));
   }
 }


### PR DESCRIPTION
[vscode] Support restarting client
This makes developing LSP much easier. No need to reload VSCode to restart language server.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/955).
* __->__ #955
