### PR TITLE
[compiler] Efficient string encoding

### DIFF
--- a/crates/samlang-core/src/ast/wasm.rs
+++ b/crates/samlang-core/src/ast/wasm.rs
@@ -1,5 +1,5 @@
 use super::hir;
-use crate::common::{int_vec_to_data_string, Heap, PStr};
+use crate::common::{byte_vec_to_data_string, Heap, PStr};
 use itertools::Itertools;
 
 pub(crate) enum InlineInstruction {
@@ -205,7 +205,7 @@ pub(crate) struct Function {
 
 pub(crate) struct GlobalData {
   pub(crate) constant_pointer: usize,
-  pub(crate) ints: Vec<i32>,
+  pub(crate) bytes: Vec<u8>,
 }
 
 pub(crate) struct Module {
@@ -230,11 +230,11 @@ impl Module {
         ));
       }
     }
-    for GlobalData { constant_pointer, ints } in &self.global_variables {
+    for GlobalData { constant_pointer, bytes } in &self.global_variables {
       collector.push_str(&format!(
         "(data (i32.const {}) \"{}\")\n",
         constant_pointer,
-        int_vec_to_data_string(ints)
+        byte_vec_to_data_string(bytes)
       ));
     }
     collector.push_str(&format!("(table $0 {} funcref)\n", self.functions.len()));

--- a/crates/samlang-core/src/ast/wasm_tests.rs
+++ b/crates/samlang-core/src/ast/wasm_tests.rs
@@ -11,8 +11,8 @@ mod tests {
     let module = Module {
       function_type_parameter_counts: vec![0, 1, 2, 3],
       global_variables: vec![
-        GlobalData { constant_pointer: 1024, ints: vec![0, 0] },
-        GlobalData { constant_pointer: 323, ints: vec![3, 2] },
+        GlobalData { constant_pointer: 1024, bytes: vec![0, 0] },
+        GlobalData { constant_pointer: 323, bytes: vec![3, 2] },
       ],
       exported_functions: vec![heap.alloc_str_for_test("main")],
       functions: vec![Function {
@@ -140,8 +140,8 @@ mod tests {
 (type $i32_=>_i32 (func (param i32) (result i32)))
 (type $i32_i32_=>_i32 (func (param i32 i32) (result i32)))
 (type $i32_i32_i32_=>_i32 (func (param i32 i32 i32) (result i32)))
-(data (i32.const 1024) "\00\00\00\00\00\00\00\00")
-(data (i32.const 323) "\03\00\00\00\02\00\00\00")
+(data (i32.const 1024) "\00\00")
+(data (i32.const 323) "\03\02")
 (table $0 1 funcref)
 (elem $0 (i32.const 0) $main)
 (func $main (param $a i32) (param $b i32) (result i32)

--- a/crates/samlang-core/src/common.rs
+++ b/crates/samlang-core/src/common.rs
@@ -377,14 +377,12 @@ fn byte_digit_to_char(byte: u8) -> char {
   u as char
 }
 
-pub(crate) fn int_vec_to_data_string(array: &Vec<i32>) -> String {
+pub(crate) fn byte_vec_to_data_string(array: &Vec<u8>) -> String {
   let mut collector = vec![];
-  for i in array {
-    for b in i.to_le_bytes() {
-      collector.push('\\');
-      collector.push(byte_digit_to_char(b / 16));
-      collector.push(byte_digit_to_char(b % 16));
-    }
+  for b in array {
+    collector.push('\\');
+    collector.push(byte_digit_to_char(b / 16));
+    collector.push(byte_digit_to_char(b % 16));
   }
   String::from_iter(collector.iter())
 }
@@ -422,7 +420,7 @@ impl<K: Clone + Eq + Hash, V: Clone> LocalStackedContext<K, V> {
 #[cfg(test)]
 mod tests {
   use super::{
-    int_vec_to_data_string, measure_time, rcs, Heap, LocalStackedContext, ModuleReference, PStr,
+    byte_vec_to_data_string, measure_time, rcs, Heap, LocalStackedContext, ModuleReference, PStr,
     StringStoredInHeap,
   };
   use pretty_assertions::assert_eq;
@@ -581,11 +579,11 @@ mod tests {
   fn int_vec_to_data_string_tests() {
     assert_eq!(
       "\\01\\00\\00\\00\\02\\00\\00\\00\\03\\00\\00\\00\\04\\00\\00\\00",
-      int_vec_to_data_string(&vec![1, 2, 3, 4])
+      byte_vec_to_data_string(&vec![1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0,])
     );
     assert_eq!(
-      "\\01\\00\\00\\00\\7c\\00\\00\\00\\b3\\11\\00\\00\\21\\00\\00\\00",
-      int_vec_to_data_string(&vec![1, 124, 4531, 33])
+      "\\01\\00\\00\\00\\7c\\00\\00\\00\\16\\00\\00\\00\\21\\00\\00\\00",
+      byte_vec_to_data_string(&vec![1, 0, 0, 0, 124, 0, 0, 0, 22, 0, 0, 0, 33, 0, 0, 0,])
     );
   }
 

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -1857,11 +1857,9 @@ class Main {
     let mut len_bytes = [0; 4];
     let ptr = usize::try_from(param).unwrap();
     mem.read(caller.as_context(), ptr + 4, &mut len_bytes).unwrap();
-    let length = usize::try_from(i32::from_le_bytes(len_bytes)).unwrap();
-    let mut str_bytes = vec![0; length * 4];
+    let length = usize::try_from(u32::from_le_bytes(len_bytes)).unwrap();
+    let mut str_bytes = vec![0; length];
     mem.read(caller.as_context(), ptr + 8, &mut str_bytes).unwrap();
-    // We sadly use 4 bytes to store 1 byte of data :(
-    str_bytes.retain(|c| *c != 0);
     String::from_utf8(str_bytes).unwrap()
   }
 }

--- a/crates/samlang-core/src/libsam.wat
+++ b/crates/samlang-core/src/libsam.wat
@@ -483,80 +483,79 @@
 )
 (func $mkString (type $t0) (param $p0 i32) (result i32)
   (local $l1 i32) (local $l2 i32) (local $l3 i32) (local $l4 i32)
-  (local.set $l1 (i32.const 0))
-  (local.set $l2 (i32.const 12))
+  (local.set $l1 (i32.add (local.get $p0) (i32.const -1)))
   (loop $L0
-    (local.set $l2 (i32.add (local.get $l2) (i32.const 4)))
-    (local.set $l3 (i32.add (local.get $p0) (local.get $l1)))
-    (local.set $l1 (local.tee $l4 (i32.add (local.get $l1) (i32.const 1))))
-    (br_if $L0 (i32.load8_u (local.get $l3)))
+    (br_if $L0 (i32.load8_u (local.tee $l1 (i32.add (local.get $l1) (i32.const 1)))))
   )
-  (i32.store offset=4
-    (local.tee $l3 (call $_builtin_malloc (local.get $l2)))
-    (local.tee $l1 (i32.add (local.get $l4) (i32.const -1)))
-  )
-  (i32.store (local.get $l3) (i32.const 1))
-  (local.set $l1
-    (select
-      (local.get $l1)
-      (i32.const 0)
-      (i32.gt_s (local.get $l1) (i32.const 0))
+  (local.set $l4
+    (i32.add
+      (local.tee $l3
+        (call $mkArray
+          (local.tee $l2 (i32.sub (local.get $l1) (local.get $p0)))
+          (local.get $l2)))
+      (i32.const 8)
     )
   )
-  (local.set $l2 (i32.add (local.get $l3) (i32.const 8)))
+  (local.set $l1 (i32.const 0))
   (block $B1
     (loop $L2
-      (br_if $B1 (i32.eqz (local.get $l1)))
-      (i32.store (local.get $l2) (i32.load8_s (local.get $p0)))
-      (local.set $l2 (i32.add (local.get $l2) (i32.const 4)))
-      (local.set $p0 (i32.add (local.get $p0) (i32.const 1)))
-      (local.set $l1 (i32.add (local.get $l1) (i32.const -1)))
+      (br_if $B1 (i32.ge_s (local.get $l1) (local.get $l2)))
+      (i32.store8
+        (i32.add (local.get $l4) (local.get $l1))
+        (i32.load8_u (i32.add (local.get $p0) (local.get $l1)))
+      )
+      (local.set $l1 (i32.add (local.get $l1) (i32.const 1)))
       (br $L2)
     )
   )
   (local.get $l3)
 )
+(func $mkArray (type $t1) (param $p0 i32) (param $p1 i32) (result i32)
+  (i32.store offset=4
+    (local.tee $p0
+      (call $_builtin_malloc (i32.add (local.get $p0) (i32.const 8))))
+      (local.get $p1)
+  )
+  (i32.store (local.get $p0) (i32.const 1))
+  (local.get $p0)
+)
 (func $__Builtins$stringToInt (type $t0) (param $p0 i32) (result i32)
-  (local $l1 i32) (local $l2 i32) (local $l3 i32) (local $l4 i32)
+  (local $l1 i32) (local $l2 i32) (local $l3 i32) (local $l4 i32) (local $l5 i32)
   (block $B0
     (br_if $B0 (i32.eqz (local.tee $l1 (i32.load offset=4 (local.get $p0)))))
-    (local.set $l1
-      (i32.sub
-        (select
-          (local.get $l1)
-          (local.tee $l3 (i32.eq (local.tee $l2 (i32.load offset=8 (local.get $p0))) (i32.const 45)))
-          (i32.gt_s (local.get $l1) (local.get $l3))
-        )
-        (local.get $l3)
-      )
-    )
-    (local.set $p0
-      (i32.add
-        (i32.add (i32.shl (local.get $l3) (i32.const 2)) (local.get $p0))
-        (i32.const 8)
-      )
-    )
-    (local.set $l3 (i32.const 0))
+    (local.set $l2 (i32.add (local.get $p0) (i32.const 8)))
+    (local.set $p0 (i32.eq (local.tee $l3 (i32.load (local.get $p0))) (i32.const 45)))
+    (local.set $l4 (i32.const 0))
     (block $B1
       (loop $L2
-        (br_if $B1 (i32.eqz (local.get $l1)))
+        (br_if $B1 (i32.ge_s (local.get $p0) (local.get $l1)))
         (br_if $B0
           (i32.gt_u
-            (local.tee $l4 (i32.add (i32.load (local.get $p0)) (i32.const -48)))
+            (i32.and
+              (i32.add
+                (local.tee $l5 (i32.load8_u (i32.add (local.get $l2) (local.get $p0))))
+                (i32.const -48)
+              )
+              (i32.const 255)
+            )
             (i32.const 9)
           )
         )
-        (local.set $p0 (i32.add (local.get $p0) (i32.const 4)))
-        (local.set $l1 (i32.add (local.get $l1) (i32.const -1)))
-        (local.set $l3 (i32.add (local.get $l4) (i32.mul (local.get $l3) (i32.const 10))))
+        (local.set $p0 (i32.add (local.get $p0) (i32.const 1)))
+        (local.set $l4
+          (i32.add
+            (i32.add (i32.mul (local.get $l4) (i32.const 10)) (local.get $l5))
+            (i32.const -48)
+          )
+        )
         (br $L2)
       )
     )
     (return
       (select
-        (i32.sub (i32.const 0) (local.get $l3))
-        (local.get $l3)
-        (i32.eq (local.get $l2) (i32.const 45))
+        (i32.sub (i32.const 0) (local.get $l4))
+        (local.get $l4)
+        (i32.eq (local.get $l3) (i32.const 45))
       )
     )
   )
@@ -564,67 +563,44 @@
 )
 (func $__Builtins$stringConcat (type $t1) (param $p0 i32) (param $p1 i32) (result i32)
   (local $l2 i32) (local $l3 i32) (local $l4 i32) (local $l5 i32) (local $l6 i32)
-  (i32.store offset=4
-    (local.tee $l5
-      (call $_builtin_malloc
-        (i32.add
-          (i32.shl
-            (local.tee $l4
-              (i32.add
-                (local.tee $l2 (i32.load offset=4 (local.get $p1)))
-                (local.tee $l3 (i32.load offset=4 (local.get $p0)))
-              )
+  (local.set $l2 (i32.add (local.get $p1) (i32.const 8)))
+  (local.set $l3 (i32.add (local.get $p0) (i32.const 8)))
+  (local.set $l6
+    (i32.add
+      (local.tee $l5
+        (call $mkArray
+          (local.tee $p0
+            (i32.add
+              (local.tee $l4 (i32.load offset=4 (local.get $p1)))
+              (local.tee $p1 (i32.load offset=4 (local.get $p0)))
             )
-            (i32.const 3))
-          (i32.const 16)
+          )
+          (local.get $p0)
         )
       )
-    )
-    (local.get $l4)
-  )
-  (i32.store (local.get $l5) (i32.const 1))
-  (local.set $l4
-    (select
-      (local.get $l3)
-      (i32.const 0)
-      (i32.gt_s (local.get $l3) (i32.const 0))
+      (i32.const 8)
     )
   )
-  (local.set $p0 (i32.add (local.get $p0) (i32.const 8)))
-  (local.set $l6 (i32.add (local.get $l5) (i32.const 8)))
+  (local.set $p0 (i32.const 0))
   (block $B0
     (loop $L1
       (block $B2
-        (br_if $B2 (local.get $l4))
-        (local.set $l4
-          (select
-            (local.get $l2)
-            (i32.const 0)
-            (i32.gt_s (local.get $l2) (i32.const 0))
-          )
-        )
-        (local.set $p0 (i32.add (local.get $p1) (i32.const 8)))
-        (local.set $l6
-          (i32.add
-            (i32.add
-              (i32.shl (local.get $l3) (i32.const 2))
-              (local.get $l5))
-            (i32.const 8)
-          )
-        )
+        (br_if $B2 (i32.lt_s (local.get $p0) (local.get $p1)))
+        (local.set $p1 (i32.add (i32.add (local.get $p1) (local.get $l5)) (i32.const 8)))
+        (local.set $p0 (i32.const 0))
         (loop $L3
-          (br_if $B0 (i32.eqz (local.get $l4)))
-          (i32.store (local.get $l6) (i32.load (local.get $p0)))
-          (local.set $l6 (i32.add (local.get $l6) (i32.const 4)))
-          (local.set $p0 (i32.add (local.get $p0) (i32.const 4)))
-          (local.set $l4 (i32.add (local.get $l4) (i32.const -1)))
+          (br_if $B0 (i32.ge_s (local.get $p0) (local.get $l4)))
+          (i32.store8 (i32.add (local.get $p1) (local.get $p0))
+          (i32.load8_u (i32.add (local.get $l2) (local.get $p0))))
+          (local.set $p0 (i32.add (local.get $p0) (i32.const 1)))
           (br $L3)
         )
       )
-      (i32.store (local.get $l6) (i32.load (local.get $p0)))
-      (local.set $l6 (i32.add (local.get $l6) (i32.const 4)))
-      (local.set $p0 (i32.add (local.get $p0) (i32.const 4)))
-      (local.set $l4 (i32.add (local.get $l4) (i32.const -1)))
+      (i32.store8
+        (i32.add (local.get $l6) (local.get $p0))
+        (i32.load8_u (i32.add (local.get $l3) (local.get $p0)))
+      )
+      (local.set $p0 (i32.add (local.get $p0) (i32.const 1)))
       (br $L1)
     )
   )

--- a/crates/samlang-wasm/loader.js
+++ b/crates/samlang-wasm/loader.js
@@ -5,10 +5,9 @@ export default async function interpretWebAssemblyModule(
 ) {
   const memory = new WebAssembly.Memory({ initial: 2, maximum: 65536 });
   function pointerToString(/** @type {number} */ p) {
-    const mem = new Uint32Array(memory.buffer);
-    const start = p / 4;
-    const length = mem[start + 1];
-    const characterCodes = Array.from(mem.subarray(start + 2, start + 2 + length).values());
+    const mem = new Uint8Array(memory.buffer);
+    const length = mem[p + 4] | (mem[p + 5] << 8) | (mem[p + 6] << 16) | (mem[p + 7] << 24);
+    const characterCodes = Array.from(mem.subarray(p + 8, p + 8 + length).values());
     return String.fromCharCode(...characterCodes);
   }
 

--- a/packages/samlang-cli/loader.js
+++ b/packages/samlang-cli/loader.js
@@ -6,10 +6,9 @@ function samlangGeneratedWebAssemblyLoader(
   const codeModule = new WebAssembly.Module(bytes);
 
   function pointerToString(/** @type {number} */ p) {
-    const mem = new Uint32Array(memory.buffer);
-    const start = p / 4;
-    const length = mem[start + 1];
-    const characterCodes = Array.from(mem.subarray(start + 2, start + 2 + length).values());
+    const mem = new Uint8Array(memory.buffer);
+    const length = mem[p + 4] | (mem[p + 5] << 8) | (mem[p + 6] << 16) | (mem[p + 7] << 24);
+    const characterCodes = Array.from(mem.subarray(p + 8, p + 8 + length).values());
     return String.fromCharCode(...characterCodes);
   }
 


### PR DESCRIPTION
Use one byte per byte instead of 4 bytes.