### PR TITLE
[checker] Split id type into NominalType and GenericType

### DIFF
--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -104,6 +104,7 @@ mod tests {
       .clone()
       .associated_comments();
     builder.unit_annot().associated_comments();
+    builder.generic_annot(heap.alloc_str_for_test("str")).associated_comments();
     builder.simple_id_annot(heap.alloc_str_for_test("str")).associated_comments();
   }
 
@@ -181,6 +182,7 @@ mod tests {
       common: common.clone(),
       parameters: vec![OptionallyAnnotatedId {
         name: Id::from(heap.alloc_str_for_test("name")),
+        type_: (),
         annotation: None,
       }],
       captured: HashMap::new(),
@@ -266,6 +268,7 @@ mod tests {
       "s",
       AnnotatedId {
         name: Id::from(heap.alloc_str_for_test("s")),
+        type_: (),
         annotation: annotation::T::Primitive(
           Location::dummy(),
           NO_COMMENT_REFERENCE,
@@ -294,7 +297,11 @@ mod tests {
         name: Id::from(heap.alloc_str_for_test("")),
         type_parameters: Rc::new(vec![]),
         type_: builder.fn_annot_unwrapped(vec![], builder.int_annot()),
-        parameters: Rc::new(vec![])
+        parameters: Rc::new(vec![AnnotatedId {
+          name: Id::from(heap.alloc_str_for_test("")),
+          type_: (),
+          annotation: builder.int_annot()
+        }])
       }]
     }
     .clone()
@@ -329,10 +336,12 @@ mod tests {
 
     assert!(AnnotatedId {
       name: Id::from(heap.alloc_str_for_test("")),
+      type_: (),
       annotation: builder.int_annot(),
     }
     .eq(&AnnotatedId {
       name: Id::from(heap.alloc_str_for_test("")),
+      type_: (),
       annotation: builder.int_annot(),
     }));
     assert!(TypeParameter {

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -107,7 +107,7 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.bool_type(), builder.int_type()],
-                        return_type: builder.simple_id_type(heap.alloc_str_for_test("Test")),
+                        return_type: builder.simple_nominal_type(heap.alloc_str_for_test("Test")),
                       },
                     },
                   ),
@@ -133,7 +133,7 @@ mod tests {
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.simple_id_type(heap.alloc_str_for_test("A"))],
+                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("A"))],
                         return_type: builder.unit_type(),
                       },
                     },
@@ -151,11 +151,11 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![
-                          builder.simple_id_type(heap.alloc_str_for_test("A")),
-                          builder.simple_id_type(heap.alloc_str_for_test("B")),
-                          builder.simple_id_type(heap.alloc_str_for_test("C")),
+                          builder.generic_type(heap.alloc_str_for_test("A")),
+                          builder.generic_type(heap.alloc_str_for_test("B")),
+                          builder.generic_type(heap.alloc_str_for_test("C")),
                         ],
-                        return_type: builder.simple_id_type(heap.alloc_str_for_test("D")),
+                        return_type: builder.generic_type(heap.alloc_str_for_test("D")),
                       },
                     },
                   ),
@@ -171,7 +171,7 @@ mod tests {
                         reason: Reason::dummy(),
                         argument_types: vec![
                           builder.fun_type(vec![builder.int_type()], builder.int_type()),
-                          builder.simple_id_type(heap.alloc_str_for_test("T")),
+                          builder.generic_type(heap.alloc_str_for_test("T")),
                         ],
                         return_type: builder.bool_type(),
                       },
@@ -188,8 +188,8 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.fun_type(
-                          vec![builder.simple_id_type(heap.alloc_str_for_test("A"))],
-                          builder.simple_id_type(heap.alloc_str_for_test("B")),
+                          vec![builder.generic_type(heap.alloc_str_for_test("A"))],
+                          builder.generic_type(heap.alloc_str_for_test("B")),
                         )],
                         return_type: builder.bool_type(),
                       },
@@ -249,7 +249,7 @@ mod tests {
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.simple_id_type(heap.alloc_str_for_test("A"))],
+                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("A"))],
                         return_type: builder.bool_type(),
                       },
                     },
@@ -279,7 +279,7 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.bool_type()],
-                        return_type: builder.simple_id_type(heap.alloc_str_for_test("Test2")),
+                        return_type: builder.simple_nominal_type(heap.alloc_str_for_test("Test2")),
                       },
                     },
                   ),
