### PR TITLE
[lsp] Drop support for completion snippets

### DIFF
--- a/crates/samlang-cli/src/main.rs
+++ b/crates/samlang-cli/src/main.rs
@@ -429,10 +429,6 @@ mod lsp {
           }),
           detail: Some(item.detail),
           insert_text: Some(item.insert_text),
-          insert_text_format: Some(match item.insert_text_format {
-            services::api::completion::InsertTextFormat::PlainText => InsertTextFormat::PLAIN_TEXT,
-            services::api::completion::InsertTextFormat::Snippet => InsertTextFormat::SNIPPET,
-          }),
           ..Default::default()
         })
         .collect(),

--- a/crates/samlang-wasm/src/lib.rs
+++ b/crates/samlang-wasm/src/lib.rs
@@ -61,8 +61,6 @@ struct AutoCompletionItem {
   label: String,
   #[serde(rename(serialize = "insertText"))]
   insert_text: String,
-  #[serde(rename(serialize = "insertTextRules"))]
-  insert_text_rules: i32,
   kind: i32,
   detail: String,
 }
@@ -142,10 +140,6 @@ pub fn autocomplete(source: String, line: i32, column: i32) -> JsValue {
       range: Range { start_line: line, start_col: column, end_line: line, end_col: column },
       label: item.label,
       insert_text: item.insert_text,
-      insert_text_rules: match item.insert_text_format {
-        samlang_core::services::api::completion::InsertTextFormat::PlainText => 1,
-        samlang_core::services::api::completion::InsertTextFormat::Snippet => 4,
-      },
       kind: item.kind as i32,
       detail: item.detail,
     })

--- a/crates/samlang-wasm/test-samlang-wasm.mjs
+++ b/crates/samlang-wasm/test-samlang-wasm.mjs
@@ -47,8 +47,9 @@ assertEqual(
 
 assertEqual(
   JSON.stringify(
-    await samlang.autoComplete(
-      `
+    (
+      await samlang.autoComplete(
+        `
 class Main {
   function main(a: Developer): Developer = a.
 }
@@ -57,9 +58,10 @@ class Developer {
   method b(): unit = {}
 }
 `,
-      3,
-      46
-    )
+        3,
+        46
+      )
+    ).map(({ insertText, ...rest }) => rest)
   ),
-  '[{"range":{"startLineNumber":3,"startColumn":46,"endLineNumber":3,"endColumn":46},"label":"b(): unit","insertText":"b()","insertTextRules":1,"kind":2,"detail":"() -> unit"}]'
+  '[{"range":{"startLineNumber":3,"startColumn":46,"endLineNumber":3,"endColumn":46},"label":"b","kind":2,"detail":"b(): unit"}]'
 );


### PR DESCRIPTION
[lsp] Drop support for completion snippets
Signature help is a better alternative. In addition, this blocks auto import during completion feature.
