### PR TITLE
[ast][compiler] Ban use of debug_string of HIR nodes in prod code

### DIFF
--- a/crates/samlang-core/src/ast/hir.rs
+++ b/crates/samlang-core/src/ast/hir.rs
@@ -6,13 +6,14 @@ use enum_as_inner::EnumAsInner;
 use itertools::Itertools;
 use std::{cmp::Ordering, hash::Hash};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct IdType {
   pub(crate) name: PStr,
   pub(crate) type_arguments: Vec<Type>,
 }
 
 impl IdType {
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     if self.type_arguments.is_empty() {
       self.name.as_str(heap).to_string()
@@ -26,13 +27,14 @@ impl IdType {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct FunctionType {
   pub(crate) argument_types: Vec<Type>,
   pub(crate) return_type: Box<Type>,
 }
 
 impl FunctionType {
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     format!(
       "({}) -> {}",
@@ -42,7 +44,7 @@ impl FunctionType {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, EnumAsInner)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, EnumAsInner)]
 pub(crate) enum Type {
   Int,
   Id(IdType),
@@ -69,6 +71,7 @@ impl Type {
     Type::Id(IdType { name, type_arguments: vec![] })
   }
 
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     match self {
       Type::Int => "int".to_string(),
@@ -97,6 +100,7 @@ fn name_with_tparams(heap: &Heap, identifier: PStr, tparams: &Vec<PStr>) -> Stri
 }
 
 impl ClosureTypeDefinition {
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     format!(
       "closure type {} = {}",
@@ -121,6 +125,7 @@ pub(crate) struct TypeDefinition {
 }
 
 impl TypeDefinition {
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     let id_part = name_with_tparams(heap, self.identifier, &self.type_parameters);
     match &self.mappings {
@@ -190,6 +195,7 @@ impl VariableName {
     VariableName { name, type_ }
   }
 
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     format!("({}: {})", self.name.as_str(heap), self.type_.pretty_print(heap))
   }
@@ -207,6 +213,7 @@ impl FunctionName {
     FunctionName { name, type_, type_arguments: vec![] }
   }
 
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     if self.type_arguments.is_empty() {
       self.name.as_str(heap).to_string()
@@ -278,19 +285,12 @@ impl Expression {
     }
   }
 
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     match self {
       Expression::IntLiteral(i) => i.to_string(),
       Expression::StringName(n) => n.as_str(heap).to_string(),
       Expression::Variable(v) => v.debug_print(heap),
-    }
-  }
-
-  pub(crate) fn dump_to_string(&self) -> String {
-    match self {
-      Expression::IntLiteral(i) => i.to_string(),
-      Expression::StringName(n) => n.debug_string(),
-      Expression::Variable(v) => v.name.debug_string(),
     }
   }
 
@@ -320,6 +320,7 @@ pub(crate) enum Callee {
 }
 
 impl Callee {
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     match self {
       Callee::FunctionName(f) => f.debug_print(heap),
@@ -337,6 +338,7 @@ pub(crate) struct GenenalLoopVariable {
 }
 
 impl GenenalLoopVariable {
+  #[cfg(test)]
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     format!(
       "{{name: {}, initial_value: {}, loop_value: {}}}",
@@ -486,6 +488,7 @@ impl Statement {
     }
   }
 
+  #[cfg(test)]
   fn debug_print_internal(
     &self,
     heap: &Heap,
@@ -663,12 +666,14 @@ impl Statement {
     }
   }
 
+  #[cfg(test)]
   fn debug_print_leveled(&self, heap: &Heap, level: usize) -> String {
     let mut collector = vec![];
     self.debug_print_internal(heap, level, &None, &mut collector);
     collector.join("").trim_end().to_string()
   }
 
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     self.debug_print_leveled(heap, 0)
   }
@@ -685,6 +690,7 @@ pub(crate) struct Function {
 }
 
 impl Function {
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     let typed_parameters = self
       .parameters
@@ -731,6 +737,7 @@ pub(crate) struct Sources {
 }
 
 impl Sources {
+  #[cfg(test)]
   pub(crate) fn debug_print(&self, heap: &Heap) -> String {
     let mut lines = vec![];
     for v in &self.global_variables {

--- a/crates/samlang-core/src/ast/hir_tests.rs
+++ b/crates/samlang-core/src/ast/hir_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
   use super::super::hir::*;
-  use crate::Heap;
+  use crate::{common::well_known_pstrs, Heap};
   use pretty_assertions::assert_eq;
   use std::{collections::hash_map::DefaultHasher, hash::Hash};
 
@@ -79,23 +79,42 @@ mod tests {
 
     assert!(
       Expression::var_name(
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
         Type::new_id(
-          heap.alloc_str_for_test("A"),
-          vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
         )
       ) == Expression::var_name(
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
         Type::new_id(
-          heap.alloc_str_for_test("A"),
-          vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
         )
       )
     );
+    assert!(Type::new_id_no_targs_unwrapped(well_known_pstrs::UPPER_B)
+      .cmp(&Type::new_id_no_targs_unwrapped(well_known_pstrs::UPPER_B))
+      .is_eq());
+    assert!(
+      Type::new_id_no_targs_unwrapped(well_known_pstrs::UPPER_B)
+        <= Type::new_id_no_targs_unwrapped(well_known_pstrs::UPPER_B)
+    );
+    assert!(Type::new_id_no_targs(well_known_pstrs::UPPER_B)
+      .cmp(&Type::new_id_no_targs(well_known_pstrs::UPPER_B))
+      .is_eq());
     assert!(
       FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
         == FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
     );
+    assert!(
+      FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
+        <= FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
+    );
+    assert!(FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
+      .cmp(&FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) })
+      .is_eq());
+    assert!(INT_TYPE <= INT_TYPE);
+    assert!(INT_TYPE.cmp(&INT_TYPE).eq(&std::cmp::Ordering::Equal));
     assert!(Expression::var_name(
       heap.alloc_str_for_test("a"),
       Type::new_id(
@@ -138,9 +157,6 @@ mod tests {
     assert_eq!("int", INT_TYPE.pretty_print(heap));
     assert_eq!("_Str", STRING_TYPE.pretty_print(heap));
     assert_eq!("0", ZERO.clone().debug_print(heap));
-    ZERO.dump_to_string();
-    Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).dump_to_string();
-    Expression::StringName(heap.alloc_str_for_test("a")).dump_to_string();
     assert_eq!(
       "(a: int)",
       Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).debug_print(heap)

--- a/crates/samlang-core/src/ast/lir.rs
+++ b/crates/samlang-core/src/ast/lir.rs
@@ -12,11 +12,11 @@ pub(crate) enum PrimitiveType {
   Any,
 }
 
-impl ToString for PrimitiveType {
-  fn to_string(&self) -> String {
+impl PrimitiveType {
+  fn as_str(&self) -> &'static str {
     match self {
-      PrimitiveType::Int => "number".to_string(),
-      PrimitiveType::Any => "any".to_string(),
+      PrimitiveType::Int => "number",
+      PrimitiveType::Any => "any",
     }
   }
 }
@@ -60,7 +60,7 @@ impl Type {
 
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
     match self {
-      Type::Primitive(t) => t.to_string(),
+      Type::Primitive(t) => t.as_str().to_string(),
       Type::Id(id) => id.as_str(heap).to_string(),
       Type::Fn(function) => function.pretty_print(heap),
     }

--- a/crates/samlang-core/src/compiler/hir_type_conversion.rs
+++ b/crates/samlang-core/src/compiler/hir_type_conversion.rs
@@ -24,8 +24,8 @@ pub(crate) struct SynthesizedTypes {
 pub(super) struct TypeSynthesizer {
   pub(super) synthesized_closure_types: BTreeMap<PStr, ClosureTypeDefinition>,
   pub(super) synthesized_tuple_types: BTreeMap<PStr, TypeDefinition>,
-  reverse_function_map: BTreeMap<String, PStr>,
-  reverse_tuple_map: BTreeMap<String, PStr>,
+  reverse_function_map: BTreeMap<(FunctionType, Vec<PStr>), PStr>,
+  reverse_tuple_map: BTreeMap<(Vec<Type>, Vec<PStr>), PStr>,
   next_id: i32,
 }
 
@@ -54,11 +54,7 @@ impl TypeSynthesizer {
     function_type: FunctionType,
     type_parameters: Vec<PStr>,
   ) -> ClosureTypeDefinition {
-    let key = format!(
-      "{}_{}",
-      function_type.pretty_print(heap),
-      type_parameters.iter().map(|it| it.as_str(heap)).join(",")
-    );
+    let key = (function_type.clone(), type_parameters.clone());
     if let Some(existing_identifier) = self.reverse_function_map.get(&key) {
       return self
         .synthesized_closure_types
@@ -80,11 +76,7 @@ impl TypeSynthesizer {
     mappings: Vec<Type>,
     type_parameters: Vec<PStr>,
   ) -> TypeDefinition {
-    let key = format!(
-      "{}_{}",
-      mappings.iter().map(|it| it.pretty_print(heap)).join(","),
-      type_parameters.iter().map(|it| it.as_str(heap)).join(",")
-    );
+    let key = (mappings.clone(), type_parameters.clone());
     if let Some(existing_identifier) = self.reverse_tuple_map.get(&key) {
       return self
         .synthesized_tuple_types


### PR DESCRIPTION
[ast][compiler] Ban use of debug_string of HIR nodes in prod code

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1009).
* #1011
* #1010
* __->__ #1009