### PR TITLE
[gc] Mark string literals

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 t = "nextest run"
-tc = "llvm-cov nextest --fail-under-lines 100 --fail-uncovered-lines 0 --fail-uncovered-functions 0 --ignore-filename-regex=(main.rs)|(samlang-wasm)"
-th = "llvm-cov nextest --html --show-missing-lines --ignore-filename-regex=(main.rs)|(samlang-wasm)"
+tc = "llvm-cov nextest --fail-under-lines 100 --fail-uncovered-lines 0 --fail-uncovered-functions 0 --show-missing-lines --ignore-filename-regex=(main.rs)|(samlang-wasm)"
+th = "llvm-cov nextest --fail-under-lines 100 --fail-uncovered-lines 0 --fail-uncovered-functions 0 --html --show-missing-lines --ignore-filename-regex=(main.rs)|(samlang-wasm)"
 lint = "clippy --no-deps --tests"

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -10,30 +10,19 @@ mod tests {
 
   #[test]
   fn boilterplate() {
+    let comment = Comment {
+      location: Location::dummy(),
+      kind: CommentKind::BLOCK,
+      text: Heap::new().alloc_str_for_test("d"),
+    };
+
     assert!(CommentKind::DOC == CommentKind::DOC.clone());
-    assert!(!format!(
-      "{:?}",
-      Comment {
-        location: Location::dummy(),
-        kind: CommentKind::BLOCK,
-        text: Heap::new().alloc_str_for_test("d")
-      }
-      .clone()
-      .text
-    )
-    .is_empty());
+    assert!(!format!("{:?}", comment.clone().text).is_empty());
     assert!(!format!("{:?}", CommentStore::new().clone().create_comment_reference(vec![]).clone())
       .is_empty());
     assert!(!format!(
       "{:?}",
-      CommentStore::new()
-        .clone()
-        .create_comment_reference(vec![Comment {
-          location: Location::dummy(),
-          kind: CommentKind::BLOCK,
-          text: Heap::new().alloc_str_for_test("d")
-        }])
-        .clone()
+      CommentStore::new().clone().create_comment_reference(vec![comment]).clone()
     )
     .is_empty());
     assert!(!CommentStore::new().all_comments().is_empty());
@@ -44,6 +33,9 @@ mod tests {
       .iter()
       .collect_vec()
       .is_empty());
+    assert!(CommentsNode::Comments(Location::dummy(), vec![comment])
+      .eq(&CommentsNode::Comments(Location::dummy(), vec![comment])));
+    assert!(CommentStore::new().eq(&CommentStore::new()));
 
     assert_eq!("!", expr::UnaryOperator::NOT.clone().to_string());
     assert_eq!("-", expr::UnaryOperator::NEG.clone().to_string());
@@ -117,7 +109,8 @@ mod tests {
 
   fn coverage_hack_for_expr(expr: expr::E<()>) {
     expr.precedence();
-    assert!(expr.eq(&expr.clone()));
+    expr.clone().common_mut();
+    assert!(expr.eq(&expr));
   }
 
   #[test]
@@ -422,6 +415,7 @@ mod tests {
       comment_store: CommentStore::new(),
       imports: vec![one_import],
       toplevels: vec![class, interface],
+      trailing_comments: NO_COMMENT_REFERENCE,
     }
     .clone()
     .comment_store

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -1865,6 +1865,7 @@ pub(crate) fn type_check_module(
       comment_store: module.comment_store.clone(),
       imports: module.imports.clone(),
       toplevels: checked_toplevels,
+      trailing_comments: module.trailing_comments,
     },
     local_cx,
   )

--- a/crates/samlang-core/src/checker/typing_context.rs
+++ b/crates/samlang-core/src/checker/typing_context.rs
@@ -61,7 +61,7 @@ impl LocalTypingContext {
     let mut map = HashMap::new();
     for (name, loc) in self.ssa_analysis_result.lambda_captures.get(lambda_loc).unwrap() {
       let first_letter = name.as_str(heap).chars().next().unwrap();
-      if ('A'..='Z').contains(&first_letter) {
+      if first_letter.is_ascii_uppercase() {
         // We captured a type id, which we don't care.
         continue;
       }

--- a/crates/samlang-core/src/compiler/hir_lowering.rs
+++ b/crates/samlang-core/src/compiler/hir_lowering.rs
@@ -2725,12 +2725,18 @@ return 0;"#,
           members: vec![],
         }),
       ],
+      trailing_comments: NO_COMMENT_REFERENCE,
     };
     let sources = HashMap::from([
       (ModuleReference::dummy(), source_module),
       (
         heap.alloc_module_reference_from_string_vec(vec!["Foo".to_string()]),
-        source::Module { comment_store: CommentStore::new(), imports: vec![], toplevels: vec![] },
+        source::Module {
+          comment_store: CommentStore::new(),
+          imports: vec![],
+          toplevels: vec![],
+          trailing_comments: NO_COMMENT_REFERENCE,
+        },
       ),
     ]);
 

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -624,6 +624,7 @@ mod tests {
         type_definition: (),
         members: vec![],
       })],
+      trailing_comments: NO_COMMENT_REFERENCE,
     };
     run(&mut heap, &module);
   }

--- a/crates/samlang-core/src/optimization/inlining_tests.rs
+++ b/crates/samlang-core/src/optimization/inlining_tests.rs
@@ -276,7 +276,7 @@ mod tests {
             },
           ]
           .into_iter()
