### PR TITLE
[refactor] Cleanup HIR primitive type

### DIFF
--- a/crates/samlang-core/src/ast/hir.rs
+++ b/crates/samlang-core/src/ast/hir.rs
@@ -6,19 +6,6 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use std::{cmp::Ordering, hash::Hash};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum PrimitiveType {
-  Int,
-}
-
-impl ToString for PrimitiveType {
-  fn to_string(&self) -> String {
-    match self {
-      PrimitiveType::Int => "int".to_string(),
-    }
-  }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct IdType {
   pub(crate) name: PStr,
@@ -57,7 +44,7 @@ impl FunctionType {
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumAsInner)]
 pub(crate) enum Type {
-  Primitive(PrimitiveType),
+  Int,
   Id(IdType),
 }
 
@@ -84,13 +71,13 @@ impl Type {
 
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     match self {
-      Type::Primitive(t) => t.to_string(),
+      Type::Int => "int".to_string(),
       Type::Id(id) => id.pretty_print(heap),
     }
   }
 }
 
-pub(crate) const INT_TYPE: Type = Type::Primitive(PrimitiveType::Int);
+pub(crate) const INT_TYPE: Type = Type::Int;
 pub(crate) const STRING_TYPE: Type = Type::new_id_no_targs(well_known_pstrs::UNDERSCORE_STR);
 pub(crate) const STRING_TYPE_REF: &Type = &Type::new_id_no_targs(well_known_pstrs::UNDERSCORE_STR);
 

--- a/crates/samlang-core/src/ast/hir_tests.rs
+++ b/crates/samlang-core/src/ast/hir_tests.rs
@@ -34,11 +34,6 @@ mod tests {
     assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a"))).is_empty());
     assert!(!format!("{:?}", Operator::GE).is_empty());
     assert!(!format!("{:?}", ZERO.type_()).is_empty());
-    assert!(!format!(
-      "{:?}",
-      Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).type_().as_primitive()
-    )
-    .is_empty());
     assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a")).type_().as_id())
       .is_empty());
     assert!(!GenenalLoopVariable {
@@ -50,8 +45,6 @@ mod tests {
     .pretty_print(heap)
     .is_empty());
     assert!(!format!("{:?}", Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE)).is_empty());
-    assert!(PrimitiveType::Int.eq(&PrimitiveType::Int));
-    assert_eq!(PrimitiveType::Int, PrimitiveType::Int);
     Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).convert_to_callee();
     Expression::StringName(heap.alloc_str_for_test("")).convert_to_callee();
     ZERO.convert_to_callee();

--- a/crates/samlang-core/src/compiler/hir_generics_specialization.rs
+++ b/crates/samlang-core/src/compiler/hir_generics_specialization.rs
@@ -251,7 +251,7 @@ impl Rewriter {
     generics_replacement_map: &HashMap<PStr, Type>,
   ) -> Type {
     match type_ {
-      Type::Primitive(kind) => Type::Primitive(*kind),
+      Type::Int => Type::Int,
       Type::Id(id) => self.rewrite_id_type(heap, id, generics_replacement_map),
     }
   }

--- a/crates/samlang-core/src/compiler/hir_type_deduplication.rs
+++ b/crates/samlang-core/src/compiler/hir_type_deduplication.rs
@@ -18,7 +18,7 @@ fn rewrite_id_type(state: &State, id: IdType) -> IdType {
 
 fn rewrite_type(state: &State, type_: Type) -> Type {
   match type_ {
-    Type::Primitive(k) => Type::Primitive(k),
+    Type::Int => Type::Int,
     Type::Id(id) => Type::Id(rewrite_id_type(state, id)),
   }
 }

--- a/crates/samlang-core/src/compiler/mir_lowering.rs
+++ b/crates/samlang-core/src/compiler/mir_lowering.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashSet};
 
 fn lower_type(type_: hir::Type) -> mir::Type {
   match type_ {
-    hir::Type::Primitive(hir::PrimitiveType::Int) => mir::Type::Primitive(mir::PrimitiveType::Int),
+    hir::Type::Int => mir::Type::Primitive(mir::PrimitiveType::Int),
     hir::Type::Id(hir::IdType { name, type_arguments }) => {
       assert!(type_arguments.is_empty());
       mir::Type::Id(name)


### PR DESCRIPTION
[refactor] Cleanup HIR primitive type


An enum is no longer needed.
