### PR TITLE
[ast] Get rid of bool type in IR

### DIFF
--- a/crates/samlang-core/src/ast/hir_tests.rs
+++ b/crates/samlang-core/src/ast/hir_tests.rs
@@ -34,7 +34,6 @@ mod tests {
     assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a"))).is_empty());
     assert!(!format!("{:?}", Operator::GE).is_empty());
     assert!(!format!("{:?}", ZERO.type_()).is_empty());
-    assert!(!format!("{:?}", FALSE.type_()).is_empty());
     assert!(!format!(
       "{:?}",
       Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).type_().as_primitive()
@@ -130,7 +129,6 @@ mod tests {
   fn print_types_and_expressions_tests() {
     let heap = &mut Heap::new();
 
-    assert_eq!("bool", BOOL_TYPE.clone().pretty_print(heap));
     assert_eq!("int", INT_TYPE.pretty_print(heap));
     assert_eq!("string", STRING_TYPE.pretty_print(heap));
     assert_eq!("0", ZERO.clone().debug_print(heap));
@@ -169,12 +167,12 @@ mod tests {
     let heap = &mut Heap::new();
 
     assert_eq!(
-      "object type A = [int, bool]",
+      "object type A = [int, int]",
       TypeDefinition {
         identifier: heap.alloc_str_for_test("A"),
         type_parameters: vec![],
         names: vec![],
-        mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, BOOL_TYPE]),
+        mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, INT_TYPE]),
       }
       .pretty_print(heap)
     );
@@ -320,17 +318,17 @@ mod tests {
 if 0 {
   let baz: FooBar = [meggo];
   let closure: CCC = Closure { fun: (foo: (int) -> int), context: 0 };
-  let dd: bool = 0 < 0;
-  let dd: bool = 0 <= 0;
-  let dd: bool = 0 > 0;
-  let dd: bool = 0 >= 0;
-  let dd: bool = 0 == 0;
-  let dd: bool = 0 != 0;
-  let dd: int = 0 & 0;
-  let dd: int = 0 | 0;
-  let dd: int = 0 << 0;
-  let dd: int = 0 >>> 0;
-  let dd: bool = 0 ^ 0;
+  let dd = 0 < 0;
+  let dd = 0 <= 0;
+  let dd = 0 > 0;
+  let dd = 0 >= 0;
+  let dd = 0 == 0;
+  let dd = 0 != 0;
+  let dd = 0 & 0;
+  let dd = 0 | 0;
+  let dd = 0 << 0;
+  let dd = 0 >>> 0;
+  let dd = 0 ^ 0;
   let cast = 0 as int;
   while (true) {
     if 0 {
@@ -347,12 +345,12 @@ if 0 {
   }
   bar = (b1: int);
 } else {
-  let dd: int = 0 + 0;
-  let dd: int = 0 + 0;
-  let dd: int = 0 - -2147483648;
-  let dd: int = 0 * 0;
-  let dd: int = 0 / 0;
-  let dd: int = 0 % 0;
+  let dd = 0 + 0;
+  let dd = 0 + 0;
+  let dd = 0 - -2147483648;
+  let dd = 0 * 0;
+  let dd = 0 / 0;
+  let dd = 0 % 0;
   let vibez: int = h((big: FooBar));
   stresso<int>((d: int));
   (d: int)((d: int));
@@ -384,7 +382,7 @@ if 0 {
         identifier: heap.alloc_str_for_test("Foo"),
         type_parameters: vec![],
         names: vec![],
-        mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, BOOL_TYPE]),
+        mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, INT_TYPE]),
       }
       .clone()],
       main_function_names: vec![heap.alloc_str_for_test("ddd")],