@@ -291,7 +291,7 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.int_type()],
-                        return_type: builder.simple_id_type(heap.alloc_str_for_test("Test2")),
+                        return_type: builder.simple_nominal_type(heap.alloc_str_for_test("Test2")),
                       },
                     },
                   ),
@@ -304,36 +304,40 @@ mod tests {
             (
               heap.alloc_str_for_test("Test3"),
               InterfaceSignature {
+                type_parameters: vec![TypeParameterSignature {
+                  name: heap.alloc_str_for_test("E"),
+                  bound: None,
+                }],
                 type_definition: Some(TypeDefinitionSignature {
                   is_object: true,
                   names: vec![heap.alloc_str_for_test("foo"), heap.alloc_str_for_test("bar")],
                   mappings: HashMap::from([
                     (
                       heap.alloc_str_for_test("foo"),
-                      (builder.simple_id_type(heap.alloc_str_for_test("E")), true),
+                      (builder.generic_type(heap.alloc_str_for_test("E")), true),
                     ),
                     (heap.alloc_str_for_test("bar"), (builder.int_type(), false)),
                   ]),
                 }),
                 functions: HashMap::new(),
                 methods: HashMap::new(),
-                type_parameters: vec![TypeParameterSignature {
-                  name: heap.alloc_str_for_test("E"),
-                  bound: None,
-                }],
                 super_types: vec![],
               },
             ),
             (
               heap.alloc_str_for_test("Test4"),
               InterfaceSignature {
+                type_parameters: vec![TypeParameterSignature {
+                  name: heap.alloc_str_for_test("E"),
+                  bound: None,
+                }],
                 type_definition: Some(TypeDefinitionSignature {
                   is_object: false,
                   names: vec![heap.alloc_str_for_test("Foo"), heap.alloc_str_for_test("Bar")],
                   mappings: HashMap::from([
                     (
                       heap.alloc_str_for_test("Foo"),
-                      (builder.simple_id_type(heap.alloc_str_for_test("E")), true),
+                      (builder.generic_type(heap.alloc_str_for_test("E")), true),
                     ),
                     (heap.alloc_str_for_test("Bar"), (builder.int_type(), true)),
                   ]),
@@ -349,10 +353,10 @@ mod tests {
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.simple_id_type(heap.alloc_str_for_test("E"))],
-                        return_type: builder.general_id_type(
+                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("E"))],
+                        return_type: builder.general_nominal_type(
                           heap.alloc_str_for_test("Test4"),
-                          vec![builder.simple_id_type(heap.alloc_str_for_test("E"))],
+                          vec![builder.generic_type(heap.alloc_str_for_test("E"))],
                         ),
                       },
                     },
@@ -368,19 +372,15 @@ mod tests {
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.int_type()],
-                        return_type: builder.general_id_type(
+                        return_type: builder.general_nominal_type(
                           heap.alloc_str_for_test("Test4"),
-                          vec![builder.simple_id_type(heap.alloc_str_for_test("E"))],
+                          vec![builder.generic_type(heap.alloc_str_for_test("E"))],
                         ),
                       },
                     },
                   ),
                 ]),
                 methods: HashMap::new(),
-                type_parameters: vec![TypeParameterSignature {
-                  name: heap.alloc_str_for_test("E"),
-                  bound: None,
-                }],
                 super_types: vec![],
               },
             ),
@@ -403,7 +403,7 @@ mod tests {
                     type_: FunctionType {
                       reason: Reason::dummy(),
                       argument_types: vec![],
-                      return_type: builder.simple_id_type(heap.alloc_str_for_test("A")),
+                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("A")),
                     },
                   },
                 )]),
@@ -431,7 +431,7 @@ mod tests {
                     type_: FunctionType {
                       reason: Reason::dummy(),
                       argument_types: vec![],
-                      return_type: builder.simple_id_type(heap.alloc_str_for_test("B")),
+                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("B")),
                     },
                   },
                 )]),
@@ -459,7 +459,7 @@ mod tests {
                     type_: FunctionType {
                       reason: Reason::dummy(),
                       argument_types: vec![],
-                      return_type: builder.simple_id_type(heap.alloc_str_for_test("C")),
+                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("C")),
                     },
                   },
                 )]),
@@ -651,33 +651,37 @@ mod tests {
     let test2_str = heap.alloc_str_for_test("Test2");
     let test4_str = heap.alloc_str_for_test("Test4");
 
-    assert_checks(heap, "Test.init(true, 3)", &builder.simple_id_type(test_str));
-    assert_checks(heap, "{ val foo=true; Test.init(foo, 3) }", &builder.simple_id_type(test_str));
+    assert_checks(heap, "Test.init(true, 3)", &builder.simple_nominal_type(test_str));
+    assert_checks(
+      heap,
+      "{ val foo=true; Test.init(foo, 3) }",
+      &builder.simple_nominal_type(test_str),
+    );
     assert_errors_with_class(
       heap,
       "Test2.Foo(true)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec![],
       "Test2",
     );
     assert_errors_with_class(
       heap,
       "Test2.Bar(42)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec![],
       "Test2",
     );
     assert_errors_with_class(
       heap,
       "Test4.Foo(true)",
-      &builder.general_id_type(test4_str, vec![builder.bool_type()]),
+      &builder.general_nominal_type(test4_str, vec![builder.bool_type()]),
       vec![],
       "Test4",
     );
     assert_errors_with_class(
       heap,
       "Test4.Foo<bool>(true)",
-      &builder.general_id_type(test4_str, vec![builder.bool_type()]),
+      &builder.general_nominal_type(test4_str, vec![builder.bool_type()]),
       vec![],
       "Test4",
     );
@@ -685,18 +689,18 @@ mod tests {
     assert_errors(
       heap,
       "Test.Foo(true)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec!["__DUMMY__.sam:1:1-1:9: [member-missing]: Cannot find member `Foo` on `Test`."],
     );
     assert_errors(
       heap,
       "Test.Bar(42)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec!["__DUMMY__.sam:1:1-1:9: [member-missing]: Cannot find member `Bar` on `Test`."],
     );
     assert_errors(heap,
       "Test4.Foo<int, bool>(true)",
-      &builder.general_id_type(test4_str, vec![builder.bool_type()]),
+      &builder.general_nominal_type(test4_str, vec![builder.bool_type()]),
       vec![
         "__DUMMY__.sam:1:1-1:21: [invalid-arity]: Incorrect type arguments size. Expected: 1, actual: 2.",
       ],
@@ -704,13 +708,13 @@ mod tests {
     assert_errors(
       heap,
       "Test4.Foo<int>(true)",
-      &builder.general_id_type(test4_str, vec![builder.int_type()]),
+      &builder.general_nominal_type(test4_str, vec![builder.int_type()]),
       vec!["__DUMMY__.sam:1:16-1:20: [incompatible-type]: Expected: `int`, actual: `bool`."],
     );
     assert_errors(
       heap,
       "Test4.Foo<int>(true)",
-      &builder.general_id_type(test4_str, vec![builder.bool_type()]),
+      &builder.general_nominal_type(test4_str, vec![builder.bool_type()]),
       vec![
         "__DUMMY__.sam:1:1-1:21: [incompatible-type]: Expected: `Test4<bool>`, actual: `Test4<int>`.",
         "__DUMMY__.sam:1:16-1:20: [incompatible-type]: Expected: `int`, actual: `bool`.",
@@ -719,13 +723,13 @@ mod tests {
     assert_errors(
       heap,
       "Test44.Bar(42)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec!["__DUMMY__.sam:1:1-1:7: [cannot-resolve-class]: Class `Test44` is not resolved."],
     );
     assert_errors_with_class(
       heap,
       "Test2.Tars(42)",
-      &builder.simple_id_type(test2_str),
+      &builder.simple_nominal_type(test2_str),
       vec!["__DUMMY__.sam:1:1-1:11: [member-missing]: Cannot find member `Tars` on `Test2`."],
       "Test2",
     );

--- a/crates/samlang-core/src/checker/ssa_analysis.rs
+++ b/crates/samlang-core/src/checker/ssa_analysis.rs
@@ -287,7 +287,7 @@ impl<'a> SsaAnalysisState<'a> {
       }
       expr::E::Lambda(e) => {
         self.context.push_scope();
-        for OptionallyAnnotatedId { name, annotation } in &e.parameters {
+        for OptionallyAnnotatedId { name, type_: _, annotation } in &e.parameters {
           self.define_id(name.name, name.loc);
           if let Some(annot) = annotation {
             self.visit_annot(annot)
@@ -346,6 +346,7 @@ impl<'a> SsaAnalysisState<'a> {
     match annot {
       annotation::T::Primitive(_, _, _) => {}
       annotation::T::Id(annot) => self.visit_id_annot(annot),
+      annotation::T::Generic(_, id) => self.use_id(&id.name, id.loc),
       annotation::T::Fn(annotation::Function {
         location: _,
         associated_comments: _,

--- a/crates/samlang-core/src/compiler/hir_type_conversion.rs
+++ b/crates/samlang-core/src/compiler/hir_type_conversion.rs
@@ -275,7 +275,7 @@ impl TypeLoweringManager {
         type_::PrimitiveTypeKind::Int => PrimitiveType::Int,
         type_::PrimitiveTypeKind::String => PrimitiveType::String,
       }),
-      type_::Type::Id(id) => {
+      type_::Type::Nominal(id) => {
         let id_string = id.id;
         if self.generic_types.contains(&id_string) {
           Type::new_id_no_targs(id_string)
@@ -285,6 +285,10 @@ impl TypeLoweringManager {
             id.type_arguments.iter().map(|it| self.lower_source_type(heap, it)).collect_vec(),
           )
         }
+      }
+      type_::Type::Generic(_, id) => {
+        debug_assert!(self.generic_types.contains(id));
+        Type::new_id_no_targs(*id)
       }
       type_::Type::Fn(f) => {
         let rewritten_function_type = Type::new_fn_unwrapped(
@@ -703,7 +707,7 @@ mod tests {
     );
 
     assert_eq!("__DUMMY___A<int>", {
-      let t = builder.general_id_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]);
+      let t = builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]);
       manager.lower_source_type(heap, &t).pretty_print(heap)
     });
 
@@ -713,7 +717,7 @@ mod tests {
     };
     assert_eq!("$SyntheticIDType0<T>", {
       let t = builder.fun_type(
-        vec![builder.simple_id_type(heap.alloc_str_for_test("T")), builder.bool_type()],
+        vec![builder.simple_nominal_type(heap.alloc_str_for_test("T")), builder.bool_type()],
         builder.int_type(),
       );
       manager2.lower_source_type(heap, &t).pretty_print(heap)

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -159,18 +159,18 @@ fn eval_expr(cx: &mut InterpretationContext, heap: &mut Heap, expr: &expr::E<Rc<
       .deref(),
     expr::E::MethodAccess(e) => {
       let obj_type = e.object.type_();
-      let id_type = obj_type.as_id().unwrap();
+      let class_name = obj_type.as_nominal().unwrap().id;
       let this_value = eval_expr(cx, heap, &e.object);
       let method_value = cx
         .classes
-        .get(&id_type.id)
-        .expect(&format!("Missing class: {}", id_type.id.as_str(heap)))
+        .get(&class_name)
+        .expect(&format!("Missing class: {}", class_name.as_str(heap)))
         .methods
         .get(&e.method_name.name)
         .expect(&format!(
           "Missing method: {} from class {}",
           e.method_name.name.as_str(heap),
-          id_type.id.as_str(heap)
+          class_name.as_str(heap)
         ));
       new_fn(
         cx,

--- a/crates/samlang-core/src/parser.rs
+++ b/crates/samlang-core/src/parser.rs
@@ -210,6 +210,10 @@ mod tests {
     class A(val a: () -> int) : Baz
     class A(val a: (string) -> int) : Baz
 
+    class TParamFixParserTest {
+      function <T: Foo<T>, R: Bar<(A) -> int>> f(): unit = {}
+    }
+
     /**
      * docs
      */
@@ -261,6 +265,7 @@ mod tests {
         "Util",
         "A",
         "A",
+        "TParamFixParserTest",
         "Option",
         "TypeInference",
         "Developer"

--- a/crates/samlang-core/src/printer/source_printer.rs
+++ b/crates/samlang-core/src/printer/source_printer.rs
@@ -131,6 +131,12 @@ pub(super) fn annotation_to_doc(
       Document::Text(rc_string(kind.to_string())),
     ),
     annotation::T::Id(annot) => id_annot_to_doc(heap, comment_store, annot),
+    annotation::T::Generic(_, id) => create_opt_preceding_comment_doc(
+      heap,
+      comment_store,
+      id.associated_comments,
+      Document::Text(rc_pstr(heap, id.name)),
+    ),
     annotation::T::Fn(annotation::Function {
       location: _,
       associated_comments,

--- a/crates/samlang-core/src/services/api.rs
+++ b/crates/samlang-core/src/services/api.rs
@@ -730,7 +730,7 @@ pub mod completion {
           (module_ref, class_name)
         }
         LocationCoverSearchResult::Expression(expr::E::FieldAccess(e)) => {
-          e.object.type_().as_id().map(|id_type| (id_type.module_reference, id_type.id))?
+          e.object.type_().as_nominal().map(|t| (t.module_reference, t.id))?
         }
         _ => return None,
       };

--- a/crates/samlang-core/src/services/gc.rs
+++ b/crates/samlang-core/src/services/gc.rs
@@ -1,6 +1,6 @@
 use crate::{
   ast::source::{annotation, expr, Id, Literal, Module, Toplevel, TypeDefinition, TypeParameter},
-  checker::type_::{FunctionType, IdType, Type},
+  checker::type_::{FunctionType, NominalType, Type},
   Heap, ModuleReference,
 };
 use std::{collections::HashMap, rc::Rc};
@@ -9,6 +9,7 @@ fn mark_annot(heap: &mut Heap, type_: &annotation::T) {
   match type_ {
     annotation::T::Primitive(_, _, _) => {}
     annotation::T::Id(annot) => mark_id_annot(heap, annot),
+    annotation::T::Generic(_, id) => heap.mark(id.name),
     annotation::T::Fn(annot) => mark_fn_annot(heap, annot),
   }
 }
@@ -38,12 +39,13 @@ fn mark_annot_opt(heap: &mut Heap, opt_t: &Option<annotation::T>) {
 fn mark_type(heap: &mut Heap, type_: &Type) {
   match type_ {
     Type::Any(_, _) | Type::Primitive(_, _) => {}
-    Type::Id(t) => mark_id_type(heap, t),
+    Type::Nominal(t) => mark_nominal_type(heap, t),
+    Type::Generic(_, id) => heap.mark(*id),
     Type::Fn(t) => mark_fn_type(heap, t),
   }
 }
 
-fn mark_id_type(heap: &mut Heap, type_: &IdType) {
+fn mark_nominal_type(heap: &mut Heap, type_: &NominalType) {
   heap.mark(type_.id);
   mark_types(heap, &type_.type_arguments);
 }

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -45,11 +45,11 @@ fn search_expression(
     }
     expr::E::FieldAccess(e) => {
       if e.field_name.loc.contains_position(position) {
-        if let Type::Id(id_type) = e.object.common().type_.deref() {
+        if let Some(nominal_type) = e.object.common().type_.as_nominal() {
           return Some(LocationCoverSearchResult::PropertyName(
             e.field_name.loc,
-            id_type.module_reference,
-            id_type.id,
+            nominal_type.module_reference,
+            nominal_type.id,
             e.field_name.name,
           ));
         }
@@ -58,11 +58,11 @@ fn search_expression(
     }
     expr::E::MethodAccess(e) => {
       if e.method_name.loc.contains_position(position) {
-        if let Type::Id(id_type) = e.object.common().type_.deref() {
+        if let Some(nominal_type) = e.object.common().type_.as_nominal() {
           return Some(LocationCoverSearchResult::InterfaceMemberName(
             e.method_name.loc,
-            id_type.module_reference,
-            id_type.id,
+            nominal_type.module_reference,
+            nominal_type.id,
             e.method_name.name,
             true,
           ));

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -150,8 +150,9 @@ fn apply_expr_renaming(
       parameters: e
         .parameters
         .iter()
-        .map(|OptionallyAnnotatedId { name, annotation }| OptionallyAnnotatedId {
+        .map(|OptionallyAnnotatedId { name, type_, annotation }| OptionallyAnnotatedId {
           name: mod_def_id(name, definition_and_uses, new_name),
+          type_: *type_,
           annotation: annotation.clone(),
         })
         .collect(),
@@ -284,8 +285,9 @@ pub(super) fn apply_renaming(
                     parameters: Rc::new(
                       parameters
                         .iter()
-                        .map(|AnnotatedId { name, annotation }| AnnotatedId {
+                        .map(|AnnotatedId { name, type_, annotation }| AnnotatedId {
                           name: mod_def_id(name, definition_and_uses, new_name),
+                          type_: *type_,
                           annotation: annotation.clone(),
                         })
                         .collect(),


### PR DESCRIPTION
[checker] Split id type into NominalType and GenericType
We decide whether an identifier type represents a nominal type or generic type during parse time. This allows much easier analysis in later stage of the type checking and compilation.