-          .chain((0..10).into_iter().map(|_| Statement::Call {
+          .chain((0..10).map(|_| Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("non-existing-function"),
               Type::new_fn_unwrapped(vec![], INT_TYPE),

--- a/crates/samlang-core/src/parser/lexer.rs
+++ b/crates/samlang-core/src/parser/lexer.rs
@@ -122,7 +122,6 @@ mod char_stream {
     fn post_process_block_comment(block_comment: &str) -> String {
       block_comment
         .split('\n')
-        .into_iter()
         .map(|line| {
           let l = line.trim_start();
           if l.starts_with('*') {

--- a/crates/samlang-core/src/printer.rs
+++ b/crates/samlang-core/src/printer.rs
@@ -1,6 +1,65 @@
 mod prettier;
 mod source_printer;
 
+pub(crate) fn pretty_print_annotation(
+  heap: &crate::common::Heap,
+  available_width: usize,
+  comment_store: &crate::ast::source::CommentStore,
+  annotation: &crate::ast::source::annotation::T,
+) -> String {
+  prettier::pretty_print(
+    available_width,
+    source_printer::annotation_to_doc(heap, comment_store, annotation),
+  )
+}
+
+pub(crate) fn pretty_print_expression(
+  heap: &crate::common::Heap,
+  available_width: usize,
+  comment_store: &crate::ast::source::CommentStore,
+  expression: &crate::ast::source::expr::E<()>,
+) -> String {
+  prettier::pretty_print(
+    available_width,
+    source_printer::expression_to_document(heap, comment_store, expression),
+  )
+}
+
+pub(crate) fn pretty_print_statement(
+  heap: &crate::common::Heap,
+  available_width: usize,
+  comment_store: &crate::ast::source::CommentStore,
+  statement: &crate::ast::source::expr::DeclarationStatement<()>,
+) -> String {
+  prettier::pretty_print(
+    available_width,
+    source_printer::statement_to_document(heap, comment_store, statement),
+  )
+}
+
+pub(crate) fn pretty_print_import(
+  heap: &crate::common::Heap,
+  available_width: usize,
+  import: &crate::ast::source::ModuleMembersImport,
+) -> String {
+  prettier::pretty_print(
+    available_width,
+    source_printer::import_to_document(heap, import.imported_module, &import.imported_members),
+  )
+}
+
+pub(crate) fn pretty_print_toplevel(
+  heap: &crate::common::Heap,
+  available_width: usize,
+  comment_store: &crate::ast::source::CommentStore,
+  toplevel: &crate::ast::source::Toplevel<()>,
+) -> String {
+  prettier::pretty_print(
+    available_width,
+    source_printer::toplevel_to_document(heap, comment_store, toplevel),
+  )
+}
+
 pub(crate) fn pretty_print_source_module(
   heap: &crate::common::Heap,
   available_width: usize,

--- a/crates/samlang-core/src/printer/prettier.rs
+++ b/crates/samlang-core/src/printer/prettier.rs
@@ -230,7 +230,7 @@ pub(super) fn pretty_print(available_width: usize, document: Document) -> String
     }
   }
 
-  let concat = string_builder.split('\n').into_iter().map(|line| line.trim_end()).join("\n");
+  let concat = string_builder.split('\n').map(|line| line.trim_end()).join("\n");
   let post_processed = concat.trim_end();
   if post_processed.is_empty() {
     post_processed.to_string()

--- a/crates/samlang-core/src/services/gc.rs
+++ b/crates/samlang-core/src/services/gc.rs
@@ -1,5 +1,5 @@
 use crate::{
-  ast::source::{annotation, expr, Id, Module, Toplevel, TypeDefinition, TypeParameter},
+  ast::source::{annotation, expr, Id, Literal, Module, Toplevel, TypeDefinition, TypeParameter},
   checker::type_::{FunctionType, IdType, Type},
   Heap, ModuleReference,
 };
@@ -66,6 +66,7 @@ fn mark_id(heap: &mut Heap, id: &Id) {
 fn mark_expression(heap: &mut Heap, expr: &expr::E<Rc<Type>>) {
   mark_type(heap, &expr.common().type_);
   match expr {
+    expr::E::Literal(_, Literal::String(s)) => heap.mark(*s),
     expr::E::Literal(_, _) => {}
     expr::E::Id(_, id) => mark_id(heap, id),
     expr::E::ClassFn(e) => {
@@ -253,6 +254,7 @@ mod tests {
 
       class Foo(val a: int) {
         function bar(): int = 3
+        function baz(): string = "3"
       }
 
       class Option<T>(None(unit), Some(T)) {

--- a/crates/samlang-core/src/services/server_state.rs
+++ b/crates/samlang-core/src/services/server_state.rs
@@ -99,7 +99,7 @@ impl ServerState {
   }
 
   pub fn all_modules(&self) -> Vec<&ModuleReference> {
-    self.parsed_modules.keys().into_iter().collect()
+    self.parsed_modules.keys().collect()
   }
 
   pub fn get_errors(&self, module_reference: &ModuleReference) -> &[CompileTimeError] {

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -236,7 +236,7 @@ fn apply_expr_renaming(
 }
 
 pub(super) fn apply_renaming(
-  Module { comment_store, imports, toplevels }: &Module<()>,
+  Module { comment_store, imports, toplevels, trailing_comments }: &Module<()>,
   definition_and_uses: &DefinitionAndUses,
   new_name: PStr,
 ) -> Module<()> {
@@ -299,6 +299,7 @@ pub(super) fn apply_renaming(
         }),
       })
       .collect(),
+    trailing_comments: *trailing_comments,
   }
 }
 


### PR DESCRIPTION
[gc] Mark string literals
Fix the embarassing crash from string literals being incorrectly GCed.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/974).
* #976
* #975
* __->__ #974
* #973