### PR TITLE
[compiler][mir] Add more dynamic ref counting functions

### DIFF
--- a/crates/samlang-core/src/ast/common_names.rs
+++ b/crates/samlang-core/src/ast/common_names.rs
@@ -22,9 +22,6 @@ pub(crate) fn encode_generic_function_name_globally(
   format!("$GENERICS$_{class_name}${function_name}")
 }
 
-pub(crate) fn encode_builtin_name(name: &str) -> String {
-  format!("_builtin_{name}")
-}
 fn encode_builtin_function_name_globally(class_name: &str, function_name: &str) -> String {
   format!("__{class_name}${function_name}")
 }
@@ -32,12 +29,11 @@ pub(crate) fn encode_main_function_name(heap: &Heap, module_reference: &ModuleRe
   encode_function_name_globally(heap, module_reference, "Main", "main")
 }
 
-pub(crate) fn encoded_fn_name_malloc() -> String {
-  encode_builtin_name("malloc")
-}
-pub(crate) fn encoded_fn_name_free() -> String {
-  encode_builtin_name("free")
-}
+pub(crate) const ENCODED_FN_NAME_MALLOC: &str = "_builtin_malloc";
+pub(crate) const ENCODED_FN_NAME_FREE: &str = "_builtin_free";
+pub(crate) const ENCODED_FN_NAME_INC_REF: &str = "_builtin_inc_ref";
+pub(crate) const ENCODED_FN_NAME_DEC_REF: &str = "_builtin_dec_ref";
+
 pub(crate) fn encoded_fn_name_string_concat() -> String {
   encode_builtin_function_name_globally("Builtins", "stringConcat")
 }
@@ -79,8 +75,6 @@ mod tests {
       .alloc_module_reference_from_string_vec(vec!["Foo-Bar-Derp".to_string(), "Baz".to_string()]);
     assert_eq!("_Foo_Bar_Derp$Baz_Main$main", encode_main_function_name(heap, &mod_ref));
 
-    assert_eq!("_builtin_malloc", encoded_fn_name_malloc());
-    assert_eq!("_builtin_free", encoded_fn_name_free());
     assert_eq!("__Builtins$stringConcat", encoded_fn_name_string_concat());
     assert_eq!("__Builtins$panic", encoded_fn_name_panic());
     assert_eq!("__Builtins$intToString", encoded_fn_name_int_to_string());

--- a/crates/samlang-core/src/ast/mir.rs
+++ b/crates/samlang-core/src/ast/mir.rs
@@ -446,7 +446,7 @@ const {} = (v: any): number => {{ v.length = 0; return 0 }};
       common_names::encoded_fn_name_string_to_int(),
       common_names::encoded_fn_name_int_to_string(),
       common_names::encoded_fn_name_panic(),
-      common_names::encoded_fn_name_free()
+      common_names::ENCODED_FN_NAME_FREE
     )); // empty the array to mess up program code that uses after free.
 
     for v in &self.global_variables {

--- a/crates/samlang-core/src/ast/mir_tests.rs
+++ b/crates/samlang-core/src/ast/mir_tests.rs
@@ -283,7 +283,7 @@ function Bar(f: number): number {{
       common_names::encoded_fn_name_string_to_int(),
       common_names::encoded_fn_name_int_to_string(),
       common_names::encoded_fn_name_panic(),
-      common_names::encoded_fn_name_free()
+      common_names::ENCODED_FN_NAME_FREE
     );
     assert_eq!(expected, sources.pretty_print(heap));
   }

--- a/crates/samlang-core/src/compiler/wasm_lowering.rs
+++ b/crates/samlang-core/src/compiler/wasm_lowering.rs
@@ -184,7 +184,7 @@ impl<'a> LoweringManager<'a> {
         vec![wasm::Instruction::Inline(self.set(name, assigned))]
       }
       mir::Statement::StructInit { struct_variable_name, type_: _, expression_list } => {
-        let fn_name = self.heap.alloc_string(common_names::encoded_fn_name_malloc());
+        let fn_name = self.heap.alloc_str_permanent(common_names::ENCODED_FN_NAME_MALLOC);
         let mut instructions = vec![wasm::Instruction::Inline(self.set(
           struct_variable_name,
           wasm::InlineInstruction::DirectCall(

--- a/crates/samlang-core/src/interpreter/mir_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/mir_interpreter.rs
@@ -236,7 +236,7 @@ fn eval_fun_call(
 ) -> i32 {
   if let Expression::Name(s, _) = callee {
     let name = s.as_str(mem.heap);
-    if name.eq(&common_names::encoded_fn_name_free()) {
+    if name.eq(common_names::ENCODED_FN_NAME_FREE) {
       let argument_vs = eval_arguments(mem, arguments);
       assert!(argument_vs.len() == 1);
       mem.free(argument_vs[0]);
@@ -431,7 +431,7 @@ mod tests {
             },
             Statement::Call {
               callee: Expression::Name(
-                heap.alloc_string(common_names::encoded_fn_name_free()),
+                heap.alloc_str_permanent(common_names::ENCODED_FN_NAME_FREE),
                 INT_TYPE,
               ),
               arguments: vec![Expression::Variable(heap.alloc_str_for_test("o"), INT_TYPE)],


### PR DESCRIPTION
In this diff, we replace the current static inc and dec ref counting function with a very dynamic ones. With the previous restriction on struct size, we can now encode the struct header as follows:

```
| 16 bits of bitset | 16 bits of ref count |
```

where the first 16 bits encodes whether a field is a ref type. This information can then be used to help us decide at runtime whether to recursively call dec_ref function. This implementation helps to significantly reduce the code size, and helps with future integration with WASM gc as well.
