### PR TITLE
[ast] Introduce HIR and optimize optimizer perf

### DIFF
--- a/crates/samlang-core/src/ast.rs
+++ b/crates/samlang-core/src/ast.rs
@@ -5,6 +5,8 @@ pub use loc::{Location, Position};
 mod reason;
 pub(crate) use reason::Reason;
 
+pub(crate) mod hir;
+mod hir_tests;
 pub(crate) mod lir;
 mod lir_tests;
 pub(crate) mod mir;

--- a/crates/samlang-core/src/ast/lir.rs
+++ b/crates/samlang-core/src/ast/lir.rs
@@ -1,6 +1,6 @@
 use super::{
   common_names,
-  mir::{GlobalVariable, Operator},
+  hir::{GlobalVariable, Operator},
 };
 use crate::common::{well_known_pstrs, Heap, PStr};
 use enum_as_inner::EnumAsInner;

--- a/crates/samlang-core/src/ast/lir_tests.rs
+++ b/crates/samlang-core/src/ast/lir_tests.rs
@@ -4,7 +4,7 @@ mod tests {
   use crate::{
     ast::{
       common_names,
-      mir::{GlobalVariable, Operator},
+      hir::{GlobalVariable, Operator},
     },
     Heap,
   };

--- a/crates/samlang-core/src/ast/wasm.rs
+++ b/crates/samlang-core/src/ast/wasm.rs
@@ -1,4 +1,4 @@
-use super::mir;
+use super::hir;
 use crate::common::{byte_vec_to_data_string, Heap, PStr};
 use itertools::Itertools;
 
@@ -7,7 +7,7 @@ pub(crate) enum InlineInstruction {
   Drop(Box<InlineInstruction>),
   LocalGet(PStr),
   LocalSet(PStr, Box<InlineInstruction>),
-  Binary(Box<InlineInstruction>, mir::Operator, Box<InlineInstruction>),
+  Binary(Box<InlineInstruction>, hir::Operator, Box<InlineInstruction>),
   Load {
     index: usize,
     pointer: Box<InlineInstruction>,
@@ -52,22 +52,22 @@ impl InlineInstruction {
       }
       InlineInstruction::Binary(v1, op, v2) => {
         let op_s = match op {
-          mir::Operator::MUL => "mul",
-          mir::Operator::DIV => "div_s",
-          mir::Operator::MOD => "rem_s",
-          mir::Operator::PLUS => "add",
-          mir::Operator::MINUS => "sub",
-          mir::Operator::LAND => "and",
-          mir::Operator::LOR => "or",
-          mir::Operator::SHL => "shl",
-          mir::Operator::SHR => "shr_u",
-          mir::Operator::XOR => "xor",
-          mir::Operator::LT => "lt_s",
-          mir::Operator::LE => "le_s",
-          mir::Operator::GT => "gt_s",
-          mir::Operator::GE => "ge_s",
-          mir::Operator::EQ => "eq",
-          mir::Operator::NE => "ne",
+          hir::Operator::MUL => "mul",
+          hir::Operator::DIV => "div_s",
+          hir::Operator::MOD => "rem_s",
+          hir::Operator::PLUS => "add",
+          hir::Operator::MINUS => "sub",
+          hir::Operator::LAND => "and",
+          hir::Operator::LOR => "or",
+          hir::Operator::SHL => "shl",
+          hir::Operator::SHR => "shr_u",
+          hir::Operator::XOR => "xor",
+          hir::Operator::LT => "lt_s",
+          hir::Operator::LE => "le_s",
+          hir::Operator::GT => "gt_s",
+          hir::Operator::GE => "ge_s",
+          hir::Operator::EQ => "eq",
+          hir::Operator::NE => "ne",
         };
         string_builder.push_str("(i32.");
         string_builder.push_str(op_s);

--- a/crates/samlang-core/src/ast/wasm_tests.rs
+++ b/crates/samlang-core/src/ast/wasm_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
   use super::super::wasm::*;
-  use crate::{ast::mir::Operator, common::Heap};
+  use crate::{ast::hir::Operator, common::Heap};
   use pretty_assertions::assert_eq;
 
   #[test]

--- a/crates/samlang-core/src/common.rs
+++ b/crates/samlang-core/src/common.rs
@@ -589,6 +589,16 @@ impl<K: Clone + Eq + Hash, V: Clone> LocalStackedContext<K, V> {
   }
 }
 
+/// Forked from https://github.com/Sgeo/take_mut/blob/master/src/lib.rs
+/// Assuming no panic
+pub(crate) fn take_mut<T, F: FnOnce(T) -> T>(mut_ref: &mut T, closure: F) {
+  unsafe {
+    let old_t = std::ptr::read(mut_ref);
+    let new_t = closure(old_t);
+    std::ptr::write(mut_ref, new_t);
+  }
+}
+
 #[cfg(test)]
 mod tests {
   use super::{
@@ -821,5 +831,30 @@ mod tests {
     context.get(&rcs("a"));
     context.get(&rcs("b"));
     context.get(&rcs("d"));
+  }
+
+  #[test]
+  fn take_mut_tests() {
+    #[derive(PartialEq, Eq, Debug)]
+    enum Foo {
+      A,
+      B,
+    }
+    assert_eq!("A", format!("{:?}", Foo::A));
+    assert_eq!("B", format!("{:?}", Foo::B));
+    impl Drop for Foo {
+      fn drop(&mut self) {
+        match *self {
+          Foo::A => println!("Foo::A dropped"),
+          Foo::B => println!("Foo::B dropped"),
+        }
+      }
+    }
+    let mut foo = Foo::A;
+    super::take_mut(&mut foo, |f| {
+      drop(f);
+      Foo::B
+    });
+    assert_eq!(&foo, &Foo::B);
   }
 }

--- a/crates/samlang-core/src/compiler.rs
+++ b/crates/samlang-core/src/compiler.rs
@@ -1,20 +1,20 @@
 mod hir_generics_specialization;
 mod hir_lowering;
 mod hir_string_manager;
+mod hir_type_conversion;
 mod lir_lowering;
 mod lir_unused_name_elimination;
 mod mir_constant_param_elimination;
 mod mir_tail_recursion_rewrite;
-mod mir_type_conversion;
 mod mir_type_deduplication;
 mod wasm_lowering;
 
 #[allow(unused_imports)]
-pub(crate) use hir_lowering::compile_sources_to_hir;
+pub(crate) use hir_lowering::compile_sources_to_mir;
 #[allow(unused_imports)]
-pub(crate) use lir_lowering::compile_hir_to_mir;
+pub(crate) use lir_lowering::compile_mir_to_lir;
 
-pub(crate) fn compile_mir_to_wasm(
+pub(crate) fn compile_lir_to_wasm(
   heap: &mut crate::common::Heap,
   sources: &crate::ast::lir::Sources,
 ) -> (String, Vec<u8>) {

--- a/crates/samlang-core/src/compiler/hir_generics_specialization.rs
+++ b/crates/samlang-core/src/compiler/hir_generics_specialization.rs
@@ -1,45 +1,47 @@
-use super::mir_type_conversion::{
+use super::hir_type_conversion::{
   encode_name_after_generics_specialization, fn_type_application, solve_type_arguments,
   type_application,
 };
 use crate::{
-  ast::mir::{
-    Binary, Callee, ClosureTypeDefinition, Expression, Function, FunctionName, FunctionType,
-    IdType, Sources, Statement, Type, TypeDefinition, TypeDefinitionMappings, VariableName,
-  },
+  ast::{hir, mir},
   common::{Heap, PStr},
 };
 use itertools::Itertools;
 use std::{
   collections::{BTreeMap, HashMap, HashSet},
   fmt::Debug,
-  rc::Rc,
 };
 
 struct Rewriter {
-  original_closure_defs: HashMap<PStr, Rc<ClosureTypeDefinition>>,
-  original_type_defs: HashMap<PStr, Rc<TypeDefinition>>,
-  original_functions: HashMap<PStr, Rc<Function>>,
+  original_closure_defs: HashMap<PStr, hir::ClosureTypeDefinition>,
+  original_type_defs: HashMap<PStr, hir::TypeDefinition>,
+  original_functions: HashMap<PStr, hir::Function>,
   used_string_names: HashSet<PStr>,
   specialized_id_type_mappings: HashMap<PStr, PStr>,
-  specialized_closure_definitions: BTreeMap<PStr, Rc<ClosureTypeDefinition>>,
-  specialized_type_definitions: BTreeMap<PStr, Rc<TypeDefinition>>,
-  specialized_functions: BTreeMap<PStr, Rc<Function>>,
+  specialized_closure_definitions: BTreeMap<PStr, Option<mir::ClosureTypeDefinition>>,
+  specialized_type_definitions: BTreeMap<PStr, Option<mir::TypeDefinition>>,
+  specialized_functions: BTreeMap<PStr, Option<mir::Function>>,
+}
+
+fn mir_to_hir_type(t: &mir::Type) -> hir::Type {
+  match t {
+    mir::Type::Int => hir::Type::Int,
+    mir::Type::Id(name) => hir::Type::Id(hir::IdType { name: *name, type_arguments: vec![] }),
+  }
 }
 
 impl Rewriter {
   fn rewrite_function(
     &mut self,
     heap: &mut Heap,
-    Function { name: _, parameters, type_parameters: _, type_: _, body, return_value }: &Function,
+    hir::Function { name: _, parameters, type_parameters: _, type_: _, body, return_value }: &hir::Function,
     new_name: PStr,
-    new_type: FunctionType,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Function {
-    Function {
+    new_type: mir::FunctionType,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::Function {
+    mir::Function {
       name: new_name,
       parameters: parameters.clone(),
-      type_parameters: vec![],
       type_: new_type,
       body: self.rewrite_stmts(heap, body, generics_replacement_map),
       return_value: self.rewrite_expr(heap, return_value, generics_replacement_map),
@@ -49,48 +51,54 @@ impl Rewriter {
   fn rewrite_stmts(
     &mut self,
     heap: &mut Heap,
-    stmts: &[Statement],
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Vec<Statement> {
+    stmts: &[hir::Statement],
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> Vec<mir::Statement> {
     stmts.iter().map(|stmt| self.rewrite_stmt(heap, stmt, generics_replacement_map)).collect_vec()
   }
 
   fn rewrite_stmt(
     &mut self,
     heap: &mut Heap,
-    stmt: &Statement,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Statement {
+    stmt: &hir::Statement,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::Statement {
     match stmt {
-      Statement::Binary(Binary { name, operator, e1, e2 }) => Statement::Binary(Binary {
-        name: *name,
-        operator: *operator,
-        e1: self.rewrite_expr(heap, e1, generics_replacement_map),
-        e2: self.rewrite_expr(heap, e2, generics_replacement_map),
-      }),
-      Statement::IndexedAccess { name, type_, pointer_expression, index } => {
-        Statement::IndexedAccess {
+      hir::Statement::Binary(hir::Binary { name, operator, e1, e2 }) => {
+        mir::Statement::Binary(mir::Binary {
+          name: *name,
+          operator: *operator,
+          e1: self.rewrite_expr(heap, e1, generics_replacement_map),
+          e2: self.rewrite_expr(heap, e2, generics_replacement_map),
+        })
+      }
+      hir::Statement::IndexedAccess { name, type_, pointer_expression, index } => {
+        mir::Statement::IndexedAccess {
           name: *name,
           type_: self.rewrite_type(heap, type_, generics_replacement_map),
           pointer_expression: self.rewrite_expr(heap, pointer_expression, generics_replacement_map),
           index: *index,
         }
       }
-      Statement::Call { callee, arguments, return_type, return_collector } => Statement::Call {
-        callee: match callee {
-          Callee::FunctionName(fn_name) => {
-            Callee::FunctionName(self.rewrite_fn_name_expr(heap, fn_name, generics_replacement_map))
-          }
-          Callee::Variable(VariableName { name, type_ }) => Callee::Variable(VariableName {
-            name: *name,
-            type_: self.rewrite_type(heap, type_, generics_replacement_map),
-          }),
-        },
-        arguments: self.rewrite_expressions(heap, arguments, generics_replacement_map),
-        return_type: self.rewrite_type(heap, return_type, generics_replacement_map),
-        return_collector: *return_collector,
-      },
-      Statement::IfElse { condition, s1, s2, final_assignments } => Statement::IfElse {
+      hir::Statement::Call { callee, arguments, return_type, return_collector } => {
+        mir::Statement::Call {
+          callee: match callee {
+            hir::Callee::FunctionName(fn_name) => mir::Callee::FunctionName(
+              self.rewrite_fn_name_expr(heap, fn_name, generics_replacement_map),
+            ),
+            hir::Callee::Variable(hir::VariableName { name, type_ }) => {
+              mir::Callee::Variable(mir::VariableName {
+                name: *name,
+                type_: self.rewrite_type(heap, type_, generics_replacement_map),
+              })
+            }
+          },
+          arguments: self.rewrite_expressions(heap, arguments, generics_replacement_map),
+          return_type: self.rewrite_type(heap, return_type, generics_replacement_map),
+          return_collector: *return_collector,
+        }
+      }
+      hir::Statement::IfElse { condition, s1, s2, final_assignments } => mir::Statement::IfElse {
         condition: self.rewrite_expr(heap, condition, generics_replacement_map),
         s1: self.rewrite_stmts(heap, s1, generics_replacement_map),
         s2: self.rewrite_stmts(heap, s2, generics_replacement_map),
@@ -106,25 +114,26 @@ impl Rewriter {
           })
           .collect_vec(),
       },
-      Statement::SingleIf { .. } => {
+      hir::Statement::SingleIf { .. } => {
         panic!("SingleIf should not appear before tailrec optimization.")
       }
-      Statement::Break(_) => {
+      hir::Statement::Break(_) => {
         panic!("Break should not appear before tailrec optimization.")
       }
-      Statement::While { .. } => {
+      hir::Statement::While { .. } => {
         panic!("While should not appear before tailrec optimization.")
       }
-      Statement::Cast { name, type_, assigned_expression } => Statement::Cast {
+      hir::Statement::Cast { name, type_, assigned_expression } => mir::Statement::Cast {
         name: *name,
         type_: self.rewrite_type(heap, type_, generics_replacement_map),
         assigned_expression: self.rewrite_expr(heap, assigned_expression, generics_replacement_map),
       },
-      Statement::StructInit { struct_variable_name, type_, expression_list } => {
-        let type_ = self.rewrite_id_type(heap, type_, generics_replacement_map).into_id().unwrap();
-        Statement::StructInit {
+      hir::Statement::StructInit { struct_variable_name, type_, expression_list } => {
+        let type_name =
+          self.rewrite_id_type(heap, type_, generics_replacement_map).into_id().unwrap();
+        mir::Statement::StructInit {
           struct_variable_name: *struct_variable_name,
-          type_,
+          type_name,
           expression_list: self.rewrite_expressions(
             heap,
             expression_list,
@@ -132,12 +141,17 @@ impl Rewriter {
           ),
         }
       }
-      Statement::ClosureInit { closure_variable_name, closure_type, function_name, context } => {
-        let closure_type =
+      hir::Statement::ClosureInit {
+        closure_variable_name,
+        closure_type,
+        function_name,
+        context,
+      } => {
+        let closure_type_name =
           self.rewrite_id_type(heap, closure_type, generics_replacement_map).into_id().unwrap();
-        Statement::ClosureInit {
+        mir::Statement::ClosureInit {
           closure_variable_name: *closure_variable_name,
-          closure_type,
+          closure_type_name,
           function_name: self.rewrite_fn_name_expr(heap, function_name, generics_replacement_map),
           context: self.rewrite_expr(heap, context, generics_replacement_map),
         }
@@ -148,51 +162,53 @@ impl Rewriter {
   fn rewrite_expressions(
     &mut self,
     heap: &mut Heap,
-    expressions: &[Expression],
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Vec<Expression> {
+    expressions: &[hir::Expression],
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> Vec<mir::Expression> {
     expressions.iter().map(|e| self.rewrite_expr(heap, e, generics_replacement_map)).collect_vec()
   }
 
   fn rewrite_expr(
     &mut self,
     heap: &mut Heap,
-    expression: &Expression,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Expression {
+    expression: &hir::Expression,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::Expression {
     match expression {
-      Expression::IntLiteral(i) => Expression::IntLiteral(*i),
-      Expression::StringName(s) => {
+      hir::Expression::IntLiteral(i) => mir::Expression::IntLiteral(*i),
+      hir::Expression::StringName(s) => {
         self.used_string_names.insert(*s);
-        Expression::StringName(*s)
+        mir::Expression::StringName(*s)
       }
-      Expression::Variable(VariableName { name, type_ }) => Expression::Variable(VariableName {
-        name: *name,
-        type_: self.rewrite_type(heap, type_, generics_replacement_map),
-      }),
+      hir::Expression::Variable(hir::VariableName { name, type_ }) => {
+        mir::Expression::Variable(mir::VariableName {
+          name: *name,
+          type_: self.rewrite_type(heap, type_, generics_replacement_map),
+        })
+      }
     }
   }
 
   fn rewrite_fn_name_expr(
     &mut self,
     heap: &mut Heap,
-    FunctionName { name, type_, type_arguments }: &FunctionName,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> FunctionName {
+    hir::FunctionName { name, type_, type_arguments }: &hir::FunctionName,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::FunctionName {
     let fn_type = self.rewrite_fn_type(heap, type_, generics_replacement_map);
     let rewritten_targs = self.rewrite_types(heap, type_arguments, generics_replacement_map);
     let rewritten_name =
       self.rewrite_fn_name(heap, *name, fn_type.clone(), rewritten_targs, generics_replacement_map);
-    FunctionName { name: rewritten_name, type_: fn_type, type_arguments: vec![] }
+    mir::FunctionName { name: rewritten_name, type_: fn_type }
   }
 
   fn rewrite_fn_name(
     &mut self,
     heap: &mut Heap,
     original_name: PStr,
-    function_type: FunctionType,
-    function_type_arguments: Vec<Type>,
-    generics_replacement_map: &HashMap<PStr, Type>,
+    function_type: mir::FunctionType,
+    function_type_arguments: Vec<mir::Type>,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
   ) -> PStr {
     if original_name.as_str(heap).starts_with("$GENERICS$_") {
       let to_be_splitted =
@@ -203,7 +219,7 @@ impl Rewriter {
       let replacement_class =
         generics_replacement_map.get(&generic_class_name).unwrap().as_id().unwrap();
       let replacement_class_type =
-        self.specialized_id_type_mappings.get(&replacement_class.name).unwrap();
+        self.specialized_id_type_mappings.get(replacement_class).unwrap();
       let rewritten_fn_name =
         heap.alloc_string(format!("_{}${}", replacement_class_type.as_str(heap), fn_name));
       return self.rewrite_fn_name(
@@ -215,11 +231,14 @@ impl Rewriter {
       );
     }
     if let Some(existing_fn) = self.original_functions.get(&original_name).cloned() {
-      let encoded_specialized_fn_name = heap.alloc_string(
-        encode_name_after_generics_specialization(heap, original_name, &function_type_arguments),
-      );
+      let encoded_specialized_fn_name =
+        heap.alloc_string(encode_name_after_generics_specialization(
+          heap,
+          original_name,
+          &function_type_arguments.iter().map(mir_to_hir_type).collect_vec(),
+        ));
       if !self.specialized_functions.contains_key(&encoded_specialized_fn_name) {
-        self.specialized_functions.insert(encoded_specialized_fn_name, existing_fn.clone());
+        self.specialized_functions.insert(encoded_specialized_fn_name, None);
         let rewritten_fn = self.rewrite_function(
           heap,
           &existing_fn,
@@ -227,7 +246,7 @@ impl Rewriter {
           function_type,
           &existing_fn.type_parameters.iter().cloned().zip(function_type_arguments).collect(),
         );
-        self.specialized_functions.insert(encoded_specialized_fn_name, Rc::new(rewritten_fn));
+        self.specialized_functions.insert(encoded_specialized_fn_name, Some(rewritten_fn));
       }
       encoded_specialized_fn_name
     } else {
@@ -238,67 +257,69 @@ impl Rewriter {
   fn rewrite_types(
     &mut self,
     heap: &mut Heap,
-    types: &[Type],
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Vec<Type> {
+    types: &[hir::Type],
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> Vec<mir::Type> {
     types.iter().map(|t| self.rewrite_type(heap, t, generics_replacement_map)).collect_vec()
   }
 
   fn rewrite_type(
     &mut self,
     heap: &mut Heap,
-    type_: &Type,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Type {
+    type_: &hir::Type,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::Type {
     match type_ {
-      Type::Int => Type::Int,
-      Type::Id(id) => self.rewrite_id_type(heap, id, generics_replacement_map),
+      hir::Type::Int => mir::Type::Int,
+      hir::Type::Id(id) => self.rewrite_id_type(heap, id, generics_replacement_map),
     }
   }
 
   fn rewrite_id_type(
     &mut self,
     heap: &mut Heap,
-    id_type: &IdType,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> Type {
+    id_type: &hir::IdType,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::Type {
     if id_type.type_arguments.is_empty() {
       if let Some(replacement) = generics_replacement_map.get(&id_type.name) {
-        return replacement.clone();
+        return *replacement;
       }
     }
-    let concrete_type = IdType {
-      name: id_type.name,
-      type_arguments: self.rewrite_types(heap, &id_type.type_arguments, generics_replacement_map),
-    };
+    let concrete_type_hir_targs = id_type
+      .type_arguments
+      .iter()
+      .map(|t| mir_to_hir_type(&self.rewrite_type(heap, t, generics_replacement_map)))
+      .collect_vec();
+    let concrete_type = hir::IdType { name: id_type.name, type_arguments: concrete_type_hir_targs };
     let encoded_name = heap.alloc_string(encode_name_after_generics_specialization(
       heap,
-      concrete_type.name,
+      id_type.name,
       &concrete_type.type_arguments,
     ));
     if self.specialized_type_definitions.get(&encoded_name).is_none() {
       if let Some(type_def) = self.original_type_defs.get(&concrete_type.name).cloned() {
-        let solved_targs_replacement_map: HashMap<PStr, Type> = type_def
+        let solved_targs_replacement_map: HashMap<PStr, hir::Type> = type_def
           .type_parameters
           .iter()
           .cloned()
           .zip(solve_type_arguments(
             &type_def.type_parameters,
             &concrete_type,
-            &IdType {
+            &hir::IdType {
               name: concrete_type.name,
               type_arguments: type_def
                 .type_parameters
                 .iter()
                 .cloned()
-                .map(Type::new_id_no_targs)
+                .map(hir::Type::new_id_no_targs)
                 .collect_vec(),
             },
           ))
           .collect();
-        self.specialized_type_definitions.insert(encoded_name, type_def.clone());
+        self.specialized_type_definitions.insert(encoded_name, None);
         let rewritten_mappings = match &type_def.mappings {
-          TypeDefinitionMappings::Struct(types) => TypeDefinitionMappings::Struct(
+          hir::TypeDefinitionMappings::Struct(types) => mir::TypeDefinitionMappings::Struct(
             types
               .iter()
               .map(|it| {
@@ -310,14 +331,13 @@ impl Rewriter {
               })
               .collect_vec(),
           ),
-          TypeDefinitionMappings::Enum => TypeDefinitionMappings::Enum,
+          hir::TypeDefinitionMappings::Enum => mir::TypeDefinitionMappings::Enum,
         };
         self.specialized_type_definitions.insert(
           encoded_name,
-          Rc::new(TypeDefinition {
+          Some(mir::TypeDefinition {
             identifier: encoded_name,
-            type_parameters: vec![],
-            names: type_def.names.clone(),
+            names: type_def.names,
             mappings: rewritten_mappings,
           }),
         );
@@ -327,25 +347,25 @@ impl Rewriter {
           .get(&concrete_type.name)
           .cloned()
           .expect(&format!("Missing {}", concrete_type.name.as_str(heap)));
-        let solved_targs_replacement_map: HashMap<PStr, Type> = closure_def
+        let solved_targs_replacement_map: HashMap<PStr, hir::Type> = closure_def
           .type_parameters
           .iter()
           .cloned()
           .zip(solve_type_arguments(
             &closure_def.type_parameters,
             &concrete_type,
-            &IdType {
+            &hir::IdType {
               name: concrete_type.name,
               type_arguments: closure_def
                 .type_parameters
                 .iter()
                 .cloned()
-                .map(Type::new_id_no_targs)
+                .map(hir::Type::new_id_no_targs)
                 .collect_vec(),
             },
           ))
           .collect();
-        self.specialized_closure_definitions.insert(encoded_name, closure_def.clone());
+        self.specialized_closure_definitions.insert(encoded_name, None);
         let rewritten_fn_type = self.rewrite_fn_type(
           heap,
           &fn_type_application(&closure_def.function_type, &solved_targs_replacement_map),
@@ -353,65 +373,72 @@ impl Rewriter {
         );
         self.specialized_closure_definitions.insert(
           encoded_name,
-          Rc::new(ClosureTypeDefinition {
+          Some(mir::ClosureTypeDefinition {
             identifier: encoded_name,
-            type_parameters: vec![],
             function_type: rewritten_fn_type,
           }),
         );
       }
     }
     self.specialized_id_type_mappings.insert(encoded_name, concrete_type.name);
-    Type::new_id_no_targs(encoded_name)
+    mir::Type::Id(encoded_name)
   }
 
   fn rewrite_fn_type(
     &mut self,
     heap: &mut Heap,
-    FunctionType { argument_types, return_type }: &FunctionType,
-    generics_replacement_map: &HashMap<PStr, Type>,
-  ) -> FunctionType {
-    FunctionType {
+    hir::FunctionType { argument_types, return_type }: &hir::FunctionType,
+    generics_replacement_map: &HashMap<PStr, mir::Type>,
+  ) -> mir::FunctionType {
+    mir::FunctionType {
       argument_types: self.rewrite_types(heap, argument_types, generics_replacement_map),
       return_type: Box::new(self.rewrite_type(heap, return_type, generics_replacement_map)),
     }
   }
 }
 
-fn rc_valued_bmap_into_vec<K, T: Debug>(map: BTreeMap<K, Rc<T>>) -> Vec<T> {
-  map.into_values().map(|v| Rc::try_unwrap(v).unwrap()).collect_vec()
+fn option_valued_bmap_into_vec<K, T: Debug>(map: BTreeMap<K, Option<T>>) -> Vec<T> {
+  map.into_values().map(|v| v.unwrap()).collect_vec()
 }
 
 pub(super) fn perform_generics_specialization(
   heap: &mut Heap,
-  Sources { global_variables, closure_types, type_definitions, main_function_names, functions }: Sources,
-) -> Sources {
+  hir::Sources {
+    global_variables,
+    closure_types,
+    type_definitions,
+    main_function_names,
+    functions,
+  }: hir::Sources,
+) -> mir::Sources {
   let mut rewriter = Rewriter {
-    original_closure_defs: closure_types
-      .into_iter()
-      .map(|it| (it.identifier, Rc::new(it)))
-      .collect(),
-    original_type_defs: type_definitions
-      .into_iter()
-      .map(|it| (it.identifier, Rc::new(it)))
-      .collect(),
-    original_functions: functions.into_iter().map(|it| (it.name, Rc::new(it))).collect(),
+    original_closure_defs: closure_types.into_iter().map(|it| (it.identifier, it)).collect(),
+    original_type_defs: type_definitions.into_iter().map(|it| (it.identifier, it)).collect(),
+    original_functions: functions.into_iter().map(|it| (it.name, it)).collect(),
     used_string_names: HashSet::new(),
     specialized_id_type_mappings: HashMap::new(),
     specialized_closure_definitions: BTreeMap::new(),
     specialized_type_definitions: BTreeMap::new(),
     specialized_functions: BTreeMap::new(),
   };
+  let empty_replacement_map = HashMap::new();
   for main_fn_name in &main_function_names {
     let original_fn = rewriter.original_functions.get(main_fn_name).cloned().unwrap();
-    let rewritten = rewriter.rewrite_function(
-      heap,
-      &original_fn,
-      *main_fn_name,
-      original_fn.type_.clone(),
-      &HashMap::new(),
-    );
-    rewriter.specialized_functions.insert(*main_fn_name, Rc::new(rewritten));
+    let fn_type = mir::FunctionType {
+      argument_types: rewriter.rewrite_types(
+        heap,
+        &original_fn.type_.argument_types,
+        &empty_replacement_map,
+      ),
+      return_type: Box::new(rewriter.rewrite_type(
+        heap,
+        &original_fn.type_.return_type,
+        &empty_replacement_map,
+      )),
+    };
+    let rewritten =
+      rewriter.rewrite_function(heap, &original_fn, *main_fn_name, fn_type, &HashMap::new());
+    rewriter.specialized_functions.insert(*main_fn_name, Some(rewritten));
   }
   let Rewriter {
     used_string_names,
@@ -420,15 +447,15 @@ pub(super) fn perform_generics_specialization(
     specialized_functions,
     ..
   } = rewriter;
-  Sources {
+  mir::Sources {
     global_variables: global_variables
       .into_iter()
       .filter(|it| used_string_names.contains(&it.name))
       .collect(),
-    closure_types: rc_valued_bmap_into_vec(specialized_closure_definitions),
-    type_definitions: rc_valued_bmap_into_vec(specialized_type_definitions),
+    closure_types: option_valued_bmap_into_vec(specialized_closure_definitions),
+    type_definitions: option_valued_bmap_into_vec(specialized_type_definitions),
     main_function_names,
-    functions: rc_valued_bmap_into_vec(specialized_functions),
+    functions: option_valued_bmap_into_vec(specialized_functions),
   }
 }
 
@@ -436,21 +463,19 @@ pub(super) fn perform_generics_specialization(
 mod tests {
   use super::*;
   use crate::{
-    ast::mir::{
-      GlobalVariable, Operator, TypeDefinitionMappings, INT_TYPE, ONE, STRING_TYPE, ZERO,
-    },
+    ast::hir::{GlobalVariable, Operator},
     common::well_known_pstrs,
   };
   use pretty_assertions::assert_eq;
 
-  fn assert_specialized(sources: Sources, heap: &mut Heap, expected: &str) {
+  fn assert_specialized(sources: hir::Sources, heap: &mut Heap, expected: &str) {
     assert_eq!(expected.trim(), perform_generics_specialization(heap, sources).debug_print(heap));
   }
 
   #[test]
   fn empty_test() {
     assert_specialized(
-      Sources {
+      hir::Sources {
         global_variables: vec![],
         closure_types: vec![],
         type_definitions: vec![],
@@ -467,27 +492,27 @@ mod tests {
     let heap = &mut Heap::new();
 
     assert_specialized(
-      Sources {
+      hir::Sources {
         global_variables: vec![],
         closure_types: vec![],
         type_definitions: vec![],
         main_function_names: vec![heap.alloc_str_for_test("main")],
         functions: vec![
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("main"),
             parameters: vec![],
             type_parameters: vec![],
-            type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
+            type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("main2"),
             parameters: vec![],
             type_parameters: vec![],
-            type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
+            type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
         ],
       },
@@ -507,34 +532,34 @@ sources.mains = [main]
     let heap = &mut Heap::new();
 
     assert_specialized(
-      Sources {
+      hir::Sources {
         global_variables: vec![GlobalVariable {
           name: heap.alloc_str_for_test("G1"),
           content: heap.alloc_str_for_test(""),
         }],
         closure_types: vec![],
-        type_definitions: vec![TypeDefinition {
+        type_definitions: vec![hir::TypeDefinition {
           identifier: well_known_pstrs::UNDERSCORE_STR,
           type_parameters: vec![],
           names: vec![],
-          mappings: TypeDefinitionMappings::Enum,
+          mappings: hir::TypeDefinitionMappings::Enum,
         }],
         main_function_names: vec![heap.alloc_str_for_test("main")],
-        functions: vec![Function {
+        functions: vec![hir::Function {
           name: heap.alloc_str_for_test("main"),
           parameters: vec![],
           type_parameters: vec![],
-          type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
-          body: vec![Statement::Call {
-            callee: Callee::FunctionName(FunctionName::new(
+          type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
+          body: vec![hir::Statement::Call {
+            callee: hir::Callee::FunctionName(hir::FunctionName::new(
               heap.alloc_str_for_test("__builtins_println"),
-              Type::new_fn_unwrapped(vec![STRING_TYPE], INT_TYPE),
+              hir::Type::new_fn_unwrapped(vec![hir::STRING_TYPE], hir::INT_TYPE),
             )),
-            arguments: vec![Expression::StringName(heap.alloc_str_for_test("G1"))],
-            return_type: INT_TYPE,
+            arguments: vec![hir::Expression::StringName(heap.alloc_str_for_test("G1"))],
+            return_type: hir::INT_TYPE,
             return_collector: None,
           }],
-          return_value: ZERO,
+          return_value: hir::ZERO,
         }],
       },
       heap,
@@ -556,23 +581,23 @@ sources.mains = [main]
   fn panic_test_1() {
     let heap = &mut Heap::new();
 
-    let sources = Sources {
+    let sources = hir::Sources {
       global_variables: vec![],
       closure_types: vec![],
-      type_definitions: vec![TypeDefinition {
+      type_definitions: vec![hir::TypeDefinition {
         identifier: well_known_pstrs::UNDERSCORE_STR,
         type_parameters: vec![],
         names: vec![],
-        mappings: TypeDefinitionMappings::Enum,
+        mappings: hir::TypeDefinitionMappings::Enum,
       }],
       main_function_names: vec![heap.alloc_str_for_test("main")],
-      functions: vec![Function {
+      functions: vec![hir::Function {
         name: heap.alloc_str_for_test("main"),
         parameters: vec![],
         type_parameters: vec![],
-        type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
-        body: vec![Statement::Break(ZERO)],
-        return_value: ZERO,
+        type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
+        body: vec![hir::Statement::Break(hir::ZERO)],
+        return_value: hir::ZERO,
       }],
     };
     perform_generics_specialization(heap, sources);
@@ -583,27 +608,27 @@ sources.mains = [main]
   fn panic_test_2() {
     let heap = &mut Heap::new();
 
-    let sources = Sources {
+    let sources = hir::Sources {
       global_variables: vec![],
       closure_types: vec![],
-      type_definitions: vec![TypeDefinition {
+      type_definitions: vec![hir::TypeDefinition {
         identifier: well_known_pstrs::UNDERSCORE_STR,
         type_parameters: vec![],
         names: vec![],
-        mappings: TypeDefinitionMappings::Enum,
+        mappings: hir::TypeDefinitionMappings::Enum,
       }],
       main_function_names: vec![heap.alloc_str_for_test("main")],
-      functions: vec![Function {
+      functions: vec![hir::Function {
         name: heap.alloc_str_for_test("main"),
         parameters: vec![],
         type_parameters: vec![],
-        type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
-        body: vec![Statement::SingleIf {
-          condition: ZERO,
+        type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
+        body: vec![hir::Statement::SingleIf {
+          condition: hir::ZERO,
           invert_condition: false,
           statements: vec![],
         }],
-        return_value: ZERO,
+        return_value: hir::ZERO,
       }],
     };
     perform_generics_specialization(heap, sources);
@@ -614,27 +639,27 @@ sources.mains = [main]
   fn panic_test_3() {
     let heap = &mut Heap::new();
 
-    let sources = Sources {
+    let sources = hir::Sources {
       global_variables: vec![],
       closure_types: vec![],
-      type_definitions: vec![TypeDefinition {
+      type_definitions: vec![hir::TypeDefinition {
         identifier: well_known_pstrs::UNDERSCORE_STR,
         type_parameters: vec![],
         names: vec![],
-        mappings: TypeDefinitionMappings::Enum,
+        mappings: hir::TypeDefinitionMappings::Enum,
       }],
       main_function_names: vec![heap.alloc_str_for_test("main")],
-      functions: vec![Function {
+      functions: vec![hir::Function {
         name: heap.alloc_str_for_test("main"),
         parameters: vec![],
         type_parameters: vec![],
-        type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
-        body: vec![Statement::While {
+        type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
+        body: vec![hir::Statement::While {
           loop_variables: vec![],
           statements: vec![],
           break_collector: None,
         }],
-        return_value: ZERO,
+        return_value: hir::ZERO,
       }],
     };
     perform_generics_specialization(heap, sources);
@@ -644,15 +669,18 @@ sources.mains = [main]
   fn comprehensive_test() {
     let heap = &mut Heap::new();
 
-    let type_a = Type::new_id_no_targs(heap.alloc_str_for_test("A"));
-    let type_b = Type::new_id_no_targs(heap.alloc_str_for_test("B"));
-    let type_j = Type::new_id_no_targs(heap.alloc_str_for_test("J"));
-    let type_ia = Type::new_id(heap.alloc_str_for_test("I"), vec![type_a.clone(), STRING_TYPE]);
-    let type_ib = Type::new_id(heap.alloc_str_for_test("I"), vec![INT_TYPE, type_b.clone()]);
-    let type_i = Type::new_id(heap.alloc_str_for_test("I"), vec![INT_TYPE, STRING_TYPE]);
-    let g1 = Expression::StringName(heap.alloc_str_for_test("G1"));
+    let type_a = hir::Type::new_id_no_targs(heap.alloc_str_for_test("A"));
+    let type_b = hir::Type::new_id_no_targs(heap.alloc_str_for_test("B"));
+    let type_j = hir::Type::new_id_no_targs(heap.alloc_str_for_test("J"));
+    let type_ia =
+      hir::Type::new_id(heap.alloc_str_for_test("I"), vec![type_a.clone(), hir::STRING_TYPE]);
+    let type_ib =
+      hir::Type::new_id(heap.alloc_str_for_test("I"), vec![hir::INT_TYPE, type_b.clone()]);
+    let type_i =
+      hir::Type::new_id(heap.alloc_str_for_test("I"), vec![hir::INT_TYPE, hir::STRING_TYPE]);
+    let g1 = hir::Expression::StringName(heap.alloc_str_for_test("G1"));
     assert_specialized(
-      Sources {
+      hir::Sources {
         global_variables: vec![
           GlobalVariable {
             name: heap.alloc_str_for_test("G1"),
@@ -663,231 +691,254 @@ sources.mains = [main]
             content: heap.alloc_str_for_test(""),
           },
         ],
-        closure_types: vec![ClosureTypeDefinition {
+        closure_types: vec![hir::ClosureTypeDefinition {
           identifier: heap.alloc_str_for_test("CC"),
           type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
-          function_type: Type::new_fn_unwrapped(vec![type_a.clone()], type_b.clone()),
+          function_type: hir::Type::new_fn_unwrapped(vec![type_a.clone()], type_b.clone()),
         }],
         type_definitions: vec![
-          TypeDefinition {
+          hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("I"),
             type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
             names: vec![],
-            mappings: TypeDefinitionMappings::Enum,
+            mappings: hir::TypeDefinitionMappings::Enum,
           },
-          TypeDefinition {
+          hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("J"),
             type_parameters: vec![],
             names: vec![],
-            mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE]),
+            mappings: hir::TypeDefinitionMappings::Struct(vec![hir::INT_TYPE]),
           },
-          TypeDefinition {
+          hir::TypeDefinition {
             identifier: well_known_pstrs::UNDERSCORE_STR,
             type_parameters: vec![],
             names: vec![],
-            mappings: TypeDefinitionMappings::Enum,
+            mappings: hir::TypeDefinitionMappings::Enum,
           },
         ],
         main_function_names: vec![heap.alloc_str_for_test("main")],
         functions: vec![
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("functor_fun"),
             parameters: vec![heap.alloc_str_for_test("a")],
             type_parameters: vec![heap.alloc_str_for_test("A")],
-            type_: Type::new_fn_unwrapped(vec![type_a.clone()], INT_TYPE),
-            body: vec![Statement::Call {
-              callee: Callee::FunctionName(FunctionName::new(
+            type_: hir::Type::new_fn_unwrapped(vec![type_a.clone()], hir::INT_TYPE),
+            body: vec![hir::Statement::Call {
+              callee: hir::Callee::FunctionName(hir::FunctionName::new(
                 heap.alloc_str_for_test("$GENERICS$_A$bar"),
-                Type::new_fn_unwrapped(vec![type_a.clone()], INT_TYPE),
+                hir::Type::new_fn_unwrapped(vec![type_a.clone()], hir::INT_TYPE),
               )),
-              arguments: vec![ZERO],
-              return_type: INT_TYPE,
+              arguments: vec![hir::ZERO],
+              return_type: hir::INT_TYPE,
               return_collector: None,
             }],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("_I$bar"),
             parameters: vec![heap.alloc_str_for_test("a")],
             type_parameters: vec![heap.alloc_str_for_test("A")],
-            type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
+            type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("_J$bar"),
             parameters: vec![heap.alloc_str_for_test("a")],
             type_parameters: vec![heap.alloc_str_for_test("A")],
-            type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
+            type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("creatorIA"),
             parameters: vec![heap.alloc_str_for_test("a")],
             type_parameters: vec![heap.alloc_str_for_test("A")],
-            type_: Type::new_fn_unwrapped(vec![type_a.clone()], type_ia.clone()),
-            body: vec![Statement::StructInit {
+            type_: hir::Type::new_fn_unwrapped(vec![type_a.clone()], type_ia.clone()),
+            body: vec![hir::Statement::StructInit {
               struct_variable_name: heap.alloc_str_for_test("v"),
               type_: type_ia.clone().into_id().unwrap(),
               expression_list: vec![
-                Expression::int(0),
-                Expression::var_name(heap.alloc_str_for_test("a"), type_a),
+                hir::Expression::int(0),
+                hir::Expression::var_name(heap.alloc_str_for_test("a"), type_a),
               ],
             }],
-            return_value: Expression::var_name(heap.alloc_str_for_test("v"), type_ia),
+            return_value: hir::Expression::var_name(heap.alloc_str_for_test("v"), type_ia),
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("creatorIB"),
             parameters: vec![heap.alloc_str_for_test("b")],
             type_parameters: vec![heap.alloc_str_for_test("B")],
-            type_: Type::new_fn_unwrapped(vec![type_b.clone()], type_ib.clone()),
-            body: vec![Statement::StructInit {
+            type_: hir::Type::new_fn_unwrapped(vec![type_b.clone()], type_ib.clone()),
+            body: vec![hir::Statement::StructInit {
               struct_variable_name: heap.alloc_str_for_test("v"),
               type_: type_ib.clone().into_id().unwrap(),
               expression_list: vec![
-                Expression::int(1),
-                Expression::var_name(heap.alloc_str_for_test("b"), type_b),
+                hir::Expression::int(1),
+                hir::Expression::var_name(heap.alloc_str_for_test("b"), type_b),
               ],
             }],
-            return_value: Expression::var_name(heap.alloc_str_for_test("v"), type_ib),
+            return_value: hir::Expression::var_name(heap.alloc_str_for_test("v"), type_ib),
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("main"),
             parameters: vec![],
             type_parameters: vec![],
-            type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
-            body: vec![Statement::IfElse {
-              condition: ONE,
+            type_: hir::Type::new_fn_unwrapped(vec![], hir::INT_TYPE),
+            body: vec![hir::Statement::IfElse {
+              condition: hir::ONE,
               s1: vec![
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName {
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName {
                     name: heap.alloc_str_for_test("creatorIA"),
-                    type_: Type::new_fn_unwrapped(vec![INT_TYPE], type_i.clone()),
-                    type_arguments: vec![INT_TYPE],
+                    type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], type_i.clone()),
+                    type_arguments: vec![hir::INT_TYPE],
                   }),
-                  arguments: vec![ZERO],
+                  arguments: vec![hir::ZERO],
                   return_type: type_i.clone(),
                   return_collector: Some(heap.alloc_str_for_test("a")),
                 },
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName {
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName {
                     name: heap.alloc_str_for_test("creatorIA"),
-                    type_: Type::new_fn_unwrapped(
-                      vec![STRING_TYPE],
-                      Type::new_id(heap.alloc_str_for_test("I"), vec![STRING_TYPE, STRING_TYPE]),
+                    type_: hir::Type::new_fn_unwrapped(
+                      vec![hir::STRING_TYPE],
+                      hir::Type::new_id(
+                        heap.alloc_str_for_test("I"),
+                        vec![hir::STRING_TYPE, hir::STRING_TYPE],
+                      ),
                     ),
-                    type_arguments: vec![STRING_TYPE],
+                    type_arguments: vec![hir::STRING_TYPE],
                   }),
                   arguments: vec![g1.clone()],
                   return_type: type_i.clone(),
                   return_collector: Some(heap.alloc_str_for_test("a2")),
                 },
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName {
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName {
                     name: heap.alloc_str_for_test("creatorIB"),
-                    type_: Type::new_fn_unwrapped(vec![STRING_TYPE], type_i.clone()),
-                    type_arguments: vec![STRING_TYPE],
+                    type_: hir::Type::new_fn_unwrapped(vec![hir::STRING_TYPE], type_i.clone()),
+                    type_arguments: vec![hir::STRING_TYPE],
                   }),
                   arguments: vec![g1.clone()],
                   return_type: type_i.clone(),
                   return_collector: Some(heap.alloc_str_for_test("b")),
                 },
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName {
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName {
                     name: heap.alloc_str_for_test("functor_fun"),
-                    type_: Type::new_fn_unwrapped(vec![type_i.clone()], INT_TYPE),
+                    type_: hir::Type::new_fn_unwrapped(vec![type_i.clone()], hir::INT_TYPE),
                     type_arguments: vec![type_i.clone()],
                   }),
                   arguments: vec![g1.clone()],
                   return_type: type_i.clone(),
                   return_collector: None,
                 },
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName {
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName {
                     name: heap.alloc_str_for_test("functor_fun"),
-                    type_: Type::new_fn_unwrapped(vec![type_j.clone()], INT_TYPE),
+                    type_: hir::Type::new_fn_unwrapped(vec![type_j.clone()], hir::INT_TYPE),
                     type_arguments: vec![type_j.clone()],
                   }),
                   arguments: vec![g1.clone()],
                   return_type: type_j.clone(),
                   return_collector: None,
                 },
-                Statement::IndexedAccess {
+                hir::Statement::IndexedAccess {
                   name: heap.alloc_str_for_test("v1"),
-                  type_: INT_TYPE,
-                  pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), type_i),
+                  type_: hir::INT_TYPE,
+                  pointer_expression: hir::Expression::var_name(
+                    heap.alloc_str_for_test("a"),
+                    type_i,
+                  ),
                   index: 0,
                 },
-                Statement::Cast {
+                hir::Statement::Cast {
                   name: heap.alloc_str_for_test("cast"),
-                  type_: INT_TYPE,
-                  assigned_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+                  type_: hir::INT_TYPE,
+                  assigned_expression: hir::Expression::var_name(
+                    heap.alloc_str_for_test("a"),
+                    hir::INT_TYPE,
+                  ),
                 },
               ],
               s2: vec![
-                Statement::Call {
-                  callee: Callee::FunctionName(FunctionName::new(
+                hir::Statement::Call {
+                  callee: hir::Callee::FunctionName(hir::FunctionName::new(
                     heap.alloc_str_for_test("main"),
-                    Type::new_fn_unwrapped(vec![], INT_TYPE),
+                    hir::Type::new_fn_unwrapped(vec![], hir::INT_TYPE),
                   )),
                   arguments: vec![],
-                  return_type: INT_TYPE,
+                  return_type: hir::INT_TYPE,
                   return_collector: None,
                 },
-                Statement::binary(heap.alloc_str_for_test("v1"), Operator::PLUS, ZERO, ZERO),
-                Statement::StructInit {
+                hir::Statement::binary(
+                  heap.alloc_str_for_test("v1"),
+                  Operator::PLUS,
+                  hir::ZERO,
+                  hir::ZERO,
+                ),
+                hir::Statement::StructInit {
                   struct_variable_name: heap.alloc_str_for_test("j"),
                   type_: type_j.clone().into_id().unwrap(),
-                  expression_list: vec![Expression::int(0)],
+                  expression_list: vec![hir::Expression::int(0)],
                 },
-                Statement::IndexedAccess {
+                hir::Statement::IndexedAccess {
                   name: heap.alloc_str_for_test("v2"),
-                  type_: INT_TYPE,
-                  pointer_expression: Expression::var_name(heap.alloc_str_for_test("j"), type_j),
+                  type_: hir::INT_TYPE,
+                  pointer_expression: hir::Expression::var_name(
+                    heap.alloc_str_for_test("j"),
+                    type_j,
+                  ),
                   index: 0,
                 },
-                Statement::ClosureInit {
+                hir::Statement::ClosureInit {
                   closure_variable_name: heap.alloc_str_for_test("c1"),
-                  closure_type: Type::new_id_unwrapped(
+                  closure_type: hir::Type::new_id_unwrapped(
                     heap.alloc_str_for_test("CC"),
-                    vec![STRING_TYPE, STRING_TYPE],
+                    vec![hir::STRING_TYPE, hir::STRING_TYPE],
                   ),
-                  function_name: FunctionName {
+                  function_name: hir::FunctionName {
                     name: heap.alloc_str_for_test("creatorIA"),
-                    type_: Type::new_fn_unwrapped(
-                      vec![STRING_TYPE],
-                      Type::new_id(heap.alloc_str_for_test("I"), vec![STRING_TYPE, STRING_TYPE]),
+                    type_: hir::Type::new_fn_unwrapped(
+                      vec![hir::STRING_TYPE],
+                      hir::Type::new_id(
+                        heap.alloc_str_for_test("I"),
+                        vec![hir::STRING_TYPE, hir::STRING_TYPE],
+                      ),
                     ),
-                    type_arguments: vec![STRING_TYPE],
+                    type_arguments: vec![hir::STRING_TYPE],
                   },
                   context: g1.clone(),
                 },
-                Statement::ClosureInit {
+                hir::Statement::ClosureInit {
                   closure_variable_name: heap.alloc_str_for_test("c2"),
-                  closure_type: Type::new_id_unwrapped(
+                  closure_type: hir::Type::new_id_unwrapped(
                     heap.alloc_str_for_test("CC"),
-                    vec![INT_TYPE, STRING_TYPE],
+                    vec![hir::INT_TYPE, hir::STRING_TYPE],
                   ),
-                  function_name: FunctionName {
+                  function_name: hir::FunctionName {
                     name: heap.alloc_str_for_test("creatorIA"),
-                    type_: Type::new_fn_unwrapped(
-                      vec![STRING_TYPE],
-                      Type::new_id(heap.alloc_str_for_test("I"), vec![STRING_TYPE, STRING_TYPE]),
+                    type_: hir::Type::new_fn_unwrapped(
+                      vec![hir::STRING_TYPE],
+                      hir::Type::new_id(
+                        heap.alloc_str_for_test("I"),
+                        vec![hir::STRING_TYPE, hir::STRING_TYPE],
+                      ),
                     ),
-                    type_arguments: vec![STRING_TYPE],
+                    type_arguments: vec![hir::STRING_TYPE],
                   },
                   context: g1,
                 },
               ],
               final_assignments: vec![(
                 heap.alloc_str_for_test("finalV"),
-                INT_TYPE,
-                Expression::var_name(heap.alloc_str_for_test("v1"), INT_TYPE),
-                Expression::var_name(heap.alloc_str_for_test("v2"), INT_TYPE),
+                hir::INT_TYPE,
+                hir::Expression::var_name(heap.alloc_str_for_test("v1"), hir::INT_TYPE),
+                hir::Expression::var_name(heap.alloc_str_for_test("v2"), hir::INT_TYPE),
               )],
             }],
-            return_value: ZERO,
+            return_value: hir::ZERO,
           },
         ],
       },
@@ -966,85 +1017,85 @@ sources.mains = [main]"#,
     let heap = &mut Heap::new();
 
     assert_specialized(
-      Sources {
+      hir::Sources {
         global_variables: vec![],
         closure_types: vec![],
         type_definitions: vec![
-          TypeDefinition {
+          hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("I"),
             type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
             names: vec![],
-            mappings: TypeDefinitionMappings::Enum,
+            mappings: hir::TypeDefinitionMappings::Enum,
           },
-          TypeDefinition {
+          hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("J"),
             type_parameters: vec![],
             names: vec![],
-            mappings: TypeDefinitionMappings::Struct(vec![Type::new_id(
+            mappings: hir::TypeDefinitionMappings::Struct(vec![hir::Type::new_id(
               heap.alloc_str_for_test("I"),
-              vec![INT_TYPE, INT_TYPE],
+              vec![hir::INT_TYPE, hir::INT_TYPE],
             )]),
           },
         ],
         main_function_names: vec![heap.alloc_str_for_test("main")],
         functions: vec![
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("creatorJ"),
             parameters: vec![],
             type_parameters: vec![],
-            type_: Type::new_fn_unwrapped(
+            type_: hir::Type::new_fn_unwrapped(
               vec![],
-              Type::new_id_no_targs(heap.alloc_str_for_test("J")),
+              hir::Type::new_id_no_targs(heap.alloc_str_for_test("J")),
             ),
             body: vec![
-              Statement::StructInit {
+              hir::Statement::StructInit {
                 struct_variable_name: heap.alloc_str_for_test("v1"),
-                type_: Type::new_id_unwrapped(
+                type_: hir::Type::new_id_unwrapped(
                   heap.alloc_str_for_test("I"),
-                  vec![INT_TYPE, INT_TYPE],
+                  vec![hir::INT_TYPE, hir::INT_TYPE],
                 ),
                 expression_list: vec![],
               },
-              Statement::StructInit {
+              hir::Statement::StructInit {
                 struct_variable_name: heap.alloc_str_for_test("v2"),
-                type_: Type::new_id_no_targs_unwrapped(heap.alloc_str_for_test("J")),
-                expression_list: vec![ZERO, ZERO],
+                type_: hir::Type::new_id_no_targs_unwrapped(heap.alloc_str_for_test("J")),
+                expression_list: vec![hir::ZERO, hir::ZERO],
               },
             ],
-            return_value: Expression::var_name(
+            return_value: hir::Expression::var_name(
               heap.alloc_str_for_test("v2"),
-              Type::new_id_no_targs(heap.alloc_str_for_test("J")),
+              hir::Type::new_id_no_targs(heap.alloc_str_for_test("J")),
             ),
           },
-          Function {
+          hir::Function {
             name: heap.alloc_str_for_test("main"),
             parameters: vec![],
             type_parameters: vec![],
-            type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
+            type_: hir::Type::new_fn_unwrapped(vec![], hir::INT_TYPE),
             body: vec![
-              Statement::Call {
-                callee: Callee::FunctionName(FunctionName::new(
+              hir::Statement::Call {
+                callee: hir::Callee::FunctionName(hir::FunctionName::new(
                   heap.alloc_str_for_test("creatorJ"),
-                  Type::new_fn_unwrapped(
+                  hir::Type::new_fn_unwrapped(
                     vec![],
-                    Type::new_id_no_targs(heap.alloc_str_for_test("J")),
+                    hir::Type::new_id_no_targs(heap.alloc_str_for_test("J")),
                   ),
                 )),
                 arguments: vec![],
-                return_type: Type::new_id_no_targs(heap.alloc_str_for_test("J")),
+                return_type: hir::Type::new_id_no_targs(heap.alloc_str_for_test("J")),
                 return_collector: None,
               },
-              Statement::Call {
-                callee: Callee::Variable(VariableName {
+              hir::Statement::Call {
+                callee: hir::Callee::Variable(hir::VariableName {
                   name: heap.alloc_str_for_test("v"),
-                  type_: INT_TYPE,
+                  type_: hir::INT_TYPE,
                 }),
                 arguments: vec![],
-                return_type: Type::new_id_no_targs(heap.alloc_str_for_test("J")),
+                return_type: hir::Type::new_id_no_targs(heap.alloc_str_for_test("J")),
                 return_collector: None,
               },
             ],
-            return_value: Expression::StringName(heap.alloc_str_for_test("creatorJ")),
+            return_value: hir::Expression::StringName(heap.alloc_str_for_test("creatorJ")),
           },
         ],
       },

--- a/crates/samlang-core/src/compiler/hir_string_manager.rs
+++ b/crates/samlang-core/src/compiler/hir_string_manager.rs
@@ -1,4 +1,4 @@
-use crate::{ast::mir::GlobalVariable, common::PStr, Heap};
+use crate::{ast::hir::GlobalVariable, common::PStr, Heap};
 use std::collections::HashMap;
 
 // TODO: move this to global variable since heap allows us to provide a better API

--- a/crates/samlang-core/src/compiler/hir_type_conversion.rs
+++ b/crates/samlang-core/src/compiler/hir_type_conversion.rs
@@ -1,7 +1,7 @@
 use crate::{
   ast::{
     common_names::{encode_samlang_type, encode_samlang_variant_subtype},
-    mir::{
+    hir::{
       ClosureTypeDefinition, FunctionType, IdType, Type, TypeDefinition, TypeDefinitionMappings,
       INT_TYPE,
     },
@@ -405,7 +405,7 @@ impl TypeLoweringManager {
 mod tests {
   use super::*;
   use crate::{
-    ast::{mir::STRING_TYPE, source::test_builder, Location, Reason},
+    ast::{hir::STRING_TYPE, source::test_builder, Location, Reason},
     checker::type_::test_type_builder,
   };
   use pretty_assertions::assert_eq;

--- a/crates/samlang-core/src/compiler/lir_unused_name_elimination.rs
+++ b/crates/samlang-core/src/compiler/lir_unused_name_elimination.rs
@@ -172,11 +172,11 @@ pub(super) fn optimize_mir_sources_by_eliminating_unused_ones(
 mod tests {
   use crate::{
     ast::{
+      hir,
       lir::{
         Expression, Function, GenenalLoopVariable, Sources, Statement, Type, TypeDefinition,
         INT_TYPE, ZERO,
       },
-      mir::GlobalVariable,
     },
     Heap,
   };
@@ -189,11 +189,11 @@ mod tests {
 
     let optimized = super::optimize_mir_sources_by_eliminating_unused_ones(Sources {
       global_variables: vec![
-        GlobalVariable {
+        hir::GlobalVariable {
           name: heap.alloc_str_for_test("bar"),
           content: heap.alloc_str_for_test("fff"),
         },
-        GlobalVariable {
+        hir::GlobalVariable {
           name: heap.alloc_str_for_test("fsdfsdf"),
           content: heap.alloc_str_for_test("fff"),
         },
@@ -255,7 +255,7 @@ mod tests {
               condition: ZERO,
               s1: vec![Statement::binary(
                 heap.alloc_str_for_test(""),
-                crate::ast::mir::Operator::GE,
+                hir::Operator::GE,
                 Expression::Name(heap.alloc_str_for_test("foo"), INT_TYPE),
                 Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE),
               )],

--- a/crates/samlang-core/src/compiler/wasm_lowering.rs
+++ b/crates/samlang-core/src/compiler/wasm_lowering.rs
@@ -1,5 +1,5 @@
 use crate::{
-  ast::{common_names, lir, mir, wasm},
+  ast::{common_names, hir, lir, wasm},
   common::{Heap, PStr},
 };
 use itertools::Itertools;
@@ -110,7 +110,7 @@ impl<'a> LoweringManager<'a> {
             vec![wasm::Instruction::IfElse {
               condition: wasm::InlineInstruction::Binary(
                 Box::new(condition),
-                mir::Operator::XOR,
+                hir::Operator::XOR,
                 Box::new(wasm::InlineInstruction::Const(1)),
               ),
               s1: s2,
@@ -126,7 +126,7 @@ impl<'a> LoweringManager<'a> {
         if *invert_condition {
           condition = wasm::InlineInstruction::Binary(
             Box::new(condition),
-            mir::Operator::XOR,
+            hir::Operator::XOR,
             Box::new(wasm::InlineInstruction::Const(1)),
           );
         }
@@ -243,7 +243,7 @@ pub(super) fn compile_mir_to_wasm(heap: &mut Heap, sources: &lir::Sources) -> wa
   let mut global_variables_to_pointer_mapping = HashMap::new();
   let mut function_index_mapping = HashMap::new();
   let mut global_variables = vec![];
-  for mir::GlobalVariable { name, content } in &sources.global_variables {
+  for hir::GlobalVariable { name, content } in &sources.global_variables {
     let content_str = content.as_str(heap);
     let mut bytes = vec![0, 0, 0, 0];
     bytes.extend_from_slice(&(content_str.len() as u32).to_le_bytes());
@@ -285,8 +285,8 @@ pub(super) fn compile_mir_to_wasm(heap: &mut Heap, sources: &lir::Sources) -> wa
 mod tests {
   use crate::{
     ast::{
+      hir::{GlobalVariable, Operator},
       lir::{Expression, Function, GenenalLoopVariable, Sources, Statement, Type, INT_TYPE, ZERO},
-      mir::{GlobalVariable, Operator},
     },
     common::Heap,
   };

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -1772,24 +1772,24 @@ class Main {
       .collect::<HashMap<_, _>>();
     let (checked_sources, _) = type_check_sources(&sources, heap, &mut error_set);
     assert_eq!("", error_set.error_messages(heap).join("\n"));
-    let unoptimized_hir_sources = compiler::compile_sources_to_hir(heap, &checked_sources);
-    let optimized_hir_sources = optimization::optimize_sources(
+    let unoptimized_mir_sources = compiler::compile_sources_to_mir(heap, &checked_sources);
+    let optimized_mir_sources = optimization::optimize_sources(
       heap,
-      unoptimized_hir_sources,
+      unoptimized_mir_sources,
       &optimization::ALL_ENABLED_CONFIGURATION,
     );
-    let mir_sources = compiler::compile_hir_to_mir(heap, optimized_hir_sources);
+    let lir_sources = compiler::compile_mir_to_lir(heap, optimized_mir_sources);
     for test in &tests {
       let mod_ref = heap.alloc_module_reference_from_string_vec(vec![test.name.to_string()]);
       let main_function =
         heap.alloc_string(common_names::encode_main_function_name(heap, &mod_ref));
-      let actual = interpreter::run_mir_sources(heap, &mir_sources, main_function);
+      let actual = interpreter::run_lir_sources(heap, &lir_sources, main_function);
       assert_eq!(test.expected_std, actual);
       // Replace with the following line for debugging
       // assert_eq!(test.expected_std, actual, "{}", test.name);
     }
 
-    let (_, wasm_module) = compiler::compile_mir_to_wasm(heap, &mir_sources);
+    let (_, wasm_module) = compiler::compile_lir_to_wasm(heap, &lir_sources);
     let engine = Engine::default();
     let module = Module::new(&engine, &mut &wasm_module[..]).unwrap();
     let mut store = Store::new(&engine, vec![]);

--- a/crates/samlang-core/src/interpreter.rs
+++ b/crates/samlang-core/src/interpreter.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::{ast, checker, common};
 
-mod mir_interpreter;
+mod lir_interpreter;
 mod source_interpreter;
 
 pub(super) fn run_source_module(
@@ -12,10 +12,10 @@ pub(super) fn run_source_module(
   source_interpreter::run(heap, module)
 }
 
-pub(super) fn run_mir_sources(
+pub(super) fn run_lir_sources(
   heap: &mut common::Heap,
   sources: &ast::lir::Sources,
   main_function: common::PStr,
 ) -> String {
-  mir_interpreter::run(heap, sources, main_function)
+  lir_interpreter::run(heap, sources, main_function)
 }

--- a/crates/samlang-core/src/interpreter/lir_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/lir_interpreter.rs
@@ -1,8 +1,8 @@
 use crate::{
   ast::{
     common_names,
+    hir::Operator,
     lir::{Expression, Function, Sources, Statement, INT_TYPE},
-    mir::Operator,
   },
   common::{Heap, PStr},
 };
@@ -324,10 +324,10 @@ mod tests {
   use crate::{
     ast::{
       common_names,
+      hir::{GlobalVariable, Operator},
       lir::{
         Expression, Function, GenenalLoopVariable, Sources, Statement, Type, INT_TYPE, ONE, ZERO,
       },
-      mir::{GlobalVariable, Operator},
     },
     common::Heap,
   };

--- a/crates/samlang-core/src/lib.rs
+++ b/crates/samlang-core/src/lib.rs
@@ -73,22 +73,22 @@ pub fn compile_sources(
     return Err(errors);
   }
 
-  let unoptimized_hir_sources = measure_time(enable_profiling, "Compile to HIR", || {
-    compiler::compile_sources_to_hir(heap, &checked_sources)
+  let unoptimized_hir_sources = measure_time(enable_profiling, "Compile to MIR", || {
+    compiler::compile_sources_to_mir(heap, &checked_sources)
   });
-  let optimized_hir_sources = measure_time(enable_profiling, "Optimize HIR", || {
+  let optimized_hir_sources = measure_time(enable_profiling, "Optimize MIR", || {
     optimization::optimize_sources(
       heap,
       unoptimized_hir_sources,
       &optimization::ALL_ENABLED_CONFIGURATION,
     )
   });
-  let mid_ir_sources = measure_time(enable_profiling, "Compile to MIR", || {
-    compiler::compile_hir_to_mir(heap, optimized_hir_sources)
+  let mid_ir_sources = measure_time(enable_profiling, "Compile to LIR", || {
+    compiler::compile_mir_to_lir(heap, optimized_hir_sources)
   });
   let common_ts_code = mid_ir_sources.pretty_print(heap);
   let (wat_text, wasm_file) = measure_time(enable_profiling, "Compile to WASM", || {
-    compiler::compile_mir_to_wasm(heap, &mid_ir_sources)
+    compiler::compile_lir_to_wasm(heap, &mid_ir_sources)
   });
 
   let mut text_code_results = BTreeMap::new();

--- a/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
+++ b/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
@@ -1,6 +1,7 @@
 use super::optimization_common::{BinaryBindedValue, BindedValue, IndexAccessBindedValue};
 use crate::{
   ast::mir::{Binary, Function, Statement},
+  common::take_mut,
   Heap,
 };
 use std::collections::BTreeSet;
@@ -12,68 +13,6 @@ fn intersection_of(
   set1.into_iter().filter(|e| others.iter().all(|it| it.contains(e))).collect()
 }
 
-fn produce_hoisted_stmt(heap: &mut Heap, value: BindedValue) -> Statement {
-  match value {
-    BindedValue::IndexedAccess(IndexAccessBindedValue { type_, pointer_expression, index }) => {
-      Statement::IndexedAccess { name: heap.alloc_temp_str(), type_, pointer_expression, index }
-    }
-    BindedValue::Binary(BinaryBindedValue { operator, e1, e2 }) => {
-      Statement::Binary(Statement::binary_unwrapped(heap.alloc_temp_str(), operator, e1, e2))
-    }
-  }
-}
-
-fn optimize_stmt(
-  stmt: Statement,
-  heap: &mut Heap,
-  set: &mut BTreeSet<BindedValue>,
-) -> Vec<Statement> {
-  match stmt {
-    // handle similar optimization in loop-invariant code motion for while
-    Statement::Call { .. }
-    | Statement::Break(_)
-    | Statement::SingleIf { .. }
-    | Statement::While { .. }
-    | Statement::Cast { .. }
-    | Statement::StructInit { .. }
-    | Statement::ClosureInit { .. } => vec![stmt],
-
-    Statement::Binary(Binary { name, operator, e1, e2 }) => {
-      set.insert(BindedValue::Binary(BinaryBindedValue {
-        operator,
-        e1: e1.clone(),
-        e2: e2.clone(),
-      }));
-      vec![Statement::Binary(Binary { name, operator, e1, e2 })]
-    }
-    Statement::IndexedAccess { name, type_, pointer_expression, index } => {
-      set.insert(BindedValue::IndexedAccess(IndexAccessBindedValue {
-        type_: type_.clone(),
-        pointer_expression: pointer_expression.clone(),
-        index,
-      }));
-      vec![Statement::IndexedAccess { name, type_, pointer_expression, index }]
-    }
-
-    Statement::IfElse { condition, s1, s2, final_assignments } => {
-      let (s1, set1) = optimize_stmts(s1, heap);
-      let (s2, set2) = optimize_stmts(s2, heap);
-      let common_expressions = intersection_of(set1, vec![set2]);
-      let mut hoisted_stmts = vec![];
-      for binded_value in common_expressions {
-        hoisted_stmts.append(&mut optimize_stmt(
-          produce_hoisted_stmt(heap, binded_value),
-          heap,
-          set,
-        ));
-      }
-      hoisted_stmts.push(Statement::IfElse { condition, s1, s2, final_assignments });
-      hoisted_stmts.reverse();
-      hoisted_stmts
-    }
-  }
-}
-
 fn optimize_stmts(
   stmts: Vec<Statement>,
   heap: &mut Heap,
@@ -81,30 +20,70 @@ fn optimize_stmts(
   let mut set = BTreeSet::new();
   let mut collector = vec![];
   for stmt in stmts.into_iter().rev() {
-    collector.append(&mut optimize_stmt(stmt, heap, &mut set));
+    match stmt {
+      // handle similar optimization in loop-invariant code motion for while
+      Statement::Call { .. }
+      | Statement::Break(_)
+      | Statement::SingleIf { .. }
+      | Statement::While { .. }
+      | Statement::Cast { .. }
+      | Statement::StructInit { .. }
+      | Statement::ClosureInit { .. } => collector.push(stmt),
+
+      Statement::Binary(Binary { name, operator, e1, e2 }) => {
+        set.insert(BindedValue::Binary(BinaryBindedValue { operator, e1, e2 }));
+        collector.push(Statement::Binary(Binary { name, operator, e1, e2 }));
+      }
+      Statement::IndexedAccess { name, type_, pointer_expression, index } => {
+        set.insert(BindedValue::IndexedAccess(IndexAccessBindedValue {
+          type_,
+          pointer_expression,
+          index,
+        }));
+        collector.push(Statement::IndexedAccess { name, type_, pointer_expression, index });
+      }
+
+      Statement::IfElse { condition, s1, s2, final_assignments } => {
+        let (s1, set1) = optimize_stmts(s1, heap);
+        let (s2, set2) = optimize_stmts(s2, heap);
+        let common_expressions = intersection_of(set1, vec![set2]);
+        collector.push(Statement::IfElse { condition, s1, s2, final_assignments });
+        for binded_value in common_expressions.into_iter().rev() {
+          set.insert(binded_value);
+          collector.push(match binded_value {
+            BindedValue::IndexedAccess(IndexAccessBindedValue {
+              type_,
+              pointer_expression,
+              index,
+            }) => Statement::IndexedAccess {
+              name: heap.alloc_temp_str(),
+              type_,
+              pointer_expression,
+              index,
+            },
+            BindedValue::Binary(BinaryBindedValue { operator, e1, e2 }) => Statement::Binary(
+              Statement::binary_unwrapped(heap.alloc_temp_str(), operator, e1, e2),
+            ),
+          })
+        }
+      }
+    }
   }
   collector.reverse();
   (collector, set)
 }
 
-pub(super) fn optimize_function(function: Function, heap: &mut Heap) -> Function {
-  let Function { name, parameters, type_parameters, type_, body, return_value } = function;
-  Function {
-    name,
-    parameters,
-    type_parameters,
-    type_,
-    body: optimize_stmts(body, heap).0,
-    return_value,
-  }
+pub(super) fn optimize_function(function: &mut Function, heap: &mut Heap) {
+  take_mut(&mut function.body, |body| optimize_stmts(body, heap).0);
 }
 
 #[cfg(test)]
 mod tests {
   use crate::{
+    ast::hir::Operator,
     ast::mir::{
-      Callee, Expression, Function, FunctionName, Operator, Statement, Type, VariableName,
-      INT_TYPE, ONE, ZERO,
+      Callee, Expression, Function, FunctionName, Statement, Type, VariableName, INT_TYPE, ONE,
+      ZERO,
     },
     Heap,
   };
@@ -112,23 +91,17 @@ mod tests {
   use pretty_assertions::assert_eq;
 
   fn assert_correctly_optimized(stmts: Vec<Statement>, heap: &mut Heap, expected: &str) {
-    let actual = super::super::local_value_numbering::optimize_function(super::optimize_function(
-      Function {
-        name: heap.alloc_str_for_test(""),
-        parameters: vec![],
-        type_parameters: vec![],
-        type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
-        body: stmts,
-        return_value: ZERO,
-      },
-      heap,
-    ))
-    .body
-    .iter()
-    .map(|s| s.debug_print(heap))
-    .join("\n");
+    let mut f = Function {
+      name: heap.alloc_str_for_test(""),
+      parameters: vec![],
+      type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
+      body: stmts,
+      return_value: ZERO,
+    };
+    super::optimize_function(&mut f, heap);
+    super::super::local_value_numbering::optimize_function(&mut f);
 
-    assert_eq!(expected, actual);
+    assert_eq!(expected, f.body.iter().map(|s| s.debug_print(heap)).join("\n"));
   }
 
   #[test]
@@ -181,8 +154,8 @@ mod tests {
         final_assignments: vec![],
       }],
       heap,
-      r#"let _t0 = 1 + 0;
-let _t1: int = 0[3];
+      r#"let _t1: int = 0[3];
+let _t0 = 1 + 0;
 if (b: int) {
   let ddddd = 1 + 1;
   fff((_t0: int), (_t1: int));

--- a/crates/samlang-core/src/optimization/dead_code_elimination.rs
+++ b/crates/samlang-core/src/optimization/dead_code_elimination.rs
@@ -1,9 +1,8 @@
-use super::optimization_common;
 use crate::{
-  ast::mir::{Binary, Callee, Expression, Function, GenenalLoopVariable, Operator, Statement},
+  ast::hir::Operator,
+  ast::mir::{Binary, Callee, Expression, Function, GenenalLoopVariable, Statement},
   common::PStr,
 };
-use itertools::Itertools;
 use std::collections::HashSet;
 
 pub(super) fn collect_use_from_expression(expression: &Expression, set: &mut HashSet<PStr>) {
@@ -61,14 +60,14 @@ fn collect_use_from_stmt(stmt: &Statement, set: &mut HashSet<PStr>) {
     Statement::Cast { name: _, type_: _, assigned_expression } => {
       collect_use_from_expression(assigned_expression, set);
     }
-    Statement::StructInit { struct_variable_name: _, type_: _, expression_list } => {
+    Statement::StructInit { struct_variable_name: _, type_name: _, expression_list } => {
       for e in expression_list {
         collect_use_from_expression(e, set);
       }
     }
     Statement::ClosureInit {
       closure_variable_name: _,
-      closure_type: _,
+      closure_type_name: _,
       function_name: _,
       context,
     } => {
@@ -83,152 +82,156 @@ pub(super) fn collect_use_from_stmts(stmts: &Vec<Statement>, set: &mut HashSet<P
   }
 }
 
-fn optimize_stmt(stmt: Statement, set: &mut HashSet<PStr>) -> Option<Statement> {
+fn optimize_stmt(stmt: &mut Statement, set: &mut HashSet<PStr>) -> bool {
   match stmt {
     Statement::Binary(binary) => {
       if !set.contains(&binary.name)
         && binary.operator != Operator::DIV
         && binary.operator != Operator::MOD
       {
-        None
+        false
       } else {
         collect_use_from_expression(&binary.e1, set);
         collect_use_from_expression(&binary.e2, set);
-        Some(Statement::Binary(binary))
+        true
       }
     }
-    Statement::IndexedAccess { name, type_, pointer_expression, index } => {
-      if !set.contains(&name) {
-        None
+    Statement::IndexedAccess { name, type_: _, pointer_expression, index: _ } => {
+      if !set.contains(name) {
+        false
       } else {
-        collect_use_from_expression(&pointer_expression, set);
-        Some(Statement::IndexedAccess { name, type_, pointer_expression, index })
+        collect_use_from_expression(pointer_expression, set);
+        true
       }
     }
-    Statement::Call { callee, arguments, return_type, return_collector } => {
-      let return_collector = match return_collector {
-        Some(n) if set.contains(&n) => Some(n),
+    Statement::Call { callee, arguments, return_type: _, return_collector } => {
+      *return_collector = match return_collector {
+        Some(n) if set.contains(n) => Some(*n),
         _ => None,
       };
       if let Callee::Variable(v) = &callee {
         set.insert(v.name);
       }
-      for e in &arguments {
+      for e in arguments {
         collect_use_from_expression(e, set);
       }
-      Some(Statement::Call { callee, arguments, return_type, return_collector })
+      true
     }
     Statement::IfElse { condition, s1, s2, final_assignments } => {
-      let final_assignments = final_assignments
-        .into_iter()
-        .filter_map(|(n, t, e1, e2)| {
-          if set.contains(&n) {
-            collect_use_from_expression(&e1, set);
-            collect_use_from_expression(&e2, set);
-            Some((n, t, e1, e2))
-          } else {
-            None
-          }
-        })
-        .collect_vec();
-      let s1 = optimize_stmts(s1, set);
-      let s2 = optimize_stmts(s2, set);
-      let if_else =
-        optimization_common::if_else_or_null(condition.clone(), s1, s2, final_assignments);
-      if if_else.is_some() {
-        collect_use_from_expression(&condition, set);
-      }
-      if_else
-    }
-    Statement::SingleIf { condition, invert_condition, statements } => {
-      let statements = optimize_stmts(statements, set);
-      if statements.is_empty() {
-        None
+      final_assignments.retain(|(n, _, e1, e2)| {
+        if set.contains(n) {
+          collect_use_from_expression(e1, set);
+          collect_use_from_expression(e2, set);
+          true
+        } else {
+          false
+        }
+      });
+      optimize_stmts(s1, set);
+      optimize_stmts(s2, set);
+      if s1.is_empty() && s2.is_empty() && final_assignments.is_empty() {
+        false
       } else {
-        collect_use_from_expression(&condition, set);
-        Some(Statement::SingleIf { condition, invert_condition, statements })
+        collect_use_from_expression(condition, set);
+        true
+      }
+    }
+    Statement::SingleIf { condition, invert_condition: _, statements } => {
+      optimize_stmts(statements, set);
+      if statements.is_empty() {
+        false
+      } else {
+        collect_use_from_expression(condition, set);
+        true
       }
     }
     Statement::Break(e) => {
-      collect_use_from_expression(&e, set);
-      Some(Statement::Break(e))
+      collect_use_from_expression(e, set);
+      true
     }
     Statement::While { loop_variables, statements, break_collector } => {
-      let break_collector = match break_collector {
-        Some(v) if set.contains(&v.name) => Some(v),
+      *break_collector = match break_collector {
+        Some(v) if set.contains(&v.name) => Some(*v),
         _ => None,
       };
       let mut used_inside_loop = HashSet::new();
-      collect_use_from_while_parts(&loop_variables, &statements, &mut used_inside_loop);
-      let used_loop_variables_inside_loop =
-        loop_variables.into_iter().filter(|it| used_inside_loop.contains(&it.name)).collect_vec();
-      for v in &used_loop_variables_inside_loop {
+      collect_use_from_while_parts(loop_variables, statements, &mut used_inside_loop);
+      loop_variables.retain(|it| used_inside_loop.contains(&it.name));
+      for v in loop_variables.iter() {
         collect_use_from_expression(&v.loop_value, set);
       }
-      let statements = optimize_stmts(statements, set);
-      let loop_variables = used_loop_variables_inside_loop
-        .into_iter()
-        .filter_map(|variable| {
-          if set.contains(&variable.name) {
-            collect_use_from_expression(&variable.initial_value, set);
-            Some(variable)
-          } else {
-            None
-          }
-        })
-        .collect_vec();
-      Some(Statement::While { loop_variables, statements, break_collector })
+      optimize_stmts(statements, set);
+      loop_variables.retain(|variable| {
+        if set.contains(&variable.name) {
+          collect_use_from_expression(&variable.initial_value, set);
+          true
+        } else {
+          false
+        }
+      });
+      true
     }
-    Statement::Cast { name, type_, assigned_expression } => {
-      if !set.contains(&name) {
-        None
+    Statement::Cast { name, type_: _, assigned_expression } => {
+      if !set.contains(name) {
+        false
       } else {
-        collect_use_from_expression(&assigned_expression, set);
-        Some(Statement::Cast { name, type_, assigned_expression })
+        collect_use_from_expression(assigned_expression, set);
+        true
       }
     }
-    Statement::StructInit { struct_variable_name, type_, expression_list } => {
-      if !set.contains(&struct_variable_name) {
-        None
+    Statement::StructInit { struct_variable_name, type_name: _, expression_list } => {
+      if !set.contains(struct_variable_name) {
+        false
       } else {
-        for e in &expression_list {
+        for e in expression_list {
           collect_use_from_expression(e, set);
         }
-        Some(Statement::StructInit { struct_variable_name, type_, expression_list })
+        true
       }
     }
-    Statement::ClosureInit { closure_variable_name, closure_type, function_name, context } => {
-      if !set.contains(&closure_variable_name) {
-        None
+    Statement::ClosureInit {
+      closure_variable_name,
+      closure_type_name: _,
+      function_name: _,
+      context,
+    } => {
+      if !set.contains(closure_variable_name) {
+        false
       } else {
-        collect_use_from_expression(&context, set);
-        Some(Statement::ClosureInit { closure_variable_name, closure_type, function_name, context })
+        collect_use_from_expression(context, set);
+        true
       }
     }
   }
 }
 
-pub(super) fn optimize_stmts(stmts: Vec<Statement>, set: &mut HashSet<PStr>) -> Vec<Statement> {
-  let mut collector = vec![];
-  for s in stmts.into_iter().rev() {
-    if let Some(s) = optimize_stmt(s, set) {
-      collector.push(s);
+pub(super) fn optimize_stmts(stmts: &mut Vec<Statement>, set: &mut HashSet<PStr>) {
+  let mut indices = vec![];
+  for (i, s) in stmts.iter_mut().enumerate().rev() {
+    if optimize_stmt(s, set) {
+      indices.push(i);
     }
   }
-  collector.reverse();
-  collector
+  let mut curr_index = 0;
+  stmts.retain(|_| {
+    if let Some(to_keep) = indices.pop() {
+      if to_keep == curr_index {
+        curr_index += 1;
+        true
+      } else {
+        indices.push(to_keep);
+        curr_index += 1;
+        false
+      }
+    } else {
+      curr_index += 1;
+      false
+    }
+  });
 }
 
-pub(super) fn optimize_function(function: Function) -> Function {
+pub(super) fn optimize_function(function: &mut Function) {
   let mut set = HashSet::new();
   collect_use_from_expression(&function.return_value, &mut set);
-  let Function { name, parameters, type_parameters, type_, body, return_value } = function;
-  Function {
-    name,
-    parameters,
-    type_parameters,
-    type_,
-    body: optimize_stmts(body, &mut set),
-    return_value,
-  }
+  optimize_stmts(&mut function.body, &mut set);
 }

--- a/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
+++ b/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod tests {
   use crate::{
+    ast::hir::Operator,
     ast::mir::{
-      Callee, Expression, Function, FunctionName, GenenalLoopVariable, Operator, Statement, Type,
+      Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
     common::Heap,
@@ -17,18 +18,18 @@ mod tests {
     heap: &mut Heap,
     expected: &str,
   ) {
-    let Function { body, return_value, .. } = local_value_numbering::optimize_function(Function {
+    let mut f = Function {
       name: heap.alloc_str_for_test(""),
       parameters: vec![],
-      type_parameters: vec![],
       type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       body: stmts,
       return_value,
-    });
+    };
+    local_value_numbering::optimize_function(&mut f);
     let actual = format!(
       "{}\nreturn {};",
-      body.iter().map(|s| s.debug_print(heap)).join("\n"),
-      return_value.debug_print(heap)
+      f.body.iter().map(|s| s.debug_print(heap)).join("\n"),
+      f.return_value.debug_print(heap)
     );
     assert_eq!(expected, actual);
   }
@@ -76,7 +77,7 @@ mod tests {
         },
         Statement::StructInit {
           struct_variable_name: heap.alloc_str_for_test("s"),
-          type_: Type::new_id_no_targs_unwrapped(heap.alloc_str_for_test("S")),
+          type_name: heap.alloc_str_for_test("S"),
           expression_list: vec![
             Expression::var_name(heap.alloc_str_for_test("i1"), INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("b1"), INT_TYPE),
@@ -85,7 +86,7 @@ mod tests {
         },
         Statement::ClosureInit {
           closure_variable_name: heap.alloc_str_for_test("s"),
-          closure_type: Type::new_id_no_targs_unwrapped(heap.alloc_str_for_test("S")),
+          closure_type_name: heap.alloc_str_for_test("S"),
           function_name: FunctionName::new(
             heap.alloc_str_for_test("a"),
             Type::new_fn_unwrapped(vec![], INT_TYPE),

--- a/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
+++ b/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
@@ -3,7 +3,8 @@ use super::loop_induction_analysis::{
   PotentialLoopInvariantExpression,
 };
 use crate::{
-  ast::mir::{Binary, Expression, Operator, Statement, INT_TYPE, ZERO},
+  ast::hir::Operator,
+  ast::mir::{Binary, Expression, Statement, INT_TYPE, ZERO},
   Heap,
 };
 
@@ -102,7 +103,7 @@ pub(super) fn optimize(
       return Some(vec![Statement::Binary(Binary {
         name: *n,
         operator: Operator::PLUS,
-        e1: e.clone(),
+        e1: *e,
         e2: ZERO,
       })]);
     }
@@ -127,7 +128,7 @@ pub(super) fn optimize(
       Statement::Binary(Statement::binary_flexible_unwrapped(
         *break_collector.0,
         Operator::PLUS,
-        relevant_general_induction_variable.initial_value.clone(),
+        relevant_general_induction_variable.initial_value,
         Expression::var_name(increment_temporary, INT_TYPE),
       )),
     ])
@@ -137,7 +138,7 @@ pub(super) fn optimize(
     Some(vec![Statement::Binary(Binary {
       name: *break_collector.0,
       operator: Operator::PLUS,
-      e1: Expression::Variable(break_collector.2.clone()),
+      e1: Expression::Variable(*break_collector.2),
       e2: ZERO,
     })])
   }

--- a/crates/samlang-core/src/optimization/loop_strength_reduction.rs
+++ b/crates/samlang-core/src/optimization/loop_strength_reduction.rs
@@ -3,7 +3,8 @@ use super::loop_induction_analysis::{
   OptimizableWhileLoop,
 };
 use crate::{
-  ast::mir::{Expression, Operator, Statement, INT_TYPE},
+  ast::hir::Operator,
+  ast::mir::{Expression, Statement, INT_TYPE},
   Heap,
 };
 use std::collections::HashMap;
@@ -49,7 +50,7 @@ pub(super) fn optimize(
         new_initial_value_temp_temporary,
         Operator::MUL,
         derived_induction_variable.multiplier.to_expression(),
-        associated_basic_induction_variable.initial_value.clone(),
+        associated_basic_induction_variable.initial_value,
       )));
       prefix_statements.push(Statement::Binary(Statement::binary_flexible_unwrapped(
         new_initial_value_name,


### PR DESCRIPTION
It's the time to reintroduce HIR, as a prep step to perform enum representation optimization during generics specialization.

The above-mentioned optimization is not done yet. Instead, this commit focuses on getting the painful refactor done first.

Now that generics specialization transforms HIR into MIR, MIR no longer needs to be generic. This suddenly makes the MIR expression copyable, which leads to a serious of perf improvements. We are able to cut 40s of runtime out of 220s on 10k repeated runs.