@@ -410,7 +408,7 @@ if 0 {
     let expected1 = r#"const dev_meggo = 'vibez';
 
 closure type c = () -> int
-object type Foo = [int, bool]
+object type Foo = [int, int]
 function Bar(f: int): int {
   let f: int = (big: FooBar)[0];
   return 0;

--- a/crates/samlang-core/src/ast/mir_tests.rs
+++ b/crates/samlang-core/src/ast/mir_tests.rs
@@ -35,9 +35,6 @@ mod tests {
 
     assert!(INT_TYPE
       .is_the_same_type(Expression::Variable(heap.alloc_str_for_test("a"), INT_TYPE).type_()));
-    assert!(
-      BOOL_TYPE.is_the_same_type(Expression::Name(heap.alloc_str_for_test("a"), BOOL_TYPE).type_())
-    );
     assert!(STRING_TYPE.is_the_same_type(Expression::IntLiteral(1, STRING_TYPE).type_()));
     assert!(STRING_TYPE.is_the_same_type(&ANY_TYPE));
     assert!(!Type::Id(heap.alloc_str_for_test("a"))
@@ -51,13 +48,10 @@ mod tests {
   fn print_types_and_expressions_tests() {
     let heap = &mut Heap::new();
 
-    assert_eq!("boolean", BOOL_TYPE.clone().pretty_print(heap));
     assert_eq!("number", INT_TYPE.pretty_print(heap));
     assert_eq!("Str", STRING_TYPE.pretty_print(heap));
     assert_eq!("any", ANY_TYPE.pretty_print(heap));
     assert_eq!("0", ZERO.clone().pretty_print(heap));
-    assert_eq!("true", TRUE.clone().pretty_print(heap));
-    assert_eq!("false", FALSE.clone().pretty_print(heap));
     assert_eq!(
       "a",
       Expression::Variable(heap.alloc_str_for_test("a"), STRING_TYPE).pretty_print(heap)
@@ -160,7 +154,7 @@ mod tests {
         Statement::IndexedAssign { assigned_expression: ZERO, pointer_expression: ZERO, index: 0 },
         Statement::Cast {
           name: heap.alloc_str_for_test("c"),
-          type_: BOOL_TYPE,
+          type_: INT_TYPE,
           assigned_expression: ZERO,
         },
         Statement::Break(ZERO),
@@ -183,13 +177,13 @@ mod tests {
   let bar: number;
   if (0) {
     let baz: FooBar = [meggo];
-    let dd: boolean = 0 < 0;
-    let dd: boolean = 0 <= 0;
-    let dd: boolean = 0 > 0;
-    let dd: boolean = 0 >= 0;
-    let dd: boolean = 0 == 0;
-    let dd: boolean = 0 != 0;
-    let dd: boolean = 0 ^ 0;
+    let dd = Number(0 < 0);
+    let dd = Number(0 <= 0);
+    let dd = Number(0 > 0);
+    let dd = Number(0 >= 0);
+    let dd = Number(0 == 0);
+    let dd = Number(0 != 0);
+    let dd = 0 ^ 0;
     while (true) {
       if (0) {
       }
@@ -205,18 +199,18 @@ mod tests {
     }
     bar = b1;
   } else {
-    let dd: number = 0 + 0;
-    let dd: number = 0 + 0;
-    let dd: number = 0 - -2147483648;
-    let dd: number = 0 * 0;
-    let dd: number = Math.floor(0 / 0);
-    let dd: number = 0 % 0;
+    let dd = 0 + 0;
+    let dd = 0 + 0;
+    let dd = 0 - -2147483648;
+    let dd = 0 * 0;
+    let dd = Math.floor(0 / 0);
+    let dd = 0 % 0;
     let vibez: number = h(big);
     stresso(d);
     d(d);
     let f: number = big[0];
     0[0] = 0;
-    let c = 0 as boolean;
+    let c = 0 as number;
     break;
     bar = b2;
   }
@@ -243,7 +237,7 @@ mod tests {
       ],
       type_definitions: vec![TypeDefinition {
         name: heap.alloc_str_for_test("Foo"),
-        mappings: vec![INT_TYPE, BOOL_TYPE],
+        mappings: vec![INT_TYPE, INT_TYPE],
       }],
       main_function_names: vec![],
       functions: vec![Function {
@@ -272,7 +266,7 @@ const {} = (_: number, [, v]: Str): number => {{ throw Error(v); }};
 const {} = (v: any): number => {{ v.length = 0; return 0 }};
 const dev_meggo: Str = [0, `vibez`];
 const esc: Str = [0, `f"\"`];
-type Foo = [number, boolean];
+type Foo = [number, number];
 function Bar(f: number): number {{
   let f: number = big[0];
   return 0;

--- a/crates/samlang-core/src/common.rs
+++ b/crates/samlang-core/src/common.rs
@@ -58,9 +58,8 @@ impl ModuleReference {
 }
 
 enum StringStoredInHeap {
-  // (string, marked)
   Permanent(&'static str),
-  Temporary(String, bool),
+  Temporary(String, /** marked */ bool),
   Deallocated(Option<String>),
 }
 

--- a/crates/samlang-core/src/compiler/hir_generics_specialization.rs
+++ b/crates/samlang-core/src/compiler/hir_generics_specialization.rs
@@ -62,9 +62,8 @@ impl Rewriter {
     generics_replacement_map: &HashMap<PStr, Type>,
   ) -> Statement {
     match stmt {
-      Statement::Binary(Binary { name, type_, operator, e1, e2 }) => Statement::Binary(Binary {
+      Statement::Binary(Binary { name, operator, e1, e2 }) => Statement::Binary(Binary {
         name: *name,
-        type_: self.rewrite_type(heap, type_, generics_replacement_map),
         operator: *operator,
         e1: self.rewrite_expr(heap, e1, generics_replacement_map),
         e2: self.rewrite_expr(heap, e2, generics_replacement_map),
@@ -162,7 +161,7 @@ impl Rewriter {
     generics_replacement_map: &HashMap<PStr, Type>,
   ) -> Expression {
     match expression {
-      Expression::IntLiteral(i, b) => Expression::IntLiteral(*i, *b),
+      Expression::IntLiteral(i) => Expression::IntLiteral(*i),
       Expression::StringName(s) => {
         self.used_string_names.insert(*s);
         Expression::StringName(*s)
@@ -437,7 +436,7 @@ pub(super) fn perform_generics_specialization(
 mod tests {
   use super::*;
   use crate::ast::hir::{
-    GlobalVariable, Operator, TypeDefinitionMappings, INT_TYPE, STRING_TYPE, TRUE, ZERO,
+    GlobalVariable, Operator, TypeDefinitionMappings, INT_TYPE, ONE, STRING_TYPE, ZERO,
   };
   use pretty_assertions::assert_eq;
 
@@ -729,7 +728,7 @@ sources.mains = [main]
             type_parameters: vec![],
             type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
             body: vec![Statement::IfElse {
-              condition: TRUE,
+              condition: ONE,
               s1: vec![
                 Statement::Call {
                   callee: Callee::FunctionName(FunctionName {
@@ -884,7 +883,7 @@ function main(): int {
     finalV = (v1: int);
   } else {
     main();
-    let v1: int = 0 + 0;
+    let v1 = 0 + 0;
     let j: J = [0];
     let v2: int = (j: J)[0];
     let c1: CC_string_string = Closure { fun: (creatorIA_string: (string) -> I_string_string), context: G1 };

--- a/crates/samlang-core/src/compiler/hir_tail_recursion_rewrite.rs
+++ b/crates/samlang-core/src/compiler/hir_tail_recursion_rewrite.rs
@@ -158,7 +158,7 @@ fn optimize_function_by_tailrec_rewrite_aux(
   function: Function,
 ) -> Result<Function, Function> {
   let expected_return_collector = match &function.return_value {
-    Expression::IntLiteral(_, _) => None,
+    Expression::IntLiteral(_) => None,
     Expression::Variable(v) => Some(v.name),
     Expression::StringName(_) => return Err(function),
   };
@@ -390,8 +390,8 @@ mod tests {
   let n: int = (_tailrec_param_n: int);
   let r: int;
   while (true) {
-    let a: int = (n: int) + 0;
-    let r: int = 0 + 0;
+    let a = (n: int) + 0;
+    let r = 0 + 0;
     n = (a: int);
   }
   return (r: int);
@@ -429,7 +429,7 @@ mod tests {
       r#"function loopy(_tailrec_param_n: int): int {
   let n: int = (_tailrec_param_n: int);
   while (true) {
-    let a: int = (n: int) + 0;
+    let a = (n: int) + 0;
     n = (a: int);
   }
   return 0;
@@ -489,13 +489,13 @@ mod tests {
   let n: int = (_tailrec_param_n: int);
   let r: int;
   while (true) {
-    let a: int = (n: int) + 0;
+    let a = (n: int) + 0;
     let _t7: int;
     if 0 {
-      let r1: int = 0 + 0;
+      let r1 = 0 + 0;
       _t7 = (a: int);
     } else {
-      let r2: int = 0 + 0;
+      let r2 = 0 + 0;
       _t7 = (a: int);
     }
     n = (_t7: int);
@@ -546,12 +546,12 @@ mod tests {
   let n: int = (_tailrec_param_n: int);
   let r: int;
   while (true) {
-    let a: int = (n: int) + 0;
+    let a = (n: int) + 0;
     if !0 {
       r = 0;
       break;
     }
-    let r1: int = 0 + 0;
+    let r1 = 0 + 0;
     n = (a: int);
   }
   return (r: int);
@@ -594,7 +594,7 @@ mod tests {
       r#"function loopy(_tailrec_param_n: int): int {
   let n: int = (_tailrec_param_n: int);
   while (true) {
-    let a: int = (n: int) + 0;
+    let a = (n: int) + 0;
     if !0 {
       undefined = 0;
       break;
@@ -668,8 +668,8 @@ mod tests {
       v = 1;
       break;
     }
-    let nn: int = (n: int) + -1;
-    let r: int = 0 + 0;
+    let nn = (n: int) + -1;
+    let r = 0 + 0;
     n = (nn: int);
   }
   return (v: int);

--- a/crates/samlang-core/src/compiler/hir_type_conversion.rs
+++ b/crates/samlang-core/src/compiler/hir_type_conversion.rs
@@ -272,9 +272,9 @@ impl TypeLoweringManager {
     match type_ {
       type_::Type::Any(_, _) => panic!(),
       type_::Type::Primitive(_, kind) => Type::Primitive(match kind {
-        type_::PrimitiveTypeKind::Bool => PrimitiveType::Bool,
-        type_::PrimitiveTypeKind::Unit => PrimitiveType::Int,
-        type_::PrimitiveTypeKind::Int => PrimitiveType::Int,
+        type_::PrimitiveTypeKind::Bool
+        | type_::PrimitiveTypeKind::Unit
+        | type_::PrimitiveTypeKind::Int => PrimitiveType::Int,
         type_::PrimitiveTypeKind::String => PrimitiveType::String,
       }),
       type_::Type::Nominal(id) => {
@@ -410,7 +410,7 @@ mod tests {
   use super::*;
   use crate::{
     ast::{
-      hir::{BOOL_TYPE, INT_TYPE, STRING_TYPE},
+      hir::{INT_TYPE, STRING_TYPE},
       source::test_builder,
       Location, Reason,
     },
@@ -429,14 +429,14 @@ mod tests {
     assert_eq!(
       "$SyntheticIDType0",
       synthesizer
-        .synthesize_tuple_type(heap, vec![BOOL_TYPE, Type::new_id(a, vec![INT_TYPE])], vec![])
+        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(a, vec![INT_TYPE])], vec![])
         .identifier
         .as_str(heap),
     );
     assert_eq!(
       "$SyntheticIDType1",
       synthesizer
-        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(b, vec![BOOL_TYPE])], vec![])
+        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(b, vec![INT_TYPE])], vec![])
         .identifier
         .as_str(heap),
     );
@@ -444,14 +444,14 @@ mod tests {
     assert_eq!(
       "$SyntheticIDType0",
       synthesizer
-        .synthesize_tuple_type(heap, vec![BOOL_TYPE, Type::new_id(a, vec![INT_TYPE])], vec![])
+        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(a, vec![INT_TYPE])], vec![])
         .identifier
         .as_str(heap),
     );
     assert_eq!(
       "$SyntheticIDType1",
       synthesizer
-        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(b, vec![BOOL_TYPE])], vec![])
+        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(b, vec![INT_TYPE])], vec![])
         .identifier
         .as_str(heap),
     );
@@ -470,25 +470,11 @@ mod tests {
         .identifier
         .as_str(heap),
     );
-    assert_eq!(
-      "$SyntheticIDType3",
-      synthesizer
-        .synthesize_closure_type(heap, Type::new_fn_unwrapped(vec![], BOOL_TYPE), vec![])
-        .identifier
-        .as_str(heap),
-    );
-    assert_eq!(
-      "$SyntheticIDType3",
-      synthesizer
-        .synthesize_closure_type(heap, Type::new_fn_unwrapped(vec![], BOOL_TYPE), vec![])
-        .identifier
-        .as_str(heap),
-    );
 
     assert_eq!(
-      "$SyntheticIDType4",
+      "$SyntheticIDType3",
       synthesizer
-        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(c, vec![BOOL_TYPE])], vec![a])
+        .synthesize_tuple_type(heap, vec![INT_TYPE, Type::new_id(c, vec![INT_TYPE])], vec![a])
         .identifier
         .as_str(heap),
     );
@@ -497,17 +483,14 @@ mod tests {
 
     assert_eq!(
       vec![
-        "object type $SyntheticIDType0 = [bool, A<int>]",
-        "object type $SyntheticIDType1 = [int, B<bool>]",
-        "object type $SyntheticIDType4<A> = [int, C<bool>]"
+        "object type $SyntheticIDType0 = [int, A<int>]",
+        "object type $SyntheticIDType1 = [int, B<int>]",
+        "object type $SyntheticIDType3<A> = [int, C<int>]"
       ],
       tuple_types.iter().map(|it| it.pretty_print(heap)).collect_vec()
     );
     assert_eq!(
-      vec![
-        "closure type $SyntheticIDType2 = () -> int",
-        "closure type $SyntheticIDType3 = () -> bool",
-      ],
+      vec!["closure type $SyntheticIDType2 = () -> int"],
       closure_types.iter().map(|it| it.pretty_print(heap)).collect_vec()
     );
   }
@@ -520,7 +503,7 @@ mod tests {
 
     assert!(collect_used_generic_types(
       &Type::new_fn_unwrapped(
-        vec![BOOL_TYPE, Type::new_id(heap.alloc_str_for_test("C"), vec![BOOL_TYPE])],
+        vec![INT_TYPE, Type::new_id(heap.alloc_str_for_test("C"), vec![INT_TYPE])],
         Type::new_id_no_targs(heap.alloc_str_for_test("C")),
       ),
       &generic_types,
@@ -603,7 +586,7 @@ mod tests {
         heap.alloc_str_for_test("FF"),
         vec![
           INT_TYPE,
-          BOOL_TYPE,
+          INT_TYPE,
           Type::new_id(heap.alloc_str_for_test("Foo"), vec![STRING_TYPE]),
           INT_TYPE,
           Type::new_id_no_targs(heap.alloc_str_for_test("B")),
@@ -614,7 +597,7 @@ mod tests {
         heap.alloc_str_for_test("FF"),
         vec![
           INT_TYPE,
-          BOOL_TYPE,
+          INT_TYPE,
           Type::new_id(heap.alloc_str_for_test("Foo"), vec![STRING_TYPE]),
           Type::new_id_no_targs(heap.alloc_str_for_test("A")),
           Type::new_id_no_targs(heap.alloc_str_for_test("B")),
@@ -629,7 +612,6 @@ mod tests {
   fn type_application_tests() {
     let heap = &mut Heap::new();
 
-    assert_eq!("bool", type_application(&BOOL_TYPE, &HashMap::new()).pretty_print(heap));
     assert_eq!("int", type_application(&INT_TYPE, &HashMap::new()).pretty_print(heap));
     assert_eq!("string", type_application(&STRING_TYPE, &HashMap::new()).pretty_print(heap));
 
@@ -659,7 +641,7 @@ mod tests {
     );
 
     assert_eq!(
-      "(int) -> bool",
+      "(int) -> int",
       fn_type_application(
         &Type::new_fn_unwrapped(
           vec![Type::new_id_no_targs(heap.alloc_str_for_test("A"))],
@@ -667,7 +649,7 @@ mod tests {
         ),
         &HashMap::from([
           (heap.alloc_str_for_test("A"), INT_TYPE),
-          (heap.alloc_str_for_test("B"), BOOL_TYPE)
+          (heap.alloc_str_for_test("B"), INT_TYPE)
         ])
       )
       .pretty_print(heap)
@@ -714,7 +696,7 @@ mod tests {
     };
     let builder = test_type_builder::create();
 
-    assert_eq!("bool", manager.lower_source_type(heap, &builder.bool_type()).pretty_print(heap));
+    assert_eq!("int", manager.lower_source_type(heap, &builder.bool_type()).pretty_print(heap));
     assert_eq!("int", manager.lower_source_type(heap, &builder.unit_type()).pretty_print(heap));
     assert_eq!("int", manager.lower_source_type(heap, &builder.int_type()).pretty_print(heap));
     assert_eq!(
@@ -751,7 +733,7 @@ mod tests {
       manager2.type_synthesizer.synthesized_types();
     assert!(tuple_types.is_empty());
     assert_eq!(
-      vec!["closure type $SyntheticIDType0<T> = (T, bool) -> int"],
+      vec!["closure type $SyntheticIDType0<T> = (T, int) -> int"],
       closure_types.iter().map(|it| it.pretty_print(heap)).collect_vec()
     );
   }
@@ -799,8 +781,8 @@ mod tests {
       manager.type_synthesizer.synthesized_types();
     assert_eq!(
       vec![
-        "closure type $SyntheticIDType0<A> = (A) -> bool",
-        "closure type $SyntheticIDType1<A> = ($SyntheticIDType0<A>) -> bool",
+        "closure type $SyntheticIDType0<A> = (A) -> int",
+        "closure type $SyntheticIDType1<A> = ($SyntheticIDType0<A>) -> int",
       ],
       closure_types.iter().map(|it| it.pretty_print(heap)).collect_vec()
     );
@@ -828,7 +810,7 @@ mod tests {
       &builder.bool_type(),
     );
     assert!(tparams1.is_empty());
-    assert_eq!("(int) -> bool", f1.pretty_print(heap));
+    assert_eq!("(int) -> int", f1.pretty_print(heap));
 
     let (tparams2, f2) = manager.lower_source_function_type_for_toplevel(
       heap,
@@ -836,6 +818,6 @@ mod tests {
       &builder.bool_type(),
     );
     assert!(tparams2.is_empty());
-    assert_eq!("($SyntheticIDType0) -> bool", f2.pretty_print(heap));
+    assert_eq!("($SyntheticIDType0) -> int", f2.pretty_print(heap));
   }
 }

--- a/crates/samlang-core/src/compiler/hir_type_deduplication.rs
+++ b/crates/samlang-core/src/compiler/hir_type_deduplication.rs
@@ -50,7 +50,7 @@ fn rewrite_fn_name(
 
 fn rewrite_expr(state: &State, expr: Expression) -> Expression {
   match expr {
-    Expression::IntLiteral(_, _) | Expression::StringName(_) => expr,
+    Expression::IntLiteral(_) | Expression::StringName(_) => expr,
     Expression::Variable(n) => Expression::Variable(rewrite_var_name(state, n)),
   }
 }
@@ -61,9 +61,8 @@ fn rewrite_expressions(state: &State, expressions: Vec<Expression>) -> Vec<Expre
 
 fn rewrite_stmt(state: &State, stmt: Statement) -> Statement {
   match stmt {
-    Statement::Binary(Binary { name, type_, operator, e1, e2 }) => Statement::Binary(Binary {
+    Statement::Binary(Binary { name, operator, e1, e2 }) => Statement::Binary(Binary {
       name,
-      type_: rewrite_type(state, type_),
       operator,
       e1: rewrite_expr(state, e1),
       e2: rewrite_expr(state, e2),
@@ -231,7 +230,7 @@ pub(super) fn deduplicate(
 mod tests {
   use super::*;
   use crate::{
-    ast::hir::{INT_TYPE, STRING_TYPE, TRUE, ZERO},
+    ast::hir::{INT_TYPE, ONE, STRING_TYPE, ZERO},
     Heap,
   };
   use pretty_assertions::assert_eq;
@@ -309,7 +308,7 @@ mod tests {
         type_parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![Statement::IfElse {
-          condition: TRUE,
+          condition: ONE,
           s1: vec![
             Statement::binary(
               heap.alloc_str_for_test("_"),
@@ -380,7 +379,7 @@ object type C = [int, string]
 function main(): int {
   let _: int;
   if 1 {
-    let _: int = 0 + 0;
+    let _ = 0 + 0;
     f<int>(0);
     (f: int)();
     let _: A = 0[0];

--- a/crates/samlang-core/src/compiler/mir_unused_name_elimination.rs
+++ b/crates/samlang-core/src/compiler/mir_unused_name_elimination.rs
@@ -31,10 +31,9 @@ fn collect_used_names_from_statement(
   statement: &Statement,
 ) {
   match statement {
-    Statement::Binary { name: _, type_, operator: _, e1, e2 } => {
+    Statement::Binary { name: _, operator: _, e1, e2 } => {
       collect_used_names_from_expression(name_set, type_set, e1);
       collect_used_names_from_expression(name_set, type_set, e2);
-      collect_for_type_set(type_, type_set);
     }
     Statement::IndexedAccess { name: _, type_, pointer_expression, index: _ } => {
       collect_used_names_from_expression(name_set, type_set, pointer_expression);

--- a/crates/samlang-core/src/compiler/wasm_lowering.rs
+++ b/crates/samlang-core/src/compiler/wasm_lowering.rs
@@ -51,7 +51,7 @@ impl<'a> LoweringManager<'a> {
 
   fn lower_stmt(&mut self, s: &mir::Statement) -> Vec<wasm::Instruction> {
     match s {
-      mir::Statement::Binary { name, type_: _, operator, e1, e2 } => {
+      mir::Statement::Binary { name, operator, e1, e2 } => {
         let i1 = Box::new(self.lower_expr(e1));
         let i2 = Box::new(self.lower_expr(e2));
         vec![wasm::Instruction::Inline(
@@ -286,9 +286,7 @@ mod tests {
   use crate::{
     ast::{
       hir::{GlobalVariable, Operator},
-      mir::{
-        Expression, Function, GenenalLoopVariable, Sources, Statement, Type, FALSE, INT_TYPE, ZERO,
-      },
+      mir::{Expression, Function, GenenalLoopVariable, Sources, Statement, Type, INT_TYPE, ZERO},
     },
     common::Heap,
   };
@@ -326,9 +324,9 @@ mod tests {
         parameters: vec![heap.alloc_str_for_test("bar")],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: vec![
-          Statement::IfElse { condition: FALSE, s1: vec![], s2: vec![], final_assignments: vec![] },
+          Statement::IfElse { condition: ZERO, s1: vec![], s2: vec![], final_assignments: vec![] },
           Statement::IfElse {
-            condition: FALSE,
+            condition: ZERO,
             s1: vec![],
             s2: vec![Statement::Cast {
               name: heap.alloc_str_for_test("c"),
@@ -338,7 +336,7 @@ mod tests {
             final_assignments: vec![],
           },
           Statement::IfElse {
-            condition: FALSE,
+            condition: ZERO,
             s1: vec![Statement::While {
               loop_variables: vec![GenenalLoopVariable {
                 name: heap.alloc_str_for_test("i"),
@@ -357,7 +355,7 @@ mod tests {
               Statement::While {
                 loop_variables: vec![],
                 statements: vec![Statement::SingleIf {
-                  condition: FALSE,
+                  condition: ZERO,
                   invert_condition: false,
                   statements: vec![Statement::Break(ZERO)],
                 }],
@@ -366,7 +364,7 @@ mod tests {
               Statement::While {
                 loop_variables: vec![],
                 statements: vec![Statement::SingleIf {
-                  condition: FALSE,
+                  condition: ZERO,
                   invert_condition: true,
                   statements: vec![Statement::Break(ZERO)],
                 }],

--- a/crates/samlang-core/src/interpreter/mir_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/mir_interpreter.rs
@@ -108,7 +108,7 @@ fn eval_stmt(
   stmt: &Statement,
 ) -> Result<(), i32> {
   match stmt {
-    Statement::Binary { name, type_: _, operator, e1, e2 } => {
+    Statement::Binary { name, operator, e1, e2 } => {
       let v1 = eval_expr(mem, e1);
       let v2 = eval_expr(mem, e2);
       let v = match operator {
@@ -564,119 +564,102 @@ mod tests {
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::PLUS,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::MINUS,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::MUL,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::DIV,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ONE,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::MOD,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ONE,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::LAND,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::LOR,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::SHL,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::SHR,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::XOR,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::LT,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::LE,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::GT,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::GE,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::EQ,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::NE,
               e1: ZERO,
               e2: ZERO,
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("v"),
-              type_: INT_TYPE,
               operator: Operator::PLUS,
               e1: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
               e2: ONE,
@@ -758,7 +741,6 @@ mod tests {
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("if_sum"),
-              type_: INT_TYPE,
               operator: Operator::PLUS,
               e1: Expression::Variable(heap.alloc_str_for_test("if1"), INT_TYPE),
               e2: Expression::Variable(heap.alloc_str_for_test("if2"), INT_TYPE),
@@ -804,7 +786,6 @@ mod tests {
             },
             Statement::Binary {
               name: heap.alloc_str_for_test("product"),
-              type_: INT_TYPE,
               operator: Operator::MUL,
               e1: Expression::Variable(heap.alloc_str_for_test("if_sum"), INT_TYPE),
               e2: Expression::Variable(heap.alloc_str_for_test("bc"), INT_TYPE),

--- a/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
+++ b/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
@@ -38,13 +38,13 @@ fn optimize_stmt(
     | Statement::StructInit { .. }
     | Statement::ClosureInit { .. } => vec![stmt],
 
-    Statement::Binary(Binary { name, type_, operator, e1, e2 }) => {
+    Statement::Binary(Binary { name, operator, e1, e2 }) => {
       set.insert(BindedValue::Binary(BinaryBindedValue {
         operator,
         e1: e1.clone(),
         e2: e2.clone(),
       }));
-      vec![Statement::Binary(Binary { name, type_, operator, e1, e2 })]
+      vec![Statement::Binary(Binary { name, operator, e1, e2 })]
     }
     Statement::IndexedAccess { name, type_, pointer_expression, index } => {
       set.insert(BindedValue::IndexedAccess(IndexAccessBindedValue {
@@ -104,7 +104,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, Operator, Statement, Type, VariableName,
-      BOOL_TYPE, INT_TYPE, ONE, ZERO,
+      INT_TYPE, ONE, ZERO,
     },
     Heap,
   };
@@ -137,7 +137,7 @@ mod tests {
 
     assert_correctly_optimized(
       vec![Statement::IfElse {
-        condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+        condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
         s1: vec![
           Statement::binary(heap.alloc_str_for_test("ddddd"), Operator::PLUS, ONE, ONE),
           Statement::binary(heap.alloc_str_for_test("a"), Operator::PLUS, ONE, ZERO),
@@ -181,10 +181,10 @@ mod tests {
         final_assignments: vec![],
       }],
       heap,
-      r#"let _t10: int = 1 + 0;
+      r#"let _t10 = 1 + 0;
 let _t11: int = 0[3];
-if (b: bool) {
-  let ddddd: int = 1 + 1;
+if (b: int) {
+  let ddddd = 1 + 1;
   fff((_t10: int), (_t11: int));
 } else {
   (eeee: int)((_t10: int), (_t11: int));

--- a/crates/samlang-core/src/optimization/conditional_constant_propagation_tests.rs
+++ b/crates/samlang-core/src/optimization/conditional_constant_propagation_tests.rs
@@ -3,7 +3,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, FALSE, INT_TYPE, ONE, TRUE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     common::Heap,
   };
@@ -296,17 +296,17 @@ mod tests {
       heap,
       r#"let c_o: Id = [6, 1, 2147483646, 0, 3];
 let i0: int = 6[2];
-let b8: int = (i0: int) * (i0: int);
-let a6: int = (i1: int) / 30;
+let b8 = (i0: int) * (i0: int);
+let a6 = (i1: int) / 30;
 let s: Id = [0, (a6: int), 30];
 let s: Id = Closure { fun: (closure: () -> int), context: 0 };
 fff(1, 0, 0, 0, 0, 0, 1);
-let a9: int = 6 / 0;
-let a10: int = 6 % 0;
-let a15: int = (i0: int) * 5;
-let a16: int = (a15: int) + 5;
-let a17: int = (a15: int) + 47;
-let a18: int = (a15: int) / 5;
+let a9 = 6 / 0;
+let a10 = 6 % 0;
+let a15 = (i0: int) * 5;
+let a16 = (a15: int) + 5;
+let a17 = (a15: int) + 47;
+let a18 = (a15: int) / 5;
 let a19 = (a18: int) as int;
 return (a17: int);"#,
     );
@@ -376,8 +376,8 @@ return 1;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: int = (a0: int) + 4;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) + 4;
 return 0;"#,
     );
 
@@ -398,8 +398,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: int = (a0: int) + -1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) + -1;
 return 0;"#,
     );
 
@@ -420,8 +420,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + -2;
-let a2: int = (a0: int) + 1;
+      r#"let a1 = (a0: int) + -2;
+let a2 = (a0: int) + 1;
 return 0;"#,
     );
 
@@ -442,8 +442,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + -2;
-let a2: int = (a0: int) + -5;
+      r#"let a1 = (a0: int) + -2;
+let a2 = (a0: int) + -5;
 return 0;"#,
     );
 
@@ -476,10 +476,10 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) * 2;
-let a2: int = (a0: int) * 6;
-let a3: int = (a0: int) + 2;
-let a4: int = (a3: int) * 3;
+      r#"let a1 = (a0: int) * 2;
+let a2 = (a0: int) * 6;
+let a3 = (a0: int) + 2;
+let a4 = (a3: int) * 3;
 return 0;"#,
     );
 
@@ -500,8 +500,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) < 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) < 1;
 return 0;"#,
     );
 
@@ -522,8 +522,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) <= 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) <= 1;
 return 0;"#,
     );
 
@@ -544,8 +544,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) > 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) > 1;
 return 0;"#,
     );
 
@@ -566,8 +566,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) >= 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) >= 1;
 return 0;"#,
     );
 
@@ -588,8 +588,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) == 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) == 1;
 return 0;"#,
     );
 
@@ -610,8 +610,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) + 2;
-let a2: bool = (a0: int) != 1;
+      r#"let a1 = (a0: int) + 2;
+let a2 = (a0: int) != 1;
 return 0;"#,
     );
 
@@ -632,8 +632,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let a1: int = (a0: int) * 2;
-let a2: bool = (a1: int) == 3;
+      r#"let a1 = (a0: int) * 2;
+let a2 = (a1: int) == 3;
 return 0;"#,
     );
   }
@@ -646,7 +646,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b1"), Operator::LT, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b1"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b1"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -669,7 +669,7 @@ return 0;"#,
         },
         Statement::binary(heap.alloc_str_for_test("b2"), Operator::GT, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b2"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b2"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -692,7 +692,7 @@ return 0;"#,
         },
         Statement::binary(heap.alloc_str_for_test("b3"), Operator::LE, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b3"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b3"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -720,7 +720,7 @@ return 0;"#,
         },
         Statement::binary(heap.alloc_str_for_test("b4"), Operator::GE, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b4"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b4"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -753,22 +753,22 @@ return 0;"#,
           Expression::var_name(heap.alloc_str_for_test("ma2"), INT_TYPE),
         ),
         Statement::binary(heap.alloc_str_for_test("r2"), Operator::NE, ONE, ZERO),
-        Statement::binary(heap.alloc_str_for_test("r3"), Operator::XOR, TRUE, FALSE),
+        Statement::binary(heap.alloc_str_for_test("r3"), Operator::XOR, ONE, ZERO),
         Statement::binary(heap.alloc_str_for_test("r4"), Operator::NE, ONE, ZERO),
         Statement::binary(
           heap.alloc_str_for_test("r5"),
           Operator::EQ,
-          Expression::var_name(heap.alloc_str_for_test("r4"), BOOL_TYPE),
-          Expression::var_name(heap.alloc_str_for_test("r2"), BOOL_TYPE),
+          Expression::var_name(heap.alloc_str_for_test("r4"), INT_TYPE),
+          Expression::var_name(heap.alloc_str_for_test("r2"), INT_TYPE),
         ),
       ],
-      Expression::var_name(heap.alloc_str_for_test("r5"), BOOL_TYPE),
+      Expression::var_name(heap.alloc_str_for_test("r5"), INT_TYPE),
       heap,
       r#"foo();
 bar();
 let a1: int = foo();
 let a22: int = bar();
-let r1: bool = (a22: int) == (a1: int);
+let r1 = (a22: int) == (a1: int);
 return 1;"#,
     );
 
@@ -787,7 +787,7 @@ return 1;"#,
           Expression::int(3),
         ),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -809,7 +809,7 @@ return 1;"#,
           final_assignments: vec![],
         },
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -836,7 +836,7 @@ return 1;"#,
           )],
         },
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![],
           s2: vec![],
           final_assignments: vec![(
@@ -849,13 +849,13 @@ return 1;"#,
       ],
       Expression::var_name(heap.alloc_str_for_test("ma2"), INT_TYPE),
       heap,
-      r#"if (b: bool) {
+      r#"if (b: int) {
   foo(6);
 } else {
   bar(9);
 }
 let ma1: int;
-if (b: bool) {
+if (b: int) {
   let a1: int = foo(6);
   ma1 = 9;
 } else {
@@ -923,7 +923,7 @@ return 6;"#,
             ZERO,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("n"),
@@ -960,7 +960,7 @@ return 6;"#,
             ZERO,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("n"),
@@ -997,7 +997,7 @@ return 6;"#,
             ZERO,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("n"),
@@ -1017,12 +1017,12 @@ return 6;"#,
       heap,
       r#"let n: int = 4;
 while (true) {
-  let is_zero: bool = (n: int) == 0;
-  if (is_zero: bool) {
+  let is_zero = (n: int) == 0;
+  if (is_zero: int) {
     undefined = (n: int);
     break;
   }
-  let _tmp_n: int = (n: int) + -1;
+  let _tmp_n = (n: int) + -1;
   n = (_tmp_n: int);
 }
 return 0;"#,
@@ -1044,7 +1044,7 @@ return 0;"#,
             ZERO,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             invert_condition: true,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("n"),
@@ -1138,7 +1138,7 @@ return (v: int);"#,
       ZERO,
       heap,
       r#"while (true) {
-  let a: int = (v2: int) + (v1: int);
+  let a = (v2: int) + (v1: int);
 }
 return 0;"#,
     );

--- a/crates/samlang-core/src/optimization/dead_code_elimination.rs
+++ b/crates/samlang-core/src/optimization/dead_code_elimination.rs
@@ -26,7 +26,7 @@ fn collect_use_from_while_parts(
 
 fn collect_use_from_stmt(stmt: &Statement, set: &mut HashSet<PStr>) {
   match stmt {
-    Statement::Binary(Binary { name: _, type_: _, operator: _, e1, e2 }) => {
+    Statement::Binary(Binary { name: _, operator: _, e1, e2 }) => {
       collect_use_from_expression(e1, set);
       collect_use_from_expression(e2, set);
     }

--- a/crates/samlang-core/src/optimization/dead_code_elimination_tests.rs
+++ b/crates/samlang-core/src/optimization/dead_code_elimination_tests.rs
@@ -5,7 +5,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, INT_TYPE, ONE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     common::Heap,
     optimization::dead_code_elimination,
@@ -83,9 +83,9 @@ mod tests {
       stmts,
       Expression::var_name(heap.alloc_str_for_test("ii"), INT_TYPE),
       heap,
-      r#"let u1: int = 0 / 1;
-let u2: int = 0 % 1;
-let p: int = 0 + 1;
+      r#"let u1 = 0 / 1;
+let u2 = 0 % 1;
+let p = 0 + 1;
 let s: S = [(p: int)];
 ff((s: int));
 return (ii: int);"#,
@@ -158,9 +158,9 @@ return (ii: int);"#,
       ],
       ZERO,
       heap,
-      r#"let u1: int = 0 / 1;
-let u2: int = 0 % 1;
-let p: int = 0 + 1;
+      r#"let u1 = 0 / 1;
+let u2 = 0 % 1;
+let p = 0 + 1;
 let i1: int = (p: int)[3];
 let s1: Id = Closure { fun: (closure: () -> int), context: (b2: int) };
 let s2 = (s1: int) as int;
@@ -177,7 +177,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -201,8 +201,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let b: bool = 0 == 1;
-if (b: bool) {
+      r#"let b = 0 == 1;
+if (b: int) {
   s1();
 } else {
   s1();
@@ -219,7 +219,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -248,9 +248,9 @@ return 0;"#,
       ],
       Expression::var_name(heap.alloc_str_for_test("ma"), INT_TYPE),
       heap,
-      r#"let b: bool = 0 == 1;
+      r#"let b = 0 == 1;
 let ma: int;
-if (b: bool) {
+if (b: int) {
   let a1: int = s1();
   ma = (a1: int);
 } else {
@@ -269,7 +269,7 @@ return (ma: int);"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -295,8 +295,8 @@ return (ma: int);"#,
       ],
       ZERO,
       heap,
-      r#"let b: bool = 0 == 1;
-if (b: bool) {
+      r#"let b = 0 == 1;
+if (b: int) {
   s1();
 } else {
   (s1: int)();
@@ -313,7 +313,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -342,8 +342,8 @@ return 0;"#,
       ],
       ZERO,
       heap,
-      r#"let b: bool = 0 == 1;
-if (b: bool) {
+      r#"let b = 0 == 1;
+if (b: int) {
   s1();
 } else {
   s1();
@@ -360,7 +360,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
           s1: vec![],
           s2: vec![],
           final_assignments: vec![],
@@ -380,7 +380,7 @@ return 0;"#,
       vec![
         Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
         Statement::SingleIf {
-          condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
           invert_condition: false,
           statements: vec![],
         },
@@ -435,7 +435,7 @@ return 0;"#,
             ZERO,
           ),
           Statement::IfElse {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             s1: vec![
               Statement::IndexedAccess {
                 name: heap.alloc_str_for_test("s"),
@@ -482,12 +482,12 @@ while (true) {
   (s1: int)();
   while (true) {
   }
-  let is_zero: bool = (n: int) == 0;
+  let is_zero = (n: int) == 0;
   let _tmp_n: int;
-  if (is_zero: bool) {
+  if (is_zero: int) {
     _tmp_n = (n: int);
   } else {
-    let s2_n: int = (n: int) + -1;
+    let s2_n = (n: int) + -1;
     _tmp_n = (s2_n: int);
   }
   n = (_tmp_n: int);
@@ -524,7 +524,7 @@ return 0;"#,
             ZERO,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(ZERO)],
           },
@@ -535,8 +535,8 @@ return 0;"#,
       heap,
       r#"let n: int = 10;
 while (true) {
-  let is_zero: bool = (n: int) == 0;
-  if (is_zero: bool) {
+  let is_zero = (n: int) == 0;
+  if (is_zero: int) {
     undefined = 0;
     break;
   }
@@ -571,7 +571,7 @@ return 0;"#,
       r#"let n: int = 10;
 let v: int;
 while (true) {
-  let n1: int = (n: int) + 0;
+  let n1 = (n: int) + 0;
   n = (n1: int);
 }
 return (v: int);"#,

--- a/crates/samlang-core/src/optimization/inlining.rs
+++ b/crates/samlang-core/src/optimization/inlining.rs
@@ -1,7 +1,7 @@
 use super::optimization_common::LocalValueContextForOptimization;
 use crate::ast::hir::{
   Binary, Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement,
-  Type, VariableName, ZERO,
+  Type, VariableName, INT_TYPE, ZERO,
 };
 use crate::common::PStr;
 use crate::Heap;
@@ -203,9 +203,8 @@ fn inline_rewrite_stmt(
   stmt: &Statement,
 ) -> Statement {
   match stmt {
-    Statement::Binary(Binary { name, type_, operator, e1, e2 }) => Statement::Binary(Binary {
-      name: bind_with_mangled_name(cx, heap, prefix, name, type_),
-      type_: type_.clone(),
+    Statement::Binary(Binary { name, operator, e1, e2 }) => Statement::Binary(Binary {
+      name: bind_with_mangled_name(cx, heap, prefix, name, &INT_TYPE),
       operator: *operator,
       e1: inline_rewrite_expr(e1, cx),
       e2: inline_rewrite_expr(e2, cx),
@@ -339,7 +338,7 @@ fn perform_inline_rewrite_on_function_stmt(
     Statement::Call {
       callee: Callee::FunctionName(FunctionName { name, type_: _, type_arguments: _ }),
       arguments,
-      return_type,
+      return_type: _,
       return_collector,
     } if functions_that_can_be_inlined.contains_key(&name) && name.ne(current_fn_name) => {
       let Function {
@@ -365,7 +364,6 @@ fn perform_inline_rewrite_on_function_stmt(
         // Using this to move the value around, will be optimized away eventually.
         rewritten_body.push(Statement::Binary(Binary {
           name: c,
-          type_: return_type,
           operator: Operator::PLUS,
           e1: inline_rewrite_expr(return_value_of_function_to_be_inlined, &mut cx),
           e2: ZERO,

--- a/crates/samlang-core/src/optimization/inlining_tests.rs
+++ b/crates/samlang-core/src/optimization/inlining_tests.rs
@@ -3,7 +3,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, INT_TYPE, ONE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     common::Heap,
   };
@@ -181,7 +181,7 @@ mod tests {
               ZERO,
             ),
             Statement::IfElse {
-              condition: Expression::var_name(heap.alloc_str_for_test("c"), BOOL_TYPE),
+              condition: Expression::var_name(heap.alloc_str_for_test("c"), INT_TYPE),
               s1: vec![],
               s2: vec![
                 Statement::binary(
@@ -347,13 +347,13 @@ mod tests {
       ],
       heap,
       r#"function factorial(n: int, acc: int): int {
-  let c: bool = (n: int) == 0;
+  let c = (n: int) == 0;
   let fa: int;
-  if (c: bool) {
+  if (c: int) {
     fa = (acc: int);
   } else {
-    let n1: int = (n: int) + -1;
-    let acc1: int = (acc: int) * (n: int);
+    let n1 = (n: int) + -1;
+    let acc1 = (acc: int) * (n: int);
     let v: int = factorial((n1: int), (acc1: int));
     fa = (v: int);
   }
@@ -741,7 +741,7 @@ function main(): int {
             loop_value: Expression::var_name(heap.alloc_str_for_test("_tmp_n"), INT_TYPE),
           }],
           statements: vec![Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("n"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(ZERO)],
           }],

--- a/crates/samlang-core/src/optimization/local_value_numbering.rs
+++ b/crates/samlang-core/src/optimization/local_value_numbering.rs
@@ -45,7 +45,7 @@ fn optimize_stmt(
   binded_value_cx: &mut LocalBindedValueContext,
 ) -> Option<Statement> {
   match stmt {
-    Statement::Binary(Binary { name, type_, operator, e1, e2 }) => {
+    Statement::Binary(Binary { name, operator, e1, e2 }) => {
       let e1 = optimize_expr(e1, variable_cx);
       let e2 = optimize_expr(e2, variable_cx);
       let value =
@@ -55,7 +55,7 @@ fn optimize_stmt(
         None
       } else {
         binded_value_cx.lvn_bind_value(&value, name);
-        Some(Statement::Binary(Binary { name, type_, operator, e1, e2 }))
+        Some(Statement::Binary(Binary { name, operator, e1, e2 }))
       }
     }
     Statement::IndexedAccess { name, type_, pointer_expression, index } => {

--- a/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
+++ b/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
@@ -3,7 +3,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, FALSE, INT_TYPE, ONE, TRUE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     common::Heap,
     optimization::local_value_numbering,
@@ -115,8 +115,8 @@ mod tests {
       Expression::var_name(heap.alloc_str_for_test("ss"), INT_TYPE),
       heap,
       r#"let i0: int = (a: int)[2];
-let b0: int = (i0: int) + 3;
-let b3: int = (i0: int) + (b0: int);
+let b0 = (i0: int) + 3;
+let b3 = (i0: int) + (b0: int);
 let c1 = 0 as int;
 let s: S = [(i0: int), (b0: int), (b3: int)];
 let s: S = Closure { fun: (a: () -> int), context: 0 };
@@ -270,7 +270,7 @@ return 0;"#,
             ZERO,
           ),
           Statement::IfElse {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             s1: vec![],
             s2: vec![Statement::binary(
               heap.alloc_str_for_test("s2_n"),
@@ -279,7 +279,7 @@ return 0;"#,
               ONE,
             )],
             final_assignments: vec![
-              (heap.alloc_str_for_test("c"), INT_TYPE, FALSE, TRUE),
+              (heap.alloc_str_for_test("c"), INT_TYPE, ZERO, ONE),
               (
                 heap.alloc_str_for_test("_tmp_n"),
                 INT_TYPE,
@@ -300,14 +300,14 @@ return 0;"#,
       heap,
       r#"let n: int = 10;
 while (true) {
-  let is_zero: bool = (n: int) == 0;
+  let is_zero = (n: int) == 0;
   let c: int;
   let _tmp_n: int;
-  if (is_zero: bool) {
+  if (is_zero: int) {
     c = 0;
     _tmp_n = (n: int);
   } else {
-    let s2_n: int = (n: int) + -1;
+    let s2_n = (n: int) + -1;
     c = 1;
     _tmp_n = (s2_n: int);
   }
@@ -336,7 +336,7 @@ return 0;"#,
             ZERO,
           ),
           Statement::IfElse {
-            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
             s1: vec![],
             s2: vec![Statement::binary(
               heap.alloc_str_for_test("s2_n"),
@@ -345,7 +345,7 @@ return 0;"#,
               ONE,
             )],
             final_assignments: vec![
-              (heap.alloc_str_for_test("c"), INT_TYPE, FALSE, TRUE),
+              (heap.alloc_str_for_test("c"), INT_TYPE, ZERO, ONE),
               (
                 heap.alloc_str_for_test("_tmp_n"),
                 INT_TYPE,
@@ -362,14 +362,14 @@ return 0;"#,
       r#"let n: int = 10;
 let v: int;
 while (true) {
-  let is_zero: bool = (n: int) == 0;
+  let is_zero = (n: int) == 0;
   let c: int;
   let _tmp_n: int;
-  if (is_zero: bool) {
+  if (is_zero: int) {
     c = 0;
     _tmp_n = (n: int);
   } else {
-    let s2_n: int = (n: int) + -1;
+    let s2_n = (n: int) + -1;
     c = 1;
     _tmp_n = (s2_n: int);
   }

--- a/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
+++ b/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
@@ -63,7 +63,7 @@ pub(super) fn optimize(
 ) -> Option<Vec<Statement>> {
   let BasicInductionVariableWithLoopGuard {
     name: basic_induction_variable_with_loop_guard_name,
-    initial_value: Expression::IntLiteral(initial_guard_value, true),
+    initial_value: Expression::IntLiteral(initial_guard_value),
     increment_amount: PotentialLoopInvariantExpression::Int(guard_increment_amount),
     guard_operator,
     guard_expression: PotentialLoopInvariantExpression::Int(guarded_value),
@@ -90,7 +90,6 @@ pub(super) fn optimize(
           *initial_guard_value + *guard_increment_amount * num_of_loop_iterations;
         return Some(vec![Statement::Binary(Binary {
           name: *n,
-          type_: t.clone(),
           operator: Operator::PLUS,
           e1: Expression::int(basic_induction_variable_with_loop_guard_final_value),
           e2: ZERO,
@@ -102,7 +101,6 @@ pub(super) fn optimize(
       // without looping around.
       return Some(vec![Statement::Binary(Binary {
         name: *n,
-        type_: t.clone(),
         operator: Operator::PLUS,
         e1: e.clone(),
         e2: ZERO,
@@ -138,7 +136,6 @@ pub(super) fn optimize(
     // without looping around.
     Some(vec![Statement::Binary(Binary {
       name: *break_collector.0,
-      type_: break_collector.1.clone(),
       operator: Operator::PLUS,
       e1: Expression::Variable(break_collector.2.clone()),
       e2: ZERO,
@@ -350,7 +347,7 @@ mod tests {
         break_collector: Some((heap.alloc_str_for_test("bc"), INT_TYPE, Expression::int(3))),
       },
       heap,
-      "let bc: int = 3 + 0;",
+      "let bc = 3 + 0;",
     );
 
     assert_optimized(
@@ -373,7 +370,7 @@ mod tests {
         )),
       },
       heap,
-      "let bc: int = 20 + 0;",
+      "let bc = 20 + 0;",
     );
 
     assert_optimized(
@@ -403,7 +400,7 @@ mod tests {
         )),
       },
       heap,
-      "let _t6: int = (outside: int) * 15;\nlet bc: int = (_t6: int) + (j_init: int);",
+      "let _t6 = (outside: int) * 15;\nlet bc = (_t6: int) + (j_init: int);",
     );
 
     assert_optimized(
@@ -433,7 +430,7 @@ mod tests {
         )),
       },
       heap,
-      "let bc: int = (aa: int) + 0;",
+      "let bc = (aa: int) + 0;",
     );
   }
 }

--- a/crates/samlang-core/src/optimization/loop_induction_variable_elimination.rs
+++ b/crates/samlang-core/src/optimization/loop_induction_variable_elimination.rs
@@ -445,10 +445,10 @@ mod tests {
 
     assert_eq!(
       vec![
-        "let _t4: int = 3 * 1;",
-        "let _t5: int = (_t4: int) + 5;",
-        "let _t6: int = 10 * 3;",
-        "let _t7: int = (_t6: int) + 5;",
+        "let _t4 = 3 * 1;",
+        "let _t5 = (_t4: int) + 5;",
+        "let _t6 = 10 * 3;",
+        "let _t7 = (_t6: int) + 5;",
         "{name: tmp_j, initial_value: (_t5: int), increment_amount: 6, guard_operator: LT, guard_expression: (_t7: int)}",
       ],
       optimized
@@ -503,10 +503,10 @@ mod tests {
 
     assert_eq!(
       vec![
-        "let _t5: int = (a: int) * 1;",
-        "let _t6: int = (_t5: int) + 5;",
-        "let _t7: int = (a: int) * 10;",
-        "let _t8: int = (_t7: int) + 5;",
+        "let _t5 = (a: int) * 1;",
+        "let _t6 = (_t5: int) + 5;",
+        "let _t7 = (a: int) * 10;",
+        "let _t8 = (_t7: int) + 5;",
         "{name: tmp_j, initial_value: (_t6: int), increment_amount: (a: int), guard_operator: LT, guard_expression: (_t8: int)}",
       ],
       optimized.prefix_statements
@@ -559,10 +559,10 @@ mod tests {
 
     assert_eq!(
       vec![
-        "let _t5: int = 1 * 1;",
-        "let _t6: int = (_t5: int) + 5;",
-        "let _t7: int = 10 * 1;",
-        "let _t8: int = (_t7: int) + 5;",
+        "let _t5 = 1 * 1;",
+        "let _t6 = (_t5: int) + 5;",
+        "let _t7 = 10 * 1;",
+        "let _t8 = (_t7: int) + 5;",
         "{name: tmp_j, initial_value: (_t6: int), increment_amount: (a: int), guard_operator: LT, guard_expression: (_t8: int)}",
       ],
       optimized.prefix_statements

--- a/crates/samlang-core/src/optimization/loop_invariant_code_motion.rs
+++ b/crates/samlang-core/src/optimization/loop_invariant_code_motion.rs
@@ -127,7 +127,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, INT_TYPE, ONE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     Heap,
   };
@@ -183,7 +183,7 @@ mod tests {
           ZERO,
         ),
         Statement::SingleIf {
-          condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(ZERO)],
         },
@@ -319,7 +319,7 @@ mod tests {
       .map(|s| s.debug_print(heap))
       .join("\n");
     assert_eq!(
-      r#"let c: int = (a: int) - (b: int);
+      r#"let c = (a: int) - (b: int);
 let d: int = (c: int)[0];
 let h: I = Closure { fun: (f: () -> int), context: (d: int) };
 let kk: I = [0];
@@ -331,20 +331,20 @@ let y: int = 0;
 let z: int = 0;
 let bc: int;
 while (true) {
-  let cc: bool = (i: int) < 0;
-  if (cc: bool) {
+  let cc = (i: int) < 0;
+  if (cc: int) {
     bc = 0;
     break;
   }
-  let tmp_i: int = (i: int) + 1;
-  let tmp_j: int = (j: int) + 3;
-  let tmp_x: int = (i: int) * 5;
-  let tmp_y: int = (tmp_x: int) + 6;
+  let tmp_i = (i: int) + 1;
+  let tmp_j = (j: int) + 3;
+  let tmp_x = (i: int) * 5;
+  let tmp_y = (tmp_x: int) + 6;
   f((tmp_x: int));
   let fc: int = f((tmp_x: int));
-  let tmp_z: int = (tmp_x: int) + (tmp_y: int);
+  let tmp_z = (tmp_x: int) + (tmp_y: int);
   let e: int = (x: int)[0];
-  let f: int = (b: int) + (x: int);
+  let f = (b: int) + (x: int);
   let g: I = Closure { fun: (f: () -> int), context: (x: int) };
   let kk2: I = [(g: int)];
   let l2 = (i: int) as int;

--- a/crates/samlang-core/src/optimization/loop_optimizations.rs
+++ b/crates/samlang-core/src/optimization/loop_optimizations.rs
@@ -5,8 +5,7 @@ use super::{
 };
 use crate::{
   ast::hir::{
-    Expression, Function, GenenalLoopVariable, Operator, Statement, VariableName, BOOL_TYPE,
-    INT_TYPE, ZERO,
+    Expression, Function, GenenalLoopVariable, Operator, Statement, VariableName, INT_TYPE, ZERO,
   },
   Heap,
 };
@@ -70,7 +69,7 @@ fn expand_optimizable_while_loop(
         basic_induction_variable_with_loop_guard.guard_expression.to_expression(),
       )),
       Statement::SingleIf {
-        condition: Expression::var_name(loop_condition_variable, BOOL_TYPE),
+        condition: Expression::var_name(loop_condition_variable, INT_TYPE),
         invert_condition: false,
         statements: vec![Statement::Break(break_value.clone())],
       },
@@ -239,7 +238,7 @@ mod tests {
   use crate::{
     ast::hir::{
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
-      VariableName, BOOL_TYPE, INT_TYPE, ONE, ZERO,
+      VariableName, INT_TYPE, ONE, ZERO,
     },
     common::INVALID_PSTR,
     Heap,
@@ -319,7 +318,7 @@ mod tests {
           assigned_expression: ZERO,
         },
         Statement::SingleIf {
-          condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
             heap.alloc_str_for_test("j"),
@@ -369,7 +368,7 @@ mod tests {
           Expression::int(10),
         ),
         Statement::SingleIf {
-          condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
             heap.alloc_str_for_test("j"),
@@ -425,7 +424,7 @@ mod tests {
           Expression::int(10),
         ),
         Statement::SingleIf {
-          condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+          condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
             heap.alloc_str_for_test("j"),
@@ -465,34 +464,34 @@ mod tests {
         None,
       ),
       heap,
-      "let a: int = 0 + 0;\nwhile (true) {\n}",
+      "let a = 0 + 0;\nwhile (true) {\n}",
     );
 
     let heap = &mut Heap::new();
     assert_loop_optimized(
       optimizable_loop_1(heap),
       heap,
-      "let cast = 0 as int;\nlet _t8: int = 10 * 10;\nlet bc: int = (_t8: int) + 0;",
+      "let cast = 0 as int;\nlet _t8 = 10 * 10;\nlet bc = (_t8: int) + 0;",
     );
 
     let heap = &mut Heap::new();
     assert_loop_optimized(
       optimizable_loop_2(heap),
       heap,
-      r#"let _t7: int = 1 * 0;
-let _t8: int = (_t7: int) + 11;
-let _t9: int = 10 * 1;
-let _t10: int = (_t9: int) + 11;
+      r#"let _t7 = 1 * 0;
+let _t8 = (_t7: int) + 11;
+let _t9 = 10 * 1;
+let _t10 = (_t9: int) + 11;
 let j: int = 0;
 let tmp_j: int = (_t8: int);
 let bc: int;
 while (true) {
-  let _t12: bool = (tmp_j: int) >= (_t10: int);
-  if (_t12: bool) {
+  let _t12 = (tmp_j: int) >= (_t10: int);
+  if (_t12: int) {
     bc = (j: int);
     break;
   }
-  let _t11: int = (tmp_j: int) + 1;
+  let _t11 = (tmp_j: int) + 1;
   j = (tmp_j: int);
   tmp_j = (_t11: int);
 }"#,
@@ -502,24 +501,24 @@ while (true) {
     assert_loop_optimized(
       optimizable_loop_3(heap),
       heap,
-      r#"let _t9: int = 1 * 0;
-let _t10: int = (_t9: int) + 10;
-let _t11: int = 1 * 0;
-let _t12: int = (_t11: int) + 10;
+      r#"let _t9 = 1 * 0;
+let _t10 = (_t9: int) + 10;
+let _t11 = 1 * 0;
+let _t12 = (_t11: int) + 10;
 let j: int = 0;
 let i: int = 0;
 let tmp_j: int = (_t10: int);
 let tmp_k: int = (_t12: int);
 let bc: int;
 while (true) {
-  let _t16: bool = (i: int) >= 10;
-  if (_t16: bool) {
+  let _t16 = (i: int) >= 10;
+  if (_t16: int) {
     bc = (j: int);
     break;
   }
-  let _t13: int = (i: int) + 1;
-  let _t14: int = (tmp_j: int) + 1;
-  let _t15: int = (tmp_k: int) + 1;
+  let _t13 = (i: int) + 1;
+  let _t14 = (tmp_j: int) + 1;
+  let _t15 = (tmp_k: int) + 1;
   j = (tmp_j: int);
   i = (_t13: int);
   tmp_j = (_t14: int);
@@ -552,7 +551,7 @@ while (true) {
             Expression::int(10),
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("j"),
@@ -579,14 +578,14 @@ while (true) {
 let i: int = 0;
 let bc: int;
 while (true) {
-  let _t9: bool = (i: int) < 10;
-  if (_t9: bool) {
+  let _t9 = (i: int) < 10;
+  if (_t9: int) {
     bc = (j: int);
     break;
   }
-  let _t8: int = (i: int) + (a: int);
-  let _t10: int = (i: int) * 2;
-  let tmp_j: int = (_t10: int) + 0;
+  let _t8 = (i: int) + (a: int);
+  let _t10 = (i: int) * 2;
+  let tmp_j = (_t10: int) + 0;
   j = (tmp_j: int);
   i = (_t8: int);
 }"#,
@@ -617,7 +616,7 @@ while (true) {
             Expression::int(10),
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("j"),
@@ -640,18 +639,18 @@ while (true) {
         None,
       ),
       heap,
-      r#"let _t6: int = 1 * 0;
-let _t7: int = (_t6: int) + 11;
-let _t8: int = 10 * 1;
-let _t9: int = (_t8: int) + 11;
+      r#"let _t6 = 1 * 0;
+let _t7 = (_t6: int) + 11;
+let _t8 = 10 * 1;
+let _t9 = (_t8: int) + 11;
 let tmp_j: int = (_t7: int);
 while (true) {
-  let _t11: bool = (tmp_j: int) >= (_t9: int);
-  if (_t11: bool) {
+  let _t11 = (tmp_j: int) >= (_t9: int);
+  if (_t11: int) {
     undefined = 0;
     break;
   }
-  let _t10: int = (tmp_j: int) + 1;
+  let _t10 = (tmp_j: int) + 1;
   tmp_j = (_t10: int);
 }"#,
     );
@@ -678,7 +677,7 @@ while (true) {
       }],
       ZERO,
       heap,
-      "let tmp_j: int = (i: int) * 2;\nreturn 0;",
+      "let tmp_j = (i: int) * 2;\nreturn 0;",
     );
 
     let heap = &mut Heap::new();
@@ -700,12 +699,12 @@ while (true) {
 let tmp_j: int = 17;
 let bc: int;
 while (true) {
-  let _t12: bool = (tmp_j: int) >= 21;
-  if (_t12: bool) {
+  let _t12 = (tmp_j: int) >= 21;
+  if (_t12: int) {
     bc = (j: int);
     break;
   }
-  let _t11: int = (tmp_j: int) + 1;
+  let _t11 = (tmp_j: int) + 1;
   j = (tmp_j: int);
   tmp_j = (_t11: int);
 }
@@ -724,14 +723,14 @@ let tmp_j: int = 16;
 let tmp_k: int = 16;
 let bc: int;
 while (true) {
-  let _t16: bool = (i: int) >= 10;
-  if (_t16: bool) {
+  let _t16 = (i: int) >= 10;
+  if (_t16: int) {
     bc = (j: int);
     break;
   }
-  let _t13: int = (i: int) + 1;
-  let _t14: int = (tmp_j: int) + 1;
-  let _t15: int = (tmp_k: int) + 1;
+  let _t13 = (i: int) + 1;
+  let _t14 = (tmp_j: int) + 1;
+  let _t15 = (tmp_k: int) + 1;
   j = (tmp_j: int);
   i = (_t13: int);
   tmp_j = (_t14: int);
@@ -765,7 +764,7 @@ return (bc: int);"#,
             ONE,
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
               heap.alloc_str_for_test("acc"),
@@ -813,7 +812,7 @@ return (bc: int);"#,
             Expression::var_name(heap.alloc_str_for_test("L"), INT_TYPE),
           ),
           Statement::SingleIf {
-            condition: Expression::var_name(heap.alloc_str_for_test("cc"), BOOL_TYPE),
+            condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: true,
             statements: vec![Statement::Break(ZERO)],
           },
@@ -849,20 +848,20 @@ return (bc: int);"#,
       }],
       ZERO,
       heap,
-      r#"let _t10: int = (init_i: int) * 3;
-let _t12: int = (init_i: int) * 3;
-let _t13: int = (_t12: int) + (a: int);
+      r#"let _t10 = (init_i: int) * 3;
+let _t12 = (init_i: int) * 3;
+let _t13 = (_t12: int) + (a: int);
 let i: int = (init_i: int);
 let j: int = (_t13: int);
 while (true) {
-  let _t16: bool = (L: int) <= (i: int);
-  if (_t16: bool) {
+  let _t16 = (L: int) <= (i: int);
+  if (_t16: int) {
     undefined = 0;
     break;
   }
   f((j: int));
-  let _t14: int = (i: int) + 2;
-  let _t15: int = (j: int) + 6;
+  let _t14 = (i: int) + 2;
+  let _t15 = (j: int) + 6;
   i = (_t14: int);
   j = (_t15: int);
 }

--- a/crates/samlang-core/src/optimization/loop_strength_reduction.rs
+++ b/crates/samlang-core/src/optimization/loop_strength_reduction.rs
@@ -155,7 +155,7 @@ mod tests {
     );
 
     assert_eq!(
-      "let _t8: int = (a: int) * 1;\nlet _t9: int = (_t8: int) + (b: int);",
+      "let _t8 = (a: int) * 1;\nlet _t9 = (_t8: int) + (b: int);",
       prefix_statements.iter().map(|s| s.debug_print(heap)).join("\n")
     );
     assert_eq!(

--- a/crates/samlang-core/src/optimization/unused_name_elimination.rs
+++ b/crates/samlang-core/src/optimization/unused_name_elimination.rs
@@ -20,7 +20,7 @@ fn collect_used_names_from_expression(
   expression: &Expression,
 ) {
   match expression {
-    Expression::IntLiteral(_, _) => {}
+    Expression::IntLiteral(_) => {}
     Expression::Variable(v) => {
       collect_for_type_set(&v.type_, type_set);
     }
@@ -36,10 +36,9 @@ fn collect_used_names_from_statement(
   statement: &Statement,
 ) {
   match statement {
-    Statement::Binary(Binary { name: _, type_, operator: _, e1, e2 }) => {
+    Statement::Binary(Binary { name: _, operator: _, e1, e2 }) => {
       collect_used_names_from_expression(name_set, type_set, e1);
       collect_used_names_from_expression(name_set, type_set, e2);
-      collect_for_type_set(type_, type_set);
     }
     Statement::IndexedAccess { name: _, type_, pointer_expression, index: _ } => {
       collect_used_names_from_expression(name_set, type_set, pointer_expression);

--- a/crates/samlang-wasm/test-samlang-wasm.mjs
+++ b/crates/samlang-wasm/test-samlang-wasm.mjs
@@ -15,14 +15,14 @@ assertEqual(
   tsCode,
   `type Str = [number, string];
 const __Builtins$stringConcat = ([, a]: Str, [, b]: Str): Str => [1, a + b];
-const __Builtins$println = ([, line]: Str): number => { console.log(line); return 0; };
-const __Builtins$stringToInt = ([, v]: Str): number => parseInt(v, 10);
-const __Builtins$intToString = (v: number): Str => [1, String(v)];
-const __Builtins$panic = ([, v]: Str): number => { throw Error(v); };
+const __Builtins$println = (_: number, [, line]: Str): number => { console.log(line); return 0; };
+const __Builtins$stringToInt = (_: number, [, v]: Str): number => parseInt(v, 10);
+const __Builtins$intToString = (_: number, v: number): Str => [1, String(v)];
+const __Builtins$panic = (_: number, [, v]: Str): number => { throw Error(v); };
 const _builtin_free = (v: any): number => { v.length = 0; return 0 };
 const GLOBAL_STRING_7: Str = [0, \`Hi\`];
 function _Demo_Main$main(): number {
-  __Builtins$println(GLOBAL_STRING_7);
+  __Builtins$println(0, GLOBAL_STRING_7);
   return 0;
 }
 


### PR DESCRIPTION
[ast] Get rid of bool type in IR

It was added for LLVM IR, but since targeting LLVM IR is no longer a goal, we can kill it and make code simpler.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1001).
* #1004
* #1003
* #1002
* __->__ #1001