### PR TITLE
[checker] Introduce synthesis mode to improve completeness

### DIFF
--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -603,7 +603,7 @@ mod tests {
       "Test.helloWorldWithTypeParameters",
       &builder.fun_type(vec![builder.string_type(), builder.string_type()], builder.unit_type()),
       vec![
-        "__DUMMY__.sam:1:1-1:34: [incompatible-type]: Expected: `(string, string) -> unit`, actual: `(placeholder) -> unit`.",
+        "__DUMMY__.sam:1:1-1:34: [incompatible-type]: Expected: `(string, string) -> unit`, actual: `(any) -> unit`.",
         "__DUMMY__.sam:1:1-1:34: [invalid-arity]: Incorrect parameter size. Expected: 2, actual: 1.",
         "__DUMMY__.sam:1:1-1:34: [underconstrained]: There is not enough context information to decide the type of this expression.",
       ],
@@ -613,7 +613,7 @@ mod tests {
       "Test.helloWorldWithTypeParameters",
       &builder.string_type(),
       vec![
-        "__DUMMY__.sam:1:1-1:34: [incompatible-type]: Expected: `string`, actual: `(placeholder) -> unit`.",
+        "__DUMMY__.sam:1:1-1:34: [incompatible-type]: Expected: `string`, actual: `(any) -> unit`.",
         "__DUMMY__.sam:1:1-1:34: [incompatible-type]: Expected: `string`, actual: `function`.",
         "__DUMMY__.sam:1:1-1:34: [underconstrained]: There is not enough context information to decide the type of this expression.",
       ]
@@ -865,15 +865,12 @@ mod tests {
 
     assert_errors(heap, "{ val _ = (t) -> t.foo; }", &builder.unit_type(), vec![
       "__DUMMY__.sam:1:12-1:13: [underconstrained]: There is not enough context information to decide the type of this expression.",
-      "__DUMMY__.sam:1:18-1:19: [incompatible-type]: Expected: `identifier`, actual: `any`.",
     ]);
     assert_errors(heap, "{ val _ = (t) -> t.bar; }", &builder.unit_type(), vec![
       "__DUMMY__.sam:1:12-1:13: [underconstrained]: There is not enough context information to decide the type of this expression.",
-      "__DUMMY__.sam:1:18-1:19: [incompatible-type]: Expected: `identifier`, actual: `any`.",
     ]);
     assert_errors(heap, "{ val _ = (t) -> t.baz; }", &builder.unit_type(), vec![
       "__DUMMY__.sam:1:12-1:13: [underconstrained]: There is not enough context information to decide the type of this expression.",
-      "__DUMMY__.sam:1:18-1:19: [incompatible-type]: Expected: `identifier`, actual: `any`.",
     ]);
   }
 
@@ -1393,7 +1390,8 @@ mod tests {
       vec![
         "__DUMMY__.sam:2:12-2:26: [invalid-arity]: Incorrect arguments size. Expected: 0, actual: 1.",
         "__DUMMY__.sam:8:11-8:64: [underconstrained]: There is not enough context information to decide the type of this expression.",
-        "__DUMMY__.sam:12:11-12:94: [underconstrained]: There is not enough context information to decide the type of this expression.",
+        "__DUMMY__.sam:12:63-12:64: [underconstrained]: There is not enough context information to decide the type of this expression.",
+        "__DUMMY__.sam:12:83-12:84: [underconstrained]: There is not enough context information to decide the type of this expression."
       ],
     );
   }

--- a/crates/samlang-core/src/checker/checker_utils.rs
+++ b/crates/samlang-core/src/checker/checker_utils.rs
@@ -154,7 +154,7 @@ fn nominal_type_has_placeholder_type(type_: &NominalType) -> bool {
   type_.type_arguments.iter().any(|t| has_placeholder_type(t))
 }
 
-fn has_placeholder_type(type_: &Type) -> bool {
+pub(super) fn has_placeholder_type(type_: &Type) -> bool {
   match type_ {
     Type::Any(_, is_placeholder) => *is_placeholder,
     Type::Primitive(_, _) | Type::Generic(_, _) => false,

--- a/crates/samlang-core/src/checker/typing_context_tests.rs
+++ b/crates/samlang-core/src/checker/typing_context_tests.rs
@@ -84,6 +84,29 @@ mod tests {
   }
 
   #[test]
+  fn run_in_synthesis_mode_tests() {
+    let mut heap = Heap::new();
+    let mut error_set = ErrorSet::new();
+    let global_cx = HashMap::new();
+    let mut local_cx = empty_local_typing_context();
+    let mut cx = TypingContext::new(
+      &global_cx,
+      &mut local_cx,
+      &mut error_set,
+      ModuleReference::dummy(),
+      heap.alloc_str_for_test("A"),
+      vec![],
+    );
+
+    let (a, b) = cx.run_in_synthesis_mode(|cx| cx.in_synthesis_mode());
+    assert!(a);
+    assert!(!b);
+
+    let (_, c) = cx.run_in_synthesis_mode(|cx| cx.mk_underconstrained_any_type(Reason::dummy()));
+    assert!(c);
+  }
+
+  #[test]
   fn is_subtype_tests() {
     let mut heap = Heap::new();
     let builder = test_type_builder::create();

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -453,6 +453,24 @@ class Main {
 "#,
       },
       CheckerTestSource {
+        test_name: "synthesis-mode",
+        source_code: r#"
+class Main {
+  function <Acc> reduce(f: (Acc, int) -> Acc, init: Acc): Acc = Builtins.panic("")
+  function getInt(): int = 10
+
+  function <T> id(v: T): T = v
+
+  function main(): unit = {
+    val _ = Main.reduce((acc, n) -> acc + n, Main.getInt());
+    val _: (int) -> int = Main.id((x) -> x);
+    val _: (int) -> int = Main.id(Main.id((x) -> x));
+    val _: (int) -> int = Main.id(Main.id(Main.id((x) -> x)));
+  }
+}
+"#,
+      },
+      CheckerTestSource {
         test_name: "undefined-type",
         source_code: r#"
 class Main {
@@ -1752,7 +1770,7 @@ class Main {
       })
       .collect::<HashMap<_, _>>();
     let (checked_sources, _) = type_check_sources(&sources, heap, &mut error_set);
-    assert!(error_set.into_errors().is_empty());
+    assert_eq!("", error_set.error_messages(heap).join("\n"));
     let unoptimized_hir_sources = compiler::compile_sources_to_hir(heap, &checked_sources);
     let optimized_hir_sources = optimization::optimize_sources(
       heap,


### PR DESCRIPTION
This change finally makes things like `Array.reduce` able to type check. Close #980.