### PR TITLE
[checker] Resolve method type with NominalType

### DIFF
--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -724,16 +724,10 @@ fn check_member_with_unresolved_tparams(
       return (partially_checked_expr, vec![]);
     }
   };
-  let method_targs = obj_type.type_arguments.clone();
-  let &NominalType { reason: _, module_reference: method_mod_ref, id: class_id, type_arguments: _ } =
-    obj_type;
-  if let Some(method_type_info) = cx.get_method_type(
-    method_mod_ref,
-    class_id,
-    expression.field_name.name,
-    method_targs,
-    expression.common.loc,
-  ) {
+  let class_id = obj_type.id;
+  if let Some(method_type_info) =
+    cx.get_method_type(obj_type, expression.field_name.name, expression.common.loc)
+  {
     // This is a valid method. We will now type check it as a method access
     for targ in &expression.explicit_type_arguments {
       cx.validate_type_instantiation_strictly(heap, &Type::from_annotation(targ))

--- a/crates/samlang-core/src/checker/typing_context.rs
+++ b/crates/samlang-core/src/checker/typing_context.rs
@@ -280,24 +280,14 @@ impl<'a> TypingContext<'a> {
 
   pub(super) fn get_method_type(
     &self,
-    module_reference: ModuleReference,
-    class_name: PStr,
+    nominal_type: &NominalType,
     method_name: PStr,
-    class_type_arguments: Vec<Rc<Type>>,
     use_loc: Location,
   ) -> Option<MemberSignature> {
-    let resolved = global_signature::resolve_method_signature(
-      self.global_signature,
-      &NominalType {
-        reason: Reason::new(use_loc, None),
-        module_reference,
-        id: class_name,
-        type_arguments: class_type_arguments,
-      },
-      method_name,
-    );
+    let resolved =
+      global_signature::resolve_method_signature(self.global_signature, nominal_type, method_name);
     let type_info = resolved.first()?;
-    if type_info.is_public || self.in_same_class(module_reference, class_name) {
+    if type_info.is_public || self.in_same_class(nominal_type.module_reference, nominal_type.id) {
       Some(type_info.reposition(use_loc))
     } else {
       None

--- a/crates/samlang-core/src/checker/typing_context_tests.rs
+++ b/crates/samlang-core/src/checker/typing_context_tests.rs
@@ -5,8 +5,8 @@ mod tests {
     checker::{
       ssa_analysis::SsaAnalysisResult,
       type_::{
-        test_type_builder, ISourceType, InterfaceSignature, MemberSignature, ModuleSignature, Type,
-        TypeDefinitionSignature, TypeParameterSignature,
+        test_type_builder, ISourceType, InterfaceSignature, MemberSignature, ModuleSignature,
+        NominalType, Type, TypeDefinitionSignature, TypeParameterSignature,
       },
       typing_context::{LocalTypingContext, TypingContext},
     },
@@ -519,28 +519,37 @@ __DUMMY__.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected:
       .is_none());
     assert!(cx
       .get_method_type(
-        ModuleReference::dummy(),
-        heap.alloc_str_for_test("B"),
+        &NominalType {
+          reason: Reason::dummy(),
+          module_reference: ModuleReference::dummy(),
+          id: heap.alloc_str_for_test("B"),
+          type_arguments: vec![]
+        },
         heap.alloc_str_for_test("m2"),
-        vec![],
         Location::dummy(),
       )
       .is_none());
     assert!(cx
       .get_method_type(
-        ModuleReference::dummy(),
-        heap.alloc_str_for_test("B"),
+        &NominalType {
+          reason: Reason::dummy(),
+          module_reference: ModuleReference::dummy(),
+          id: heap.alloc_str_for_test("B"),
+          type_arguments: vec![]
+        },
         heap.alloc_str_for_test("m3"),
-        vec![],
         Location::dummy(),
       )
       .is_none());
     assert!(cx
       .get_method_type(
-        ModuleReference::dummy(),
-        heap.alloc_str_for_test("C"),
+        &NominalType {
+          reason: Reason::dummy(),
+          module_reference: ModuleReference::dummy(),
+          id: heap.alloc_str_for_test("C"),
+          type_arguments: vec![]
+        },
         heap.alloc_str_for_test("m3"),
-        vec![],
         Location::dummy(),
       )
       .is_none());
@@ -548,10 +557,13 @@ __DUMMY__.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected:
     assert_eq!(
       "public <C>(int, int) -> int",
       cx.get_method_type(
-        ModuleReference::dummy(),
-        heap.alloc_str_for_test("A"),
+        &NominalType {
+          reason: Reason::dummy(),
+          module_reference: ModuleReference::dummy(),
+          id: heap.alloc_str_for_test("A"),
+          type_arguments: vec![builder.int_type(), builder.int_type()]
+        },
         heap.alloc_str_for_test("m1"),
-        vec![builder.int_type(), builder.int_type()],
         Location::dummy(),
       )
       .unwrap()


### PR DESCRIPTION
[checker] Resolve method type with NominalType
Prepares for eventual unification of method & function call with companion object.
