### PR TITLE
[repo] Various cleanup

### DIFF
--- a/crates/samlang-core/src/ast/hir_tests.rs
+++ b/crates/samlang-core/src/ast/hir_tests.rs
@@ -13,10 +13,10 @@ mod tests {
     assert!(!format!(
       "{:?}",
       Expression::var_name(
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
         Type::new_id(
-          heap.alloc_str_for_test("A"),
-          vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
         )
       )
     )
@@ -24,48 +24,35 @@ mod tests {
     assert!(!format!(
       "{:?}",
       Expression::var_name(
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
         Type::new_id(
-          heap.alloc_str_for_test("A"),
-          vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
         )
       )
     )
     .is_empty());
-    assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a"))).is_empty());
+    assert!(!format!("{:?}", Expression::StringName(well_known_pstrs::LOWER_A)).is_empty());
     assert!(!format!("{:?}", Operator::GE).is_empty());
     assert!(Operator::MINUS <= Operator::GE);
     assert!(!format!("{:?}", Operator::MINUS.partial_cmp(&Operator::GE)).is_empty());
     assert!(!format!("{:?}", Operator::MINUS.cmp(&Operator::GE)).is_empty());
     assert!(!format!("{:?}", ZERO.type_()).is_empty());
-    assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a")).type_().as_id())
+    assert!(!format!("{:?}", Expression::StringName(well_known_pstrs::LOWER_A).type_().as_id())
       .is_empty());
-    assert!(Expression::StringName(heap.alloc_str_for_test("a")).type_().as_id().is_some());
+    assert!(Expression::StringName(well_known_pstrs::LOWER_A).type_().as_id().is_some());
     assert_eq!(
       "(s: int)",
       VariableName::new(heap.alloc_str_for_test("s"), INT_TYPE).debug_print(heap)
     );
-    assert!(!GenenalLoopVariable {
-      name: heap.alloc_str_for_test(""),
-      type_: INT_TYPE,
-      initial_value: ZERO,
-      loop_value: ZERO
-    }
-    .pretty_print(heap)
-    .is_empty());
     assert!(!format!("{:?}", Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE)).is_empty());
-    Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).type_();
-    Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).convert_to_callee();
-    Expression::StringName(heap.alloc_str_for_test("")).convert_to_callee();
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).type_();
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).convert_to_callee();
+    Expression::StringName(well_known_pstrs::LOWER_A).convert_to_callee();
     ZERO.convert_to_callee();
-    Statement::Break(ZERO).as_binary();
-    assert!(Statement::Break(ZERO).into_break().is_ok());
-    Statement::binary(heap.alloc_str_for_test("name"), Operator::DIV, ZERO, ZERO)
-      .clone()
-      .as_binary();
     let call = Statement::Call {
       callee: Callee::FunctionName(FunctionName {
-        name: heap.alloc_str_for_test(""),
+        name: well_known_pstrs::LOWER_A,
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         type_arguments: vec![INT_TYPE],
       }),
@@ -74,8 +61,6 @@ mod tests {
       return_collector: None,
     };
     assert!(!format!("{:?}", call).is_empty());
-    assert!(call.as_call().is_some());
-    assert!(call.into_break().is_err());
 
     assert!(
       Expression::var_name(
@@ -116,32 +101,31 @@ mod tests {
     assert!(INT_TYPE <= INT_TYPE);
     assert!(INT_TYPE.cmp(&INT_TYPE).eq(&std::cmp::Ordering::Equal));
     assert!(Expression::var_name(
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
       Type::new_id(
-        heap.alloc_str_for_test("A"),
-        vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+        well_known_pstrs::UPPER_A,
+        vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
       )
     )
     .eq(&Expression::var_name(
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
       Type::new_id(
-        heap.alloc_str_for_test("A"),
-        vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+        well_known_pstrs::UPPER_A,
+        vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
       )
     )));
     assert!(Type::new_id(
-      heap.alloc_str_for_test("A"),
-      vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+      well_known_pstrs::UPPER_A,
+      vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
     )
     .eq(
       &(Type::new_id(
-        heap.alloc_str_for_test("A"),
-        vec![INT_TYPE, Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+        well_known_pstrs::UPPER_A,
+        vec![INT_TYPE, Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
       ))
     ));
     let mut hasher = DefaultHasher::new();
     Operator::DIV.hash(&mut hasher);
-    Statement::binary_flexible_unwrapped(heap.alloc_str_for_test(""), Operator::DIV, ZERO, ZERO);
     Callee::FunctionName(FunctionName::new(
       heap.alloc_str_for_test("s"),
       FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) },
@@ -159,15 +143,15 @@ mod tests {
     assert_eq!("0", ZERO.clone().debug_print(heap));
     assert_eq!(
       "(a: int)",
-      Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).debug_print(heap)
+      Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).debug_print(heap)
     );
     assert_eq!(
       "(a: A<int, B>)",
       Expression::var_name(
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
         Type::new_id(
-          heap.alloc_str_for_test("A"),
-          vec![INT_TYPE, (Type::new_id_no_targs(heap.alloc_str_for_test("B")))]
+          well_known_pstrs::UPPER_A,
+          vec![INT_TYPE, (Type::new_id_no_targs(well_known_pstrs::UPPER_B))]
         )
       )
       .clone()
@@ -176,12 +160,12 @@ mod tests {
     assert_eq!(
       "(a: A<int>)",
       Expression::var_name(
-        heap.alloc_str_for_test("a"),
-        Type::new_id(heap.alloc_str_for_test("A"), vec![(INT_TYPE)])
+        well_known_pstrs::LOWER_A,
+        Type::new_id(well_known_pstrs::UPPER_A, vec![(INT_TYPE)])
       )
       .debug_print(heap)
     );
-    assert_eq!("a", Expression::StringName(heap.alloc_str_for_test("a")).clone().debug_print(heap));
+    assert_eq!("a", Expression::StringName(well_known_pstrs::LOWER_A).clone().debug_print(heap));
   }
 
   #[test]
@@ -191,7 +175,7 @@ mod tests {
     assert_eq!(
       "object type A = [int, int]",
       TypeDefinition {
-        identifier: heap.alloc_str_for_test("A"),
+        identifier: well_known_pstrs::UPPER_A,
         type_parameters: vec![],
         names: vec![],
         mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, INT_TYPE]),
@@ -201,8 +185,8 @@ mod tests {
     assert_eq!(
       "variant type B<C>",
       TypeDefinition {
-        identifier: heap.alloc_str_for_test("B"),
-        type_parameters: vec![heap.alloc_str_for_test("C")],
+        identifier: well_known_pstrs::UPPER_B,
+        type_parameters: vec![well_known_pstrs::UPPER_C],
         names: vec![],
         mappings: TypeDefinitionMappings::Enum,
       }
@@ -231,17 +215,72 @@ mod tests {
           ),
           context: ZERO,
         },
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::LT, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::LE, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::GT, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::GE, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::EQ, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::NE, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::LAND, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::LOR, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::SHL, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::SHR, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::XOR.clone(), ZERO, ZERO),
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::LT,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::LE,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::GT,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::GE,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::EQ,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::NE,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::LAND,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::LOR,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::SHL,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::SHR,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::XOR.clone(),
+          e1: ZERO,
+          e2: ZERO,
+        },
         Statement::Cast {
           name: heap.alloc_str_for_test("cast"),
           type_: INT_TYPE,
@@ -275,17 +314,42 @@ mod tests {
         },
       ],
       s2: vec![
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::PLUS, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::MINUS, ZERO, ZERO),
-        Statement::binary(
-          heap.alloc_str_for_test("dd"),
-          Operator::MINUS,
-          ZERO,
-          Expression::int(-2147483648),
-        ),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::MUL, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::DIV, ZERO, ZERO),
-        Statement::binary(heap.alloc_str_for_test("dd"), Operator::MOD, ZERO, ZERO),
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::PLUS,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::MINUS,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::MINUS,
+          e1: ZERO,
+          e2: Expression::int(-2147483648),
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::MUL,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::DIV,
+          e1: ZERO,
+          e2: ZERO,
+        },
+        Statement::Binary {
+          name: heap.alloc_str_for_test("dd"),
+          operator: Operator::MOD,
+          e1: ZERO,
+          e2: ZERO,
+        },
         Statement::Call {
           callee: Callee::FunctionName(FunctionName::new(
             heap.alloc_str_for_test("h"),
@@ -304,21 +368,21 @@ mod tests {
             type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
             type_arguments: vec![INT_TYPE],
           }),
-          arguments: vec![Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE)],
+          arguments: vec![Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::Call {
           callee: Callee::Variable(VariableName {
-            name: heap.alloc_str_for_test("d"),
+            name: well_known_pstrs::LOWER_D,
             type_: INT_TYPE,
           }),
-          arguments: vec![Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE)],
+          arguments: vec![Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
             heap.alloc_str_for_test("big"),
@@ -368,7 +432,7 @@ if 0 {
   bar = (b1: int);
 } else {
   let dd = 0 + 0;
-  let dd = 0 + 0;
+  let dd = 0 - 0;
   let dd = 0 - -2147483648;
   let dd = 0 * 0;
   let dd = 0 / 0;
@@ -395,7 +459,7 @@ if 0 {
       }
       .clone()],
       closure_types: vec![ClosureTypeDefinition {
-        identifier: heap.alloc_str_for_test("c"),
+        identifier: well_known_pstrs::LOWER_C,
         type_parameters: vec![],
         function_type: Type::new_fn_unwrapped(vec![], INT_TYPE),
       }
@@ -410,11 +474,11 @@ if 0 {
       main_function_names: vec![heap.alloc_str_for_test("ddd")],
       functions: vec![Function {
         name: heap.alloc_str_for_test("Bar"),
-        parameters: vec![heap.alloc_str_for_test("f")],
+        parameters: vec![well_known_pstrs::LOWER_F],
         type_parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
             heap.alloc_str_for_test("big"),
@@ -446,8 +510,8 @@ sources.mains = [ddd]"#;
       main_function_names: vec![],
       functions: vec![Function {
         name: heap.alloc_str_for_test("Bar"),
-        parameters: vec![heap.alloc_str_for_test("f")],
-        type_parameters: vec![heap.alloc_str_for_test("A")],
+        parameters: vec![well_known_pstrs::LOWER_F],
+        type_parameters: vec![well_known_pstrs::UPPER_A],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![],
         return_value: ZERO,
@@ -458,140 +522,5 @@ sources.mains = [ddd]"#;
 }
 "#;
     assert_eq!(expected2, sources2.debug_print(heap));
-  }
-
-  #[test]
-  fn flexible_order_binary_tests() {
-    let heap = &mut Heap::new();
-
-    assert_eq!(
-      (Operator::PLUS, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::PLUS, ZERO, ONE)
-    );
-    assert_eq!(
-      (Operator::PLUS, ZERO, ZERO),
-      Statement::flexible_order_binary(Operator::PLUS, ZERO, ZERO)
-    );
-    assert_eq!(
-      (Operator::PLUS, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::PLUS, ONE, ZERO)
-    );
-    assert_eq!(
-      (Operator::PLUS, Expression::StringName(heap.alloc_str_for_test("")), ZERO),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        ZERO,
-        Expression::StringName(heap.alloc_str_for_test(""))
-      ),
-    );
-    assert_eq!(
-      (Operator::PLUS, Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE), ZERO),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        ZERO,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE)
-      ),
-    );
-
-    let a = heap.alloc_str_for_test("a");
-    let b = heap.alloc_str_for_test("b");
-    assert_eq!(
-      (Operator::PLUS, Expression::StringName(b), Expression::StringName(a),),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::StringName(a),
-        Expression::StringName(b),
-      ),
-    );
-    assert_eq!(
-      (Operator::PLUS, Expression::StringName(heap.alloc_str_for_test("b")), ZERO),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::StringName(heap.alloc_str_for_test("b")),
-        ZERO
-      ),
-    );
-    assert_eq!(
-      (
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("")),
-      ),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::StringName(heap.alloc_str_for_test("")),
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
-      ),
-    );
-
-    assert_eq!(
-      (Operator::PLUS, Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE), ZERO),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
-        ZERO
-      ),
-    );
-    assert_eq!(
-      (
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("b")),
-      ),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("b")),
-      ),
-    );
-    assert_eq!(
-      (
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-      ),
-      Statement::flexible_order_binary(
-        Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
-      ),
-    );
-
-    assert_eq!(
-      (Operator::GT, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::LT, ZERO, ONE)
-    );
-    assert_eq!(
-      (Operator::LT, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::LT, ONE, ZERO)
-    );
-    assert_eq!(
-      (Operator::LE, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::LE, ONE, ZERO)
-    );
-    assert_eq!(
-      (Operator::GE, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::LE, ZERO, ONE)
-    );
-    assert_eq!(
-      (Operator::LT, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::GT, ZERO, ONE)
-    );
-    assert_eq!(
-      (Operator::GT, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::GT, ONE, ZERO)
-    );
-    assert_eq!(
-      (Operator::LE, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::GE, ZERO, ONE)
-    );
-    assert_eq!(
-      (Operator::GE, ONE, ZERO),
-      Statement::flexible_order_binary(Operator::GE, ONE, ZERO)
-    );
-    assert_eq!(
-      (Operator::DIV, ZERO, ONE),
-      Statement::flexible_order_binary(Operator::DIV, ZERO, ONE)
-    );
   }
 }

--- a/crates/samlang-core/src/ast/lir_tests.rs
+++ b/crates/samlang-core/src/ast/lir_tests.rs
@@ -6,39 +6,38 @@ mod tests {
       common_names,
       hir::{GlobalVariable, Operator},
     },
+    common::well_known_pstrs,
     Heap,
   };
   use pretty_assertions::assert_eq;
 
   #[test]
   fn boilterplate() {
-    let heap = &mut Heap::new();
-
     assert!(PrimitiveType::Int.eq(&PrimitiveType::Int));
     assert!(STRING_TYPE.as_fn().is_none());
     assert!(ZERO.as_name().is_none());
 
     assert!(!format!(
       "{:?}",
-      Expression::Variable(heap.alloc_str_for_test("a"), Type::Id(heap.alloc_str_for_test("A")))
-        .clone()
+      Expression::Variable(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A)).clone()
     )
     .is_empty());
-    assert!(!format!("{:?}", Expression::Name(heap.alloc_str_for_test("a"), STRING_TYPE).clone())
-      .is_empty());
+    assert!(
+      !format!("{:?}", Expression::Name(well_known_pstrs::LOWER_A, STRING_TYPE).clone()).is_empty()
+    );
     assert!(!format!("{:?}", Type::new_fn(vec![(INT_TYPE)], INT_TYPE).clone()).is_empty());
   }
 
   #[test]
   fn type_eq_test() {
-    let heap = &mut Heap::new();
-
-    assert!(INT_TYPE
-      .is_the_same_type(Expression::Variable(heap.alloc_str_for_test("a"), INT_TYPE).type_()));
+    assert!(
+      INT_TYPE.is_the_same_type(Expression::Variable(well_known_pstrs::LOWER_A, INT_TYPE).type_())
+    );
     assert!(STRING_TYPE.is_the_same_type(Expression::IntLiteral(1, STRING_TYPE).type_()));
-    assert!(!Type::Id(heap.alloc_str_for_test("a"))
-      .is_the_same_type(&Type::Id(heap.alloc_str_for_test("b"))));
-    assert!(!Type::Id(heap.alloc_str_for_test("a")).is_the_same_type(&INT_TYPE));
+    assert!(
+      !Type::Id(well_known_pstrs::LOWER_A).is_the_same_type(&Type::Id(well_known_pstrs::LOWER_B))
+    );
+    assert!(!Type::Id(well_known_pstrs::LOWER_A).is_the_same_type(&INT_TYPE));
     assert!(Type::new_fn(vec![(INT_TYPE)], INT_TYPE)
       .is_the_same_type(&Type::new_fn(vec![(INT_TYPE)], INT_TYPE)));
   }
@@ -53,9 +52,9 @@ mod tests {
     assert_eq!("0", ZERO.clone().pretty_print(heap));
     assert_eq!(
       "a",
-      Expression::Variable(heap.alloc_str_for_test("a"), STRING_TYPE).pretty_print(heap)
+      Expression::Variable(well_known_pstrs::LOWER_A, STRING_TYPE).pretty_print(heap)
     );
-    assert_eq!("a", Expression::Name(heap.alloc_str_for_test("a"), STRING_TYPE).pretty_print(heap));
+    assert_eq!("a", Expression::Name(well_known_pstrs::LOWER_A, STRING_TYPE).pretty_print(heap));
     assert_eq!(
       "(t0: number) => number",
       Type::new_fn(vec![(INT_TYPE)], INT_TYPE).pretty_print(heap)
@@ -131,18 +130,18 @@ mod tests {
             heap.alloc_str_for_test("stresso"),
             Type::new_fn(vec![], INT_TYPE),
           ),
-          arguments: vec![Expression::Variable(heap.alloc_str_for_test("d"), INT_TYPE)],
+          arguments: vec![Expression::Variable(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::Call {
-          callee: Expression::Variable(heap.alloc_str_for_test("d"), INT_TYPE),
-          arguments: vec![Expression::Variable(heap.alloc_str_for_test("d"), INT_TYPE)],
+          callee: Expression::Variable(well_known_pstrs::LOWER_D, INT_TYPE),
+          arguments: vec![Expression::Variable(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::Variable(
             heap.alloc_str_for_test("big"),
@@ -152,7 +151,7 @@ mod tests {
         },
         Statement::IndexedAssign { assigned_expression: ZERO, pointer_expression: ZERO, index: 0 },
         Statement::Cast {
-          name: heap.alloc_str_for_test("c"),
+          name: well_known_pstrs::LOWER_C,
           type_: INT_TYPE,
           assigned_expression: ZERO,
         },
@@ -166,7 +165,7 @@ mod tests {
       )],
     };
     let f = Function {
-      name: heap.alloc_str_for_test("f"),
+      name: well_known_pstrs::LOWER_F,
       parameters: vec![heap.alloc_str_for_test("v1")],
       type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
       body: vec![stmt],
@@ -241,10 +240,10 @@ mod tests {
       main_function_names: vec![],
       functions: vec![Function {
         name: heap.alloc_str_for_test("Bar"),
-        parameters: vec![heap.alloc_str_for_test("f")],
+        parameters: vec![well_known_pstrs::LOWER_F],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::Variable(
             heap.alloc_str_for_test("big"),

--- a/crates/samlang-core/src/ast/mir_tests.rs
+++ b/crates/samlang-core/src/ast/mir_tests.rs
@@ -3,6 +3,7 @@ mod tests {
   use super::super::mir::*;
   use crate::{
     ast::hir::{GlobalVariable, Operator},
+    common::well_known_pstrs,
     Heap,
   };
   use pretty_assertions::assert_eq;
@@ -17,25 +18,25 @@ mod tests {
     assert!(ZERO.as_int_literal().is_some());
     assert!(!format!(
       "{:?}",
-      Expression::var_name(heap.alloc_str_for_test("a"), Type::Id(heap.alloc_str_for_test("A"),))
+      Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A,))
     )
     .is_empty());
     assert!(!format!(
       "{:?}",
-      Expression::var_name(heap.alloc_str_for_test("a"), Type::Id(heap.alloc_str_for_test("A"),))
+      Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A,))
     )
     .is_empty());
-    assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a"))).is_empty());
+    assert!(!format!("{:?}", Expression::StringName(well_known_pstrs::LOWER_A)).is_empty());
     assert!(!format!("{:?}", ZERO.type_()).is_empty());
-    assert!(!format!("{:?}", Expression::StringName(heap.alloc_str_for_test("a")).type_().as_id())
+    assert!(!format!("{:?}", Expression::StringName(well_known_pstrs::LOWER_A).type_().as_id())
       .is_empty());
-    assert!(Expression::StringName(heap.alloc_str_for_test("a")).type_().as_id().is_some());
+    assert!(Expression::StringName(well_known_pstrs::LOWER_A).type_().as_id().is_some());
     assert_eq!(
       "(s: int)",
       VariableName::new(heap.alloc_str_for_test("s"), INT_TYPE).debug_print(heap)
     );
     assert!(!GenenalLoopVariable {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       type_: INT_TYPE,
       initial_value: ZERO,
       loop_value: ZERO
@@ -43,9 +44,9 @@ mod tests {
     .pretty_print(heap)
     .is_empty());
     assert!(!format!("{:?}", Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE)).is_empty());
-    Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).type_();
-    Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).convert_to_callee();
-    Expression::StringName(heap.alloc_str_for_test("")).convert_to_callee();
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).type_();
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).convert_to_callee();
+    Expression::StringName(well_known_pstrs::LOWER_A).convert_to_callee();
     ZERO.convert_to_callee();
     Statement::Break(ZERO).as_binary();
     assert!(Statement::Break(ZERO).into_break().is_ok());
@@ -54,7 +55,7 @@ mod tests {
       .as_binary();
     let call = Statement::Call {
       callee: Callee::FunctionName(FunctionName {
-        name: heap.alloc_str_for_test(""),
+        name: well_known_pstrs::LOWER_A,
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       }),
       arguments: vec![],
@@ -66,11 +67,8 @@ mod tests {
     assert!(call.into_break().is_err());
 
     assert!(
-      Expression::var_name(heap.alloc_str_for_test("a"), Type::Id(heap.alloc_str_for_test("A"),))
-        == Expression::var_name(
-          heap.alloc_str_for_test("a"),
-          Type::Id(heap.alloc_str_for_test("A"),)
-        )
+      Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A,))
+        == Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A,))
     );
     assert!(
       FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) }
@@ -78,10 +76,10 @@ mod tests {
     );
     let mut hasher = DefaultHasher::new();
     ZERO.hash(&mut hasher);
-    Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE).hash(&mut hasher);
-    Expression::var_name(heap.alloc_str_for_test(""), Type::Id(heap.alloc_str_for_test("")))
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).hash(&mut hasher);
+    Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::LOWER_A))
       .hash(&mut hasher);
-    Statement::binary_flexible_unwrapped(heap.alloc_str_for_test(""), Operator::DIV, ZERO, ZERO);
+    Statement::binary_flexible_unwrapped(well_known_pstrs::LOWER_A, Operator::DIV, ZERO, ZERO);
     Callee::FunctionName(FunctionName::new(
       heap.alloc_str_for_test("s"),
       FunctionType { argument_types: vec![], return_type: Box::new(INT_TYPE) },
@@ -98,18 +96,18 @@ mod tests {
     assert_eq!("_Str", STRING_TYPE.pretty_print(heap));
     assert_eq!("0", ZERO.clone().debug_print(heap));
     ZERO.dump_to_string();
-    Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).dump_to_string();
-    Expression::StringName(heap.alloc_str_for_test("a")).dump_to_string();
+    Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).dump_to_string();
+    Expression::StringName(well_known_pstrs::LOWER_A).dump_to_string();
     assert_eq!(
       "(a: int)",
-      Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE).debug_print(heap)
+      Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE).debug_print(heap)
     );
     assert_eq!(
       "(a: A)",
-      Expression::var_name(heap.alloc_str_for_test("a"), Type::Id(heap.alloc_str_for_test("A")))
+      Expression::var_name(well_known_pstrs::LOWER_A, Type::Id(well_known_pstrs::UPPER_A))
         .debug_print(heap)
     );
-    assert_eq!("a", Expression::StringName(heap.alloc_str_for_test("a")).clone().debug_print(heap));
+    assert_eq!("a", Expression::StringName(well_known_pstrs::LOWER_A).clone().debug_print(heap));
   }
 
   #[test]
@@ -119,7 +117,7 @@ mod tests {
     assert_eq!(
       "object type A = [int, int]",
       TypeDefinition {
-        identifier: heap.alloc_str_for_test("A"),
+        identifier: well_known_pstrs::UPPER_A,
         names: vec![],
         mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, INT_TYPE]),
       }
@@ -128,7 +126,7 @@ mod tests {
     assert_eq!(
       "variant type B",
       TypeDefinition {
-        identifier: heap.alloc_str_for_test("B"),
+        identifier: well_known_pstrs::UPPER_B,
         names: vec![],
         mappings: TypeDefinitionMappings::Enum,
       }
@@ -229,21 +227,21 @@ mod tests {
             name: heap.alloc_str_for_test("stresso"),
             type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
           }),
-          arguments: vec![Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE)],
+          arguments: vec![Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::Call {
           callee: Callee::Variable(VariableName {
-            name: heap.alloc_str_for_test("d"),
+            name: well_known_pstrs::LOWER_D,
             type_: INT_TYPE,
           }),
-          arguments: vec![Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE)],
+          arguments: vec![Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         },
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
             heap.alloc_str_for_test("big"),
@@ -320,7 +318,7 @@ if 0 {
       }
       .clone()],
       closure_types: vec![ClosureTypeDefinition {
-        identifier: heap.alloc_str_for_test("c"),
+        identifier: well_known_pstrs::LOWER_C,
         function_type: Type::new_fn_unwrapped(vec![], INT_TYPE),
       }
       .clone()],
@@ -333,10 +331,10 @@ if 0 {
       main_function_names: vec![heap.alloc_str_for_test("ddd")],
       functions: vec![Function {
         name: heap.alloc_str_for_test("Bar"),
-        parameters: vec![heap.alloc_str_for_test("f")],
+        parameters: vec![well_known_pstrs::LOWER_F],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("f"),
+          name: well_known_pstrs::LOWER_F,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
             heap.alloc_str_for_test("big"),
@@ -368,7 +366,7 @@ sources.mains = [ddd]"#;
       main_function_names: vec![],
       functions: vec![Function {
         name: heap.alloc_str_for_test("Bar"),
-        parameters: vec![heap.alloc_str_for_test("f")],
+        parameters: vec![well_known_pstrs::LOWER_F],
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![],
         return_value: ZERO,
@@ -383,8 +381,6 @@ sources.mains = [ddd]"#;
 
   #[test]
   fn flexible_order_binary_tests() {
-    let heap = &mut Heap::new();
-
     assert_eq!(
       (Operator::PLUS, ONE, ZERO),
       Statement::flexible_order_binary(Operator::PLUS, ZERO, ONE)
@@ -398,24 +394,24 @@ sources.mains = [ddd]"#;
       Statement::flexible_order_binary(Operator::PLUS, ONE, ZERO)
     );
     assert_eq!(
-      (Operator::PLUS, Expression::StringName(heap.alloc_str_for_test("")), ZERO),
+      (Operator::PLUS, Expression::StringName(well_known_pstrs::LOWER_A), ZERO),
       Statement::flexible_order_binary(
         Operator::PLUS,
         ZERO,
-        Expression::StringName(heap.alloc_str_for_test(""))
+        Expression::StringName(well_known_pstrs::LOWER_A)
       ),
     );
     assert_eq!(
-      (Operator::PLUS, Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE), ZERO),
+      (Operator::PLUS, Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE), ZERO),
       Statement::flexible_order_binary(
         Operator::PLUS,
         ZERO,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE)
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)
       ),
     );
 
-    let a = heap.alloc_str_for_test("a");
-    let b = heap.alloc_str_for_test("b");
+    let a = well_known_pstrs::LOWER_A;
+    let b = well_known_pstrs::LOWER_B;
     assert_eq!(
       (Operator::PLUS, Expression::StringName(b), Expression::StringName(a),),
       Statement::flexible_order_binary(
@@ -425,56 +421,56 @@ sources.mains = [ddd]"#;
       ),
     );
     assert_eq!(
-      (Operator::PLUS, Expression::StringName(heap.alloc_str_for_test("b")), ZERO),
+      (Operator::PLUS, Expression::StringName(well_known_pstrs::LOWER_B), ZERO),
       Statement::flexible_order_binary(
         Operator::PLUS,
-        Expression::StringName(heap.alloc_str_for_test("b")),
+        Expression::StringName(well_known_pstrs::LOWER_B),
         ZERO
       ),
     );
     assert_eq!(
       (
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("")),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+        Expression::StringName(well_known_pstrs::LOWER_A),
       ),
       Statement::flexible_order_binary(
         Operator::PLUS,
-        Expression::StringName(heap.alloc_str_for_test("")),
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        Expression::StringName(well_known_pstrs::LOWER_A),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       ),
     );
 
     assert_eq!(
-      (Operator::PLUS, Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE), ZERO),
+      (Operator::PLUS, Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE), ZERO),
       Statement::flexible_order_binary(
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
         ZERO
       ),
     );
     assert_eq!(
       (
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("b")),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+        Expression::StringName(well_known_pstrs::LOWER_B),
       ),
       Statement::flexible_order_binary(
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::StringName(heap.alloc_str_for_test("b")),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+        Expression::StringName(well_known_pstrs::LOWER_B),
       ),
     );
     assert_eq!(
       (
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+        Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       ),
       Statement::flexible_order_binary(
         Operator::PLUS,
-        Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-        Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+        Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+        Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
       ),
     );
 

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -2,6 +2,7 @@
 mod tests {
   use super::super::source::expr::*;
   use super::super::source::*;
+  use crate::common::well_known_pstrs;
   use crate::{ast::loc::Location, common::Heap, common::ModuleReference};
   use itertools::Itertools;
   use std::collections::HashMap;
@@ -281,7 +282,7 @@ mod tests {
     assert!(InterfaceDeclaration {
       loc: Location::dummy(),
       associated_comments: NO_COMMENT_REFERENCE,
-      name: Id::from(heap.alloc_str_for_test("")),
+      name: Id::from(well_known_pstrs::LOWER_A),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
       type_definition: (),
@@ -290,11 +291,11 @@ mod tests {
         associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: true,
-        name: Id::from(heap.alloc_str_for_test("")),
+        name: Id::from(well_known_pstrs::LOWER_A),
         type_parameters: Rc::new(vec![]),
         type_: builder.fn_annot_unwrapped(vec![], builder.int_annot()),
         parameters: Rc::new(vec![AnnotatedId {
-          name: Id::from(heap.alloc_str_for_test("")),
+          name: Id::from(well_known_pstrs::LOWER_A),
           type_: (),
           annotation: builder.int_annot()
         }])
@@ -331,23 +332,23 @@ mod tests {
     assert!(enum_type_def.clone().eq(&enum_type_def));
 
     assert!(AnnotatedId {
-      name: Id::from(heap.alloc_str_for_test("")),
+      name: Id::from(well_known_pstrs::LOWER_A),
       type_: (),
       annotation: builder.int_annot(),
     }
     .eq(&AnnotatedId {
-      name: Id::from(heap.alloc_str_for_test("")),
+      name: Id::from(well_known_pstrs::LOWER_A),
       type_: (),
       annotation: builder.int_annot(),
     }));
     assert!(TypeParameter {
       loc: Location::dummy(),
-      name: Id::from(heap.alloc_str_for_test("")),
+      name: Id::from(well_known_pstrs::LOWER_A),
       bound: None,
     }
     .eq(&TypeParameter {
       loc: Location::dummy(),
-      name: Id::from(heap.alloc_str_for_test("")),
+      name: Id::from(well_known_pstrs::LOWER_A),
       bound: None,
     }));
 
@@ -371,7 +372,7 @@ mod tests {
           associated_comments: NO_COMMENT_REFERENCE,
           is_public: true,
           is_method: true,
-          name: Id::from(heap.alloc_str_for_test("")),
+          name: Id::from(well_known_pstrs::LOWER_A),
           type_parameters: Rc::new(vec![]),
           type_: builder.fn_annot_unwrapped(vec![], builder.int_annot()),
           parameters: Rc::new(vec![]),
@@ -396,7 +397,7 @@ mod tests {
         associated_comments: NO_COMMENT_REFERENCE,
         is_public: true,
         is_method: true,
-        name: Id::from(heap.alloc_str_for_test("")),
+        name: Id::from(well_known_pstrs::LOWER_A),
         type_parameters: Rc::new(vec![]),
         type_: builder.fn_annot_unwrapped(vec![], builder.int_annot()),
         parameters: Rc::new(vec![]),

--- a/crates/samlang-core/src/ast/wasm_tests.rs
+++ b/crates/samlang-core/src/ast/wasm_tests.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod tests {
   use super::super::wasm::*;
-  use crate::{ast::hir::Operator, common::Heap};
+  use crate::{
+    ast::hir::Operator,
+    common::{well_known_pstrs, Heap},
+  };
   use pretty_assertions::assert_eq;
 
   #[test]
@@ -17,17 +20,17 @@ mod tests {
       exported_functions: vec![heap.alloc_str_for_test("main")],
       functions: vec![Function {
         name: heap.alloc_str_for_test("main"),
-        parameters: vec![heap.alloc_str_for_test("a"), heap.alloc_str_for_test("b")],
-        local_variables: vec![heap.alloc_str_for_test("c"), heap.alloc_str_for_test("d")],
+        parameters: vec![well_known_pstrs::LOWER_A, well_known_pstrs::LOWER_B],
+        local_variables: vec![well_known_pstrs::LOWER_C, well_known_pstrs::LOWER_D],
         instructions: vec![
           Instruction::IfElse {
             condition: InlineInstruction::Const(1),
             s1: vec![
               Instruction::Inline(InlineInstruction::Const(1)),
               Instruction::Inline(InlineInstruction::Drop(Box::new(InlineInstruction::Const(0)))),
-              Instruction::Inline(InlineInstruction::LocalGet(heap.alloc_str_for_test("a"))),
+              Instruction::Inline(InlineInstruction::LocalGet(well_known_pstrs::LOWER_A)),
               Instruction::Inline(InlineInstruction::LocalSet(
-                heap.alloc_str_for_test("b"),
+                well_known_pstrs::LOWER_B,
                 Box::new(InlineInstruction::Const(0)),
               )),
             ],

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -129,12 +129,12 @@ mod tests {
                     MemberSignature {
                       is_public: false,
                       type_parameters: vec![TypeParameterSignature {
-                        name: heap.alloc_str_for_test("A"),
+                        name: well_known_pstrs::UPPER_A,
                         bound: None,
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("A"))],
+                        argument_types: vec![builder.generic_type(well_known_pstrs::UPPER_A)],
                         return_type: builder.unit_type(),
                       },
                     },
@@ -144,19 +144,19 @@ mod tests {
                     MemberSignature {
                       is_public: false,
                       type_parameters: vec![
-                        TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-                        TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
-                        TypeParameterSignature { name: heap.alloc_str_for_test("C"), bound: None },
-                        TypeParameterSignature { name: heap.alloc_str_for_test("D"), bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_C, bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_D, bound: None },
                       ],
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![
-                          builder.generic_type(heap.alloc_str_for_test("A")),
-                          builder.generic_type(heap.alloc_str_for_test("B")),
-                          builder.generic_type(heap.alloc_str_for_test("C")),
+                          builder.generic_type(well_known_pstrs::UPPER_A),
+                          builder.generic_type(well_known_pstrs::UPPER_B),
+                          builder.generic_type(well_known_pstrs::UPPER_C),
                         ],
-                        return_type: builder.generic_type(heap.alloc_str_for_test("D")),
+                        return_type: builder.generic_type(well_known_pstrs::UPPER_D),
                       },
                     },
                   ),
@@ -183,14 +183,14 @@ mod tests {
                     MemberSignature {
                       is_public: false,
                       type_parameters: vec![
-                        TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-                        TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+                        TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
                       ],
                       type_: FunctionType {
                         reason: Reason::dummy(),
                         argument_types: vec![builder.fun_type(
-                          vec![builder.generic_type(heap.alloc_str_for_test("A"))],
-                          builder.generic_type(heap.alloc_str_for_test("B")),
+                          vec![builder.generic_type(well_known_pstrs::UPPER_A)],
+                          builder.generic_type(well_known_pstrs::UPPER_B),
                         )],
                         return_type: builder.bool_type(),
                       },
@@ -230,7 +230,7 @@ mod tests {
                     MemberSignature {
                       is_public: false,
                       type_parameters: vec![TypeParameterSignature {
-                        name: heap.alloc_str_for_test("A"),
+                        name: well_known_pstrs::UPPER_A,
                         bound: None,
                       }],
                       type_: FunctionType {
@@ -245,12 +245,12 @@ mod tests {
                     MemberSignature {
                       is_public: false,
                       type_parameters: vec![TypeParameterSignature {
-                        name: heap.alloc_str_for_test("A"),
+                        name: well_known_pstrs::UPPER_A,
                         bound: None,
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("A"))],
+                        argument_types: vec![builder.generic_type(well_known_pstrs::UPPER_A)],
                         return_type: builder.bool_type(),
                       },
                     },
@@ -308,13 +308,13 @@ mod tests {
               heap.alloc_str_for_test("Test3"),
               InterfaceSignature {
                 type_parameters: vec![TypeParameterSignature {
-                  name: heap.alloc_str_for_test("E"),
+                  name: well_known_pstrs::UPPER_E,
                   bound: None,
                 }],
                 type_definition: Some(TypeDefinitionSignature::Struct(vec![
                   StructItemDefinitionSignature {
                     name: heap.alloc_str_for_test("foo"),
-                    type_: builder.generic_type(heap.alloc_str_for_test("E")),
+                    type_: builder.generic_type(well_known_pstrs::UPPER_E),
                     is_public: true,
                   },
                   StructItemDefinitionSignature {
@@ -332,13 +332,13 @@ mod tests {
               heap.alloc_str_for_test("Test4"),
               InterfaceSignature {
                 type_parameters: vec![TypeParameterSignature {
-                  name: heap.alloc_str_for_test("E"),
+                  name: well_known_pstrs::UPPER_E,
                   bound: None,
                 }],
                 type_definition: Some(TypeDefinitionSignature::Enum(vec![
                   EnumVariantDefinitionSignature {
                     name: heap.alloc_str_for_test("Foo"),
-                    types: vec![builder.generic_type(heap.alloc_str_for_test("E"))],
+                    types: vec![builder.generic_type(well_known_pstrs::UPPER_E)],
                   },
                   EnumVariantDefinitionSignature {
                     name: heap.alloc_str_for_test("Bar"),
@@ -351,15 +351,15 @@ mod tests {
                     MemberSignature {
                       is_public: true,
                       type_parameters: vec![TypeParameterSignature {
-                        name: heap.alloc_str_for_test("E"),
+                        name: well_known_pstrs::UPPER_E,
                         bound: None,
                       }],
                       type_: FunctionType {
                         reason: Reason::dummy(),
-                        argument_types: vec![builder.generic_type(heap.alloc_str_for_test("E"))],
+                        argument_types: vec![builder.generic_type(well_known_pstrs::UPPER_E)],
                         return_type: builder.general_nominal_type(
                           heap.alloc_str_for_test("Test4"),
-                          vec![builder.generic_type(heap.alloc_str_for_test("E"))],
+                          vec![builder.generic_type(well_known_pstrs::UPPER_E)],
                         ),
                       },
                     },
@@ -369,7 +369,7 @@ mod tests {
                     MemberSignature {
                       is_public: true,
                       type_parameters: vec![TypeParameterSignature {
-                        name: heap.alloc_str_for_test("E"),
+                        name: well_known_pstrs::UPPER_E,
                         bound: None,
                       }],
                       type_: FunctionType {
@@ -377,7 +377,7 @@ mod tests {
                         argument_types: vec![builder.int_type()],
                         return_type: builder.general_nominal_type(
                           heap.alloc_str_for_test("Test4"),
-                          vec![builder.generic_type(heap.alloc_str_for_test("E"))],
+                          vec![builder.generic_type(well_known_pstrs::UPPER_E)],
                         ),
                       },
                     },
@@ -388,39 +388,7 @@ mod tests {
               },
             ),
             (
-              heap.alloc_str_for_test("A"),
-              InterfaceSignature {
-                type_definition: Some(TypeDefinitionSignature::Struct(vec![
-                  StructItemDefinitionSignature {
-                    name: heap.alloc_str_for_test("a"),
-                    type_: builder.int_type(),
-                    is_public: true,
-                  },
-                  StructItemDefinitionSignature {
-                    name: heap.alloc_str_for_test("b"),
-                    type_: builder.bool_type(),
-                    is_public: false,
-                  },
-                ])),
-                functions: HashMap::from([(
-                  well_known_pstrs::INIT,
-                  MemberSignature {
-                    is_public: true,
-                    type_parameters: vec![],
-                    type_: FunctionType {
-                      reason: Reason::dummy(),
-                      argument_types: vec![],
-                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("A")),
-                    },
-                  },
-                )]),
-                methods: HashMap::new(),
-                type_parameters: vec![],
-                super_types: vec![],
-              },
-            ),
-            (
-              heap.alloc_str_for_test("B"),
+              well_known_pstrs::UPPER_A,
               InterfaceSignature {
                 type_definition: Some(TypeDefinitionSignature::Struct(vec![
                   StructItemDefinitionSignature {
@@ -442,7 +410,7 @@ mod tests {
                     type_: FunctionType {
                       reason: Reason::dummy(),
                       argument_types: vec![],
-                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("B")),
+                      return_type: builder.simple_nominal_type(well_known_pstrs::UPPER_A),
                     },
                   },
                 )]),
@@ -452,15 +420,47 @@ mod tests {
               },
             ),
             (
-              heap.alloc_str_for_test("C"),
+              well_known_pstrs::UPPER_B,
+              InterfaceSignature {
+                type_definition: Some(TypeDefinitionSignature::Struct(vec![
+                  StructItemDefinitionSignature {
+                    name: well_known_pstrs::LOWER_A,
+                    type_: builder.int_type(),
+                    is_public: true,
+                  },
+                  StructItemDefinitionSignature {
+                    name: well_known_pstrs::LOWER_B,
+                    type_: builder.bool_type(),
+                    is_public: false,
+                  },
+                ])),
+                functions: HashMap::from([(
+                  well_known_pstrs::INIT,
+                  MemberSignature {
+                    is_public: true,
+                    type_parameters: vec![],
+                    type_: FunctionType {
+                      reason: Reason::dummy(),
+                      argument_types: vec![],
+                      return_type: builder.simple_nominal_type(well_known_pstrs::UPPER_B),
+                    },
+                  },
+                )]),
+                methods: HashMap::new(),
+                type_parameters: vec![],
+                super_types: vec![],
+              },
+            ),
+            (
+              well_known_pstrs::UPPER_C,
               InterfaceSignature {
                 type_definition: Some(TypeDefinitionSignature::Enum(vec![
                   EnumVariantDefinitionSignature {
-                    name: heap.alloc_str_for_test("a"),
+                    name: well_known_pstrs::LOWER_A,
                     types: vec![builder.int_type()],
                   },
                   EnumVariantDefinitionSignature {
-                    name: heap.alloc_str_for_test("b"),
+                    name: well_known_pstrs::LOWER_B,
                     types: vec![builder.bool_type()],
                   },
                 ])),
@@ -472,7 +472,7 @@ mod tests {
                     type_: FunctionType {
                       reason: Reason::dummy(),
                       argument_types: vec![],
-                      return_type: builder.simple_nominal_type(heap.alloc_str_for_test("C")),
+                      return_type: builder.simple_nominal_type(well_known_pstrs::UPPER_C),
                     },
                   },
                 )]),

--- a/crates/samlang-core/src/checker/checker_utils_tests.rs
+++ b/crates/samlang-core/src/checker/checker_utils_tests.rs
@@ -3,6 +3,7 @@ mod tests {
   use super::super::checker_utils::*;
   use super::super::type_::{ISourceType, Type, TypeParameterSignature};
   use crate::checker::type_::test_type_builder;
+  use crate::common::well_known_pstrs;
   use crate::{ast::Reason, common::Heap, errors::ErrorSet};
   use pretty_assertions::assert_eq;
   use std::{collections::HashMap, rc::Rc};
@@ -26,7 +27,7 @@ mod tests {
     assert_eq!(meet(&builder.unit_type(), &builder.int_type(), heap), "FAILED_MEET");
     assert_eq!(meet(&Type::Any(Reason::dummy(), false), &builder.string_type(), heap), "Str");
     assert_eq!(
-      meet(&builder.unit_type(), &builder.simple_nominal_type(heap.alloc_str_for_test("A")), heap),
+      meet(&builder.unit_type(), &builder.simple_nominal_type(well_known_pstrs::UPPER_A), heap),
       "FAILED_MEET"
     );
 
@@ -41,45 +42,45 @@ mod tests {
     );
 
     assert_eq!(
-      meet(&builder.simple_nominal_type(heap.alloc_str_for_test("A")), &builder.unit_type(), heap),
+      meet(&builder.simple_nominal_type(well_known_pstrs::UPPER_A), &builder.unit_type(), heap),
       "FAILED_MEET"
     );
     assert_eq!(
       meet(
-        &builder.simple_nominal_type(heap.alloc_str_for_test("A")),
-        &builder.simple_nominal_type(heap.alloc_str_for_test("B")),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_A),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_B),
         heap
       ),
       "FAILED_MEET"
     );
     assert_eq!(
       meet(
-        &builder.generic_type(heap.alloc_str_for_test("A")),
-        &builder.simple_nominal_type(heap.alloc_str_for_test("B")),
+        &builder.generic_type(well_known_pstrs::UPPER_A),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_B),
         heap
       ),
       "FAILED_MEET"
     );
     assert_eq!(
       meet(
-        &builder.generic_type(heap.alloc_str_for_test("A")),
-        &builder.generic_type(heap.alloc_str_for_test("B")),
+        &builder.generic_type(well_known_pstrs::UPPER_A),
+        &builder.generic_type(well_known_pstrs::UPPER_B),
         heap
       ),
       "FAILED_MEET"
     );
     assert_eq!(
       meet(
-        &builder.generic_type(heap.alloc_str_for_test("A")),
-        &builder.generic_type(heap.alloc_str_for_test("A")),
+        &builder.generic_type(well_known_pstrs::UPPER_A),
+        &builder.generic_type(well_known_pstrs::UPPER_A),
         heap
       ),
       "A"
     );
     assert_eq!(
       meet(
-        &builder.simple_nominal_type(heap.alloc_str_for_test("A")),
-        &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_A),
+        &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.int_type()]),
         heap
       ),
       "FAILED_MEET",
@@ -87,12 +88,12 @@ mod tests {
     assert_eq!(
       meet(
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
-          vec![builder.simple_nominal_type(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![builder.simple_nominal_type(well_known_pstrs::UPPER_B)]
         ),
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
-          vec![builder.simple_nominal_type(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![builder.simple_nominal_type(well_known_pstrs::UPPER_B)]
         ),
         heap,
       ),
@@ -101,12 +102,12 @@ mod tests {
     assert_eq!(
       meet(
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
-          vec![builder.simple_nominal_type(heap.alloc_str_for_test("A"))]
+          well_known_pstrs::UPPER_A,
+          vec![builder.simple_nominal_type(well_known_pstrs::UPPER_A)]
         ),
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
-          vec![builder.simple_nominal_type(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![builder.simple_nominal_type(well_known_pstrs::UPPER_B)]
         ),
         heap,
       ),
@@ -116,11 +117,11 @@ mod tests {
     assert_eq!(
       meet(
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
-          vec![builder.simple_nominal_type(heap.alloc_str_for_test("B"))]
+          well_known_pstrs::UPPER_A,
+          vec![builder.simple_nominal_type(well_known_pstrs::UPPER_B)]
         ),
         &builder.general_nominal_type(
-          heap.alloc_str_for_test("A"),
+          well_known_pstrs::UPPER_A,
           vec![Rc::new(Type::Any(Reason::dummy(), false))]
         ),
         heap,
@@ -129,7 +130,7 @@ mod tests {
     );
     assert_eq!(
       meet(
-        &builder.simple_nominal_type(heap.alloc_str_for_test("B")),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_B),
         &Type::Any(Reason::dummy(), false),
         heap
       ),
@@ -143,7 +144,7 @@ mod tests {
     assert_eq!(
       meet(
         &builder.fun_type(vec![], builder.int_type()),
-        &builder.simple_nominal_type(heap.alloc_str_for_test("B")),
+        &builder.simple_nominal_type(well_known_pstrs::UPPER_B),
         heap
       ),
       "FAILED_MEET",
@@ -203,7 +204,7 @@ mod tests {
 
   #[test]
   fn type_substitution_tests() {
-    let mut heap = Heap::new();
+    let heap = Heap::new();
     let builder = test_type_builder::create();
 
     assert_eq!(
@@ -212,28 +213,27 @@ mod tests {
         &builder.fun_type(
           vec![
             builder.general_nominal_type(
-              heap.alloc_str_for_test("A"),
+              well_known_pstrs::UPPER_A,
               vec![
-                builder.generic_type(heap.alloc_str_for_test("B")),
-                builder
-                  .general_nominal_type(heap.alloc_str_for_test("C"), vec![builder.int_type()])
+                builder.generic_type(well_known_pstrs::UPPER_B),
+                builder.general_nominal_type(well_known_pstrs::UPPER_C, vec![builder.int_type()])
               ]
             ),
-            builder.generic_type(heap.alloc_str_for_test("D")),
+            builder.generic_type(well_known_pstrs::UPPER_D),
             builder.general_nominal_type(
-              heap.alloc_str_for_test("E"),
-              vec![builder.simple_nominal_type(heap.alloc_str_for_test("F"))]
+              well_known_pstrs::UPPER_E,
+              vec![builder.simple_nominal_type(well_known_pstrs::UPPER_F)]
             ),
             builder.int_type()
           ],
           builder.int_type()
         ),
         &HashMap::from([
-          (heap.alloc_str_for_test("A"), builder.int_type()),
-          (heap.alloc_str_for_test("B"), builder.int_type()),
-          (heap.alloc_str_for_test("C"), builder.int_type()),
-          (heap.alloc_str_for_test("D"), builder.int_type()),
-          (heap.alloc_str_for_test("E"), builder.int_type()),
+          (well_known_pstrs::UPPER_A, builder.int_type()),
+          (well_known_pstrs::UPPER_B, builder.int_type()),
+          (well_known_pstrs::UPPER_C, builder.int_type()),
+          (well_known_pstrs::UPPER_D, builder.int_type()),
+          (well_known_pstrs::UPPER_E, builder.int_type()),
         ])
       )
       .pretty_print(&heap)
@@ -242,7 +242,7 @@ mod tests {
     assert_eq!(
       "A",
       perform_nominal_type_substitution(
-        &builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("A")),
+        &builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_A),
         &HashMap::new()
       )
       .pretty_print(&heap)
@@ -353,16 +353,16 @@ mod tests {
       ),
       &builder.fun_type(
         vec![
-          builder.generic_type(heap.alloc_str_for_test("A")),
-          builder.generic_type(heap.alloc_str_for_test("B")),
-          builder.generic_type(heap.alloc_str_for_test("A")),
+          builder.generic_type(well_known_pstrs::UPPER_A),
+          builder.generic_type(well_known_pstrs::UPPER_B),
+          builder.generic_type(well_known_pstrs::UPPER_A),
         ],
-        builder.generic_type(heap.alloc_str_for_test("C")),
+        builder.generic_type(well_known_pstrs::UPPER_C),
       ),
       vec![
-        TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-        TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
-        TypeParameterSignature { name: heap.alloc_str_for_test("C"), bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_C, bound: None },
       ],
       &HashMap::from([("has_error", "true"), ("A", "int"), ("B", "bool"), ("C", "unit")]),
       heap,
@@ -371,16 +371,16 @@ mod tests {
       &builder.int_type(),
       &builder.fun_type(
         vec![
-          builder.generic_type(heap.alloc_str_for_test("A")),
-          builder.generic_type(heap.alloc_str_for_test("B")),
-          builder.generic_type(heap.alloc_str_for_test("A")),
+          builder.generic_type(well_known_pstrs::UPPER_A),
+          builder.generic_type(well_known_pstrs::UPPER_B),
+          builder.generic_type(well_known_pstrs::UPPER_A),
         ],
-        builder.generic_type(heap.alloc_str_for_test("C")),
+        builder.generic_type(well_known_pstrs::UPPER_C),
       ),
       vec![
-        TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-        TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
-        TypeParameterSignature { name: heap.alloc_str_for_test("C"), bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_C, bound: None },
       ],
       &HashMap::from([
         ("has_error", "true"),
@@ -394,7 +394,7 @@ mod tests {
 
   #[test]
   fn type_constrain_solver_integration_test_1() {
-    let mut heap = Heap::new();
+    let heap = Heap::new();
     let mut error_set = ErrorSet::new();
     let builder = test_type_builder::create();
 
@@ -416,16 +416,16 @@ mod tests {
       &builder.fun_type(
         vec![
           builder.fun_type(
-            vec![builder.generic_type(heap.alloc_str_for_test("A"))],
-            builder.generic_type(heap.alloc_str_for_test("A")),
+            vec![builder.generic_type(well_known_pstrs::UPPER_A)],
+            builder.generic_type(well_known_pstrs::UPPER_A),
           ),
-          builder.generic_type(heap.alloc_str_for_test("B")),
+          builder.generic_type(well_known_pstrs::UPPER_B),
         ],
         builder.unit_type(),
       ),
       &vec![
-        TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-        TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+        TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
       ],
       &heap,
       &mut error_set,
@@ -441,7 +441,7 @@ mod tests {
 
   #[test]
   fn type_constrain_solver_integration_test_2() {
-    let mut heap = Heap::new();
+    let heap = Heap::new();
     let mut error_set = ErrorSet::new();
     let builder = test_type_builder::create();
 
@@ -463,14 +463,14 @@ mod tests {
       &builder.fun_type(
         vec![
           builder.fun_type(
-            vec![builder.simple_nominal_type(heap.alloc_str_for_test("A"))],
-            builder.simple_nominal_type(heap.alloc_str_for_test("A")),
+            vec![builder.simple_nominal_type(well_known_pstrs::UPPER_A)],
+            builder.simple_nominal_type(well_known_pstrs::UPPER_A),
           ),
-          builder.generic_type(heap.alloc_str_for_test("B")),
+          builder.generic_type(well_known_pstrs::UPPER_B),
         ],
         builder.unit_type(),
       ),
-      &vec![TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None }],
+      &vec![TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None }],
       &heap,
       &mut error_set,
     );

--- a/crates/samlang-core/src/checker/global_signature.rs
+++ b/crates/samlang-core/src/checker/global_signature.rs
@@ -394,6 +394,7 @@ mod tests {
     checker::type_::{
       create_builtin_module_signature, test_type_builder, GlobalSignature, NominalType,
     },
+    common::well_known_pstrs,
     errors::ErrorSet,
     parser::parse_source_module_from_text,
     Heap, ModuleReference,
@@ -511,7 +512,7 @@ interface UsingConflictingExtends : ConflictExtends1, ConflictExtends2 {}
           reason: Reason::dummy(),
           is_class_statics: false,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("C"),
+          id: well_known_pstrs::UPPER_C,
           type_arguments: vec![]
         },
       )
@@ -617,39 +618,39 @@ interface UsingConflictingExtends : ConflictExtends1, ConflictExtends2 {}
       &global_cx,
       (
         heap.alloc_module_reference_from_string_vec(vec!["A".to_string()]),
-        heap.alloc_str_for_test("C")
+        well_known_pstrs::UPPER_C
       ),
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_function_signature(
       &global_cx,
-      (ModuleReference::root(), heap.alloc_str_for_test("C")),
-      heap.alloc_str_for_test("a"),
+      (ModuleReference::root(), well_known_pstrs::UPPER_C),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_function_signature(
       &global_cx,
-      (ModuleReference::dummy(), heap.alloc_str_for_test("C")),
-      heap.alloc_str_for_test("a"),
+      (ModuleReference::dummy(), well_known_pstrs::UPPER_C),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_function_signature(
       &global_cx,
       (ModuleReference::dummy(), heap.alloc_str_for_test("IUseNonExistent")),
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_function_signature(
       &global_cx,
       (ModuleReference::dummy(), heap.alloc_str_for_test("ICyclic1")),
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_function_signature(
       &global_cx,
       (ModuleReference::dummy(), heap.alloc_str_for_test("ICyclic2")),
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
   }
@@ -666,10 +667,10 @@ interface UsingConflictingExtends : ConflictExtends1, ConflictExtends2 {}
         reason: Reason::dummy(),
         is_class_statics: false,
         module_reference: ModuleReference::dummy(),
-        id: heap.alloc_str_for_test("C"),
+        id: well_known_pstrs::UPPER_C,
         type_arguments: vec![]
       },
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_method_signature(
@@ -681,7 +682,7 @@ interface UsingConflictingExtends : ConflictExtends1, ConflictExtends2 {}
         id: heap.alloc_str_for_test("IUseNonExistent"),
         type_arguments: vec![]
       },
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert_eq!(
@@ -731,7 +732,7 @@ public <C : A>(int, int) -> C
         id: heap.alloc_str_for_test("ICyclic1"),
         type_arguments: vec![]
       },
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert!(resolve_method_signature(
@@ -743,7 +744,7 @@ public <C : A>(int, int) -> C
         id: heap.alloc_str_for_test("ICyclic2"),
         type_arguments: vec![]
       },
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
     )
     .is_empty());
     assert_eq!(

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -105,6 +105,7 @@ mod mod_type_tests {
       Location, Reason,
     },
     checker::type_::{test_type_builder, Type},
+    common::well_known_pstrs,
     Heap, ModuleReference,
   };
   use std::{collections::HashMap, rc::Rc};
@@ -123,9 +124,9 @@ mod mod_type_tests {
     let builder = test_type_builder::create();
 
     mod_type(zero_expr(), builder.bool_type());
-    mod_type(E::LocalId(common(), Id::from(heap.alloc_str_for_test("d"))), builder.bool_type());
+    mod_type(E::LocalId(common(), Id::from(well_known_pstrs::LOWER_D)), builder.bool_type());
     mod_type(
-      E::ClassId(common(), ModuleReference::dummy(), Id::from(heap.alloc_str_for_test("d"))),
+      E::ClassId(common(), ModuleReference::dummy(), Id::from(well_known_pstrs::LOWER_D)),
       builder.bool_type(),
     );
     mod_type(

--- a/crates/samlang-core/src/checker/type_.rs
+++ b/crates/samlang-core/src/checker/type_.rs
@@ -709,7 +709,7 @@ mod type_tests {
       "A",
       TypeParameterSignature::from_list(&[TypeParameter {
         loc: Location::dummy(),
-        name: Id::from(heap.alloc_str_for_test("A")),
+        name: Id::from(well_known_pstrs::UPPER_A),
         bound: None
       }])[0]
         .pretty_print(&heap)
@@ -718,11 +718,11 @@ mod type_tests {
       "A : B",
       TypeParameterSignature::from_list(&[TypeParameter {
         loc: Location::dummy(),
-        name: Id::from(heap.alloc_str_for_test("A")),
+        name: Id::from(well_known_pstrs::UPPER_A),
         bound: Some(annotation::Id {
           location: Location::dummy(),
           module_reference: ModuleReference::dummy(),
-          id: Id::from(heap.alloc_str_for_test("B")),
+          id: Id::from(well_known_pstrs::UPPER_B),
           type_arguments: vec![]
         })
       }])[0]
@@ -735,12 +735,10 @@ mod type_tests {
       TypeParameterSignature::pretty_print_list(
         &vec![
           TypeParameterSignature {
-            name: heap.alloc_str_for_test("A"),
-            bound: Option::Some(
-              builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("B"))
-            )
+            name: well_known_pstrs::UPPER_A,
+            bound: Option::Some(builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_B))
           },
-          TypeParameterSignature { name: heap.alloc_str_for_test("C"), bound: Option::None }
+          TypeParameterSignature { name: well_known_pstrs::UPPER_C, bound: Option::None }
         ],
         &heap
       )
@@ -776,12 +774,12 @@ m2: public () -> any
       InterfaceSignature {
         type_definition: Some(TypeDefinitionSignature::Struct(vec![
           StructItemDefinitionSignature {
-            name: heap.alloc_str_for_test("a"),
+            name: well_known_pstrs::LOWER_A,
             type_: builder.bool_type(),
             is_public: true
           },
           StructItemDefinitionSignature {
-            name: heap.alloc_str_for_test("b"),
+            name: well_known_pstrs::LOWER_B,
             type_: builder.bool_type(),
             is_public: false
           },
@@ -823,7 +821,7 @@ m2: public () -> any
     assert_eq!(
       "A(bool)",
       TypeDefinitionSignature::Enum(vec![EnumVariantDefinitionSignature {
-        name: heap.alloc_str_for_test("A"),
+        name: well_known_pstrs::UPPER_A,
         types: vec![builder.bool_type()]
       }])
       .to_string(&heap)
@@ -831,7 +829,7 @@ m2: public () -> any
     assert_eq!(
       "B(bool, bool)",
       TypeDefinitionSignature::Enum(vec![EnumVariantDefinitionSignature {
-        name: heap.alloc_str_for_test("B"),
+        name: well_known_pstrs::UPPER_B,
         types: vec![builder.bool_type(), builder.bool_type()]
       }])
       .to_string(&heap)
@@ -839,7 +837,7 @@ m2: public () -> any
     assert_eq!(
       "C",
       TypeDefinitionSignature::Enum(vec![EnumVariantDefinitionSignature {
-        name: heap.alloc_str_for_test("C"),
+        name: well_known_pstrs::UPPER_C,
         types: vec![]
       }])
       .to_string(&heap)
@@ -928,7 +926,7 @@ m2: public () -> any
         vec![builder.bool_annot()],
         builder.general_id_annot(
           heap.alloc_str_for_test("I"),
-          vec![builder.int_annot(), builder.generic_annot(heap.alloc_str_for_test("A"))]
+          vec![builder.int_annot(), builder.generic_annot(well_known_pstrs::UPPER_A)]
         )
       ))
       .pretty_print(heap)
@@ -937,35 +935,34 @@ m2: public () -> any
 
   #[test]
   fn test_equality_test() {
-    let mut heap = Heap::new();
     let builder = test_type_builder::create();
 
     assert!(!builder
       .unit_type()
-      .is_the_same_type(&builder.simple_nominal_type(heap.alloc_str_for_test("A"))));
+      .is_the_same_type(&builder.simple_nominal_type(well_known_pstrs::UPPER_A)));
 
     assert!(Type::Any(Reason::dummy(), true).is_the_same_type(&Type::Any(Reason::dummy(), false)));
     assert!(builder.unit_type().is_the_same_type(&builder.unit_type()));
     assert!(!builder.unit_type().is_the_same_type(&builder.int_type()));
 
     assert!(builder
-      .simple_nominal_type(heap.alloc_str_for_test("A"))
-      .is_the_same_type(&builder.simple_nominal_type(heap.alloc_str_for_test("A"))));
+      .simple_nominal_type(well_known_pstrs::UPPER_A)
+      .is_the_same_type(&builder.simple_nominal_type(well_known_pstrs::UPPER_A)));
     assert!(!builder
-      .simple_nominal_type(heap.alloc_str_for_test("A"))
-      .is_the_same_type(&builder.simple_nominal_type(heap.alloc_str_for_test("B"))));
+      .simple_nominal_type(well_known_pstrs::UPPER_A)
+      .is_the_same_type(&builder.simple_nominal_type(well_known_pstrs::UPPER_B)));
     assert!(builder
-      .general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.bool_type()])
+      .general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.bool_type()])
       .is_the_same_type(
-        &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.bool_type()])
+        &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.bool_type()])
       ));
     assert!(!builder
-      .general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.bool_type()])
+      .general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.bool_type()])
       .is_the_same_type(
-        &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()])
+        &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.int_type()])
       ));
-    assert!(!builder.simple_nominal_type(heap.alloc_str_for_test("A")).is_the_same_type(
-      &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.bool_type()])
+    assert!(!builder.simple_nominal_type(well_known_pstrs::UPPER_A).is_the_same_type(
+      &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.bool_type()])
     ));
 
     assert!(builder

--- a/crates/samlang-core/src/checker/typing_context_tests.rs
+++ b/crates/samlang-core/src/checker/typing_context_tests.rs
@@ -50,7 +50,7 @@ mod tests {
       .possibly_in_scope_local_variables(Position(0, 0))
       .is_empty());
 
-    let mut heap = Heap::new();
+    let heap = Heap::new();
     let builder = test_type_builder::create();
     let mut cx = LocalTypingContext::new(SsaAnalysisResult {
       unbound_names: HashSet::new(),
@@ -60,14 +60,14 @@ mod tests {
       local_scoped_def_locs: HashMap::from([
         (
           Location::from_pos(1, 1, 100, 100),
-          HashMap::from([(heap.alloc_str_for_test("a"), Location::from_pos(1, 2, 3, 4))]),
+          HashMap::from([(well_known_pstrs::LOWER_A, Location::from_pos(1, 2, 3, 4))]),
         ),
         (Location::from_pos(300, 1, 1000, 1000), HashMap::new()),
         (
           Location::from_pos(10, 10, 50, 50),
           HashMap::from([
-            (heap.alloc_str_for_test("b"), Location::from_pos(5, 6, 7, 8)),
-            (heap.alloc_str_for_test("c"), Location::from_pos(9, 10, 11, 12)),
+            (well_known_pstrs::LOWER_B, Location::from_pos(5, 6, 7, 8)),
+            (well_known_pstrs::LOWER_C, Location::from_pos(9, 10, 11, 12)),
           ]),
         ),
       ]),
@@ -86,7 +86,6 @@ mod tests {
 
   #[test]
   fn run_in_synthesis_mode_tests() {
-    let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
     let global_cx = HashMap::new();
     let mut local_cx = empty_local_typing_context();
@@ -95,7 +94,7 @@ mod tests {
       &mut local_cx,
       &mut error_set,
       ModuleReference::dummy(),
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![],
     );
 
@@ -117,7 +116,7 @@ mod tests {
       ModuleReference::dummy(),
       ModuleSignature {
         interfaces: HashMap::from([(
-          heap.alloc_str_for_test("A"),
+          well_known_pstrs::UPPER_A,
           InterfaceSignature {
             type_definition: Some(TypeDefinitionSignature::Enum(vec![])),
             type_parameters: vec![TypeParameterSignature {
@@ -125,7 +124,7 @@ mod tests {
               bound: None,
             }],
             super_types: vec![builder.general_nominal_type_unwrapped(
-              heap.alloc_str_for_test("B"),
+              well_known_pstrs::UPPER_B,
               vec![builder.generic_type(heap.alloc_str_for_test("T")), builder.int_type()],
             )],
             functions: HashMap::new(),
@@ -139,43 +138,44 @@ mod tests {
       &mut local_cx,
       &mut error_set,
       ModuleReference::dummy(),
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![],
     );
 
     // Non-id lower type
-    assert!(!cx
-      .is_subtype(&builder.int_type(), &builder.simple_nominal_type(heap.alloc_str_for_test("B"))));
+    assert!(
+      !cx.is_subtype(&builder.int_type(), &builder.simple_nominal_type(well_known_pstrs::UPPER_B))
+    );
     // Non-existent type
     assert!(!cx.is_subtype(
-      &builder.simple_nominal_type(heap.alloc_str_for_test("B")),
-      &builder.simple_nominal_type(heap.alloc_str_for_test("C"))
+      &builder.simple_nominal_type(well_known_pstrs::UPPER_B),
+      &builder.simple_nominal_type(well_known_pstrs::UPPER_C)
     ));
     // Type-args length mismatch
     assert!(!cx.is_subtype(
-      &builder.simple_nominal_type(heap.alloc_str_for_test("A")),
-      &builder.simple_nominal_type(heap.alloc_str_for_test("B"))
+      &builder.simple_nominal_type(well_known_pstrs::UPPER_A),
+      &builder.simple_nominal_type(well_known_pstrs::UPPER_B)
     ));
     // Type-args mismatch
     assert!(!cx.is_subtype(
-      &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]),
+      &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.int_type()]),
       &builder.general_nominal_type(
-        heap.alloc_str_for_test("B"),
+        well_known_pstrs::UPPER_B,
         vec![builder.string_type(), builder.int_type()]
       )
     ));
     assert!(!cx.is_subtype(
-      &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]),
+      &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.int_type()]),
       &builder.general_nominal_type(
-        heap.alloc_str_for_test("B"),
+        well_known_pstrs::UPPER_B,
         vec![builder.string_type(), builder.string_type()]
       )
     ));
     // Good
     assert!(cx.is_subtype(
-      &builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.string_type()]),
+      &builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.string_type()]),
       &builder.general_nominal_type(
-        heap.alloc_str_for_test("B"),
+        well_known_pstrs::UPPER_B,
         vec![builder.string_type(), builder.int_type()]
       )
     ));
@@ -192,14 +192,14 @@ mod tests {
       ModuleSignature {
         interfaces: HashMap::from([
           (
-            heap.alloc_str_for_test("A"),
+            well_known_pstrs::UPPER_A,
             InterfaceSignature {
               type_definition: Some(TypeDefinitionSignature::Enum(vec![])),
               type_parameters: vec![
                 TypeParameterSignature { name: heap.alloc_str_for_test("T1"), bound: None },
                 TypeParameterSignature {
                   name: heap.alloc_str_for_test("T2"),
-                  bound: Some(builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("B"))),
+                  bound: Some(builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_B)),
                 },
               ],
               super_types: vec![],
@@ -208,11 +208,11 @@ mod tests {
             },
           ),
           (
-            heap.alloc_str_for_test("B"),
+            well_known_pstrs::UPPER_B,
             InterfaceSignature {
               type_definition: None,
               type_parameters: vec![],
-              super_types: vec![builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("B"))],
+              super_types: vec![builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_B)],
               functions: HashMap::new(),
               methods: HashMap::new(),
             },
@@ -225,20 +225,20 @@ mod tests {
       &mut local_cx,
       &mut error_set,
       ModuleReference::dummy(),
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![
         TypeParameterSignature { name: heap.alloc_str_for_test("TPARAM"), bound: None },
         TypeParameterSignature {
           name: heap.alloc_str_for_test("T2"),
-          bound: Some(builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("A"))),
+          bound: Some(builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_A)),
         },
       ],
     );
 
     let str_tparam = heap.alloc_str_for_test("TPARAM");
     let str_t = heap.alloc_str_for_test("T");
-    let str_a = heap.alloc_str_for_test("A");
-    let str_b = heap.alloc_str_for_test("B");
+    let str_a = well_known_pstrs::UPPER_A;
+    let str_b = well_known_pstrs::UPPER_B;
     cx.validate_type_instantiation_allow_abstract_types(&heap, &builder.int_type());
     cx.validate_type_instantiation_allow_abstract_types(
       &heap,
@@ -328,7 +328,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
             },
           ),
           (
-            heap.alloc_str_for_test("B"),
+            well_known_pstrs::UPPER_B,
             InterfaceSignature {
               type_definition: None,
               type_parameters: vec![
@@ -374,11 +374,11 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
       &mut local_cx,
       &mut error_set,
       ModuleReference::dummy(),
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![
         TypeParameterSignature {
           name: heap.alloc_str_for_test("TT1"),
-          bound: Some(builder.simple_nominal_type_unwrapped(heap.alloc_str_for_test("A"))),
+          bound: Some(builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_A)),
         },
         TypeParameterSignature { name: heap.alloc_str_for_test("TT2"), bound: None },
         TypeParameterSignature {
@@ -393,7 +393,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
     assert!(!cx.class_exists(ModuleReference::dummy(), heap.alloc_str_for_test("s")));
     assert!(!cx.class_exists(
       heap.alloc_module_reference_from_string_vec(vec!["A".to_string()]),
-      heap.alloc_str_for_test("A")
+      well_known_pstrs::UPPER_A
     ));
     assert!(cx
       .get_method_type(
@@ -401,7 +401,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: heap.alloc_module_reference_from_string_vec(vec!["A".to_string()]),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f1"),
@@ -414,7 +414,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f1"),
@@ -427,7 +427,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f2"),
@@ -440,7 +440,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f3"),
@@ -453,7 +453,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m1"),
@@ -466,7 +466,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m2"),
@@ -479,7 +479,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m3"),
@@ -492,7 +492,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f1"),
@@ -505,7 +505,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f2"),
@@ -518,7 +518,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f3"),
@@ -531,7 +531,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m1"),
@@ -544,7 +544,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m2"),
@@ -557,7 +557,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m3"),
@@ -570,7 +570,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: false,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m2"),
@@ -583,7 +583,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: false,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("B"),
+          id: well_known_pstrs::UPPER_B,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m3"),
@@ -596,7 +596,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: false,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("C"),
+          id: well_known_pstrs::UPPER_C,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("m3"),
@@ -611,7 +611,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: false,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![builder.int_type(), builder.int_type()]
         },
         heap.alloc_str_for_test("m1"),
@@ -627,7 +627,7 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
           reason: Reason::dummy(),
           is_class_statics: true,
           module_reference: ModuleReference::dummy(),
-          id: heap.alloc_str_for_test("A"),
+          id: well_known_pstrs::UPPER_A,
           type_arguments: vec![]
         },
         heap.alloc_str_for_test("f2"),
@@ -669,28 +669,28 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
   fn resolve_type_definitions_test() {
     let builder = test_type_builder::create();
     let mut local_cx = empty_local_typing_context();
-    let mut heap = Heap::new();
+    let heap = Heap::new();
     let mut error_set = ErrorSet::new();
     let global_cx = HashMap::from([(
       ModuleReference::dummy(),
       ModuleSignature {
         interfaces: HashMap::from([
           (
-            heap.alloc_str_for_test("A"),
+            well_known_pstrs::UPPER_A,
             InterfaceSignature {
               type_definition: Some(TypeDefinitionSignature::Enum(vec![
                 EnumVariantDefinitionSignature {
-                  name: heap.alloc_str_for_test("a"),
-                  types: vec![builder.generic_type(heap.alloc_str_for_test("A"))],
+                  name: well_known_pstrs::LOWER_A,
+                  types: vec![builder.generic_type(well_known_pstrs::UPPER_A)],
                 },
                 EnumVariantDefinitionSignature {
-                  name: heap.alloc_str_for_test("b"),
-                  types: vec![builder.generic_type(heap.alloc_str_for_test("B"))],
+                  name: well_known_pstrs::LOWER_B,
+                  types: vec![builder.generic_type(well_known_pstrs::UPPER_B)],
                 },
               ])),
               type_parameters: vec![
-                TypeParameterSignature { name: heap.alloc_str_for_test("A"), bound: None },
-                TypeParameterSignature { name: heap.alloc_str_for_test("B"), bound: None },
+                TypeParameterSignature { name: well_known_pstrs::UPPER_A, bound: None },
+                TypeParameterSignature { name: well_known_pstrs::UPPER_B, bound: None },
               ],
               super_types: vec![],
               functions: HashMap::new(),
@@ -698,12 +698,12 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
             },
           ),
           (
-            heap.alloc_str_for_test("B"),
+            well_known_pstrs::UPPER_B,
             InterfaceSignature {
               type_definition: Some(TypeDefinitionSignature::Struct(vec![])),
               type_parameters: vec![
-                TypeParameterSignature { name: heap.alloc_str_for_test("E"), bound: None },
-                TypeParameterSignature { name: heap.alloc_str_for_test("F"), bound: None },
+                TypeParameterSignature { name: well_known_pstrs::UPPER_E, bound: None },
+                TypeParameterSignature { name: well_known_pstrs::UPPER_F, bound: None },
               ],
               super_types: vec![],
               functions: HashMap::new(),
@@ -718,32 +718,32 @@ DUMMY.sam:0:0-0:0: [invalid-arity]: Incorrect type arguments size. Expected: 2, 
       &mut local_cx,
       &mut error_set,
       ModuleReference::dummy(),
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![],
     );
 
     assert!(cx.resolve_struct_definitions(&builder.bool_type()).is_empty());
     assert!(cx
       .resolve_struct_definitions(&builder.general_nominal_type(
-        heap.alloc_str_for_test("A"),
+        well_known_pstrs::UPPER_A,
         vec![builder.int_type(), builder.int_type()]
       ))
       .is_empty());
     assert!(cx
       .resolve_struct_definitions(&builder.general_nominal_type(
-        heap.alloc_str_for_test("A"),
+        well_known_pstrs::UPPER_A,
         vec![builder.int_type(), builder.int_type()]
       ))
       .is_empty());
     assert!(cx
       .resolve_struct_definitions(&builder.general_nominal_type(
-        heap.alloc_str_for_test("C"),
+        well_known_pstrs::UPPER_C,
         vec![builder.int_type(), builder.int_type()]
       ))
       .is_empty());
 
     let resolved = cx.resolve_enum_definitions(&builder.general_nominal_type(
-      heap.alloc_str_for_test("A"),
+      well_known_pstrs::UPPER_A,
       vec![builder.int_type(), builder.int_type()],
     ));
     assert_eq!(2, resolved.len());

--- a/crates/samlang-core/src/common.rs
+++ b/crates/samlang-core/src/common.rs
@@ -636,6 +636,8 @@ pub(crate) fn take_mut<T, F: FnOnce(T) -> T>(mut_ref: &mut T, closure: F) {
 
 #[cfg(test)]
 mod tests {
+  use crate::common::well_known_pstrs;
+
   use super::{
     byte_vec_to_data_string, measure_time, rcs, Heap, LocalStackedContext, ModuleReference, PStr,
     PStrPrivateRepr, PStrPrivateReprInline, StringStoredInHeap,
@@ -671,7 +673,7 @@ mod tests {
     let mut heap = Heap::default();
     assert_eq!(1, heap.alloc_dummy_module_reference().0);
     let a1 = heap.alloc_str_for_test("aaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    let b = heap.alloc_str_for_test("b");
+    let b = well_known_pstrs::LOWER_B;
     let a2 = heap.alloc_str_for_test("aaaaaaaaaaaaaaaaaaaaaaaaaaa");
     a1.debug_string();
     assert!(PStrPrivateRepr { heap_id: 0 }.clone().eq(&PStrPrivateRepr { heap_id: 0 }));

--- a/crates/samlang-core/src/compiler/hir_string_manager.rs
+++ b/crates/samlang-core/src/compiler/hir_string_manager.rs
@@ -37,18 +37,16 @@ impl StringManager {
 #[cfg(test)]
 mod tests {
   use super::StringManager;
-  use crate::Heap;
+  use crate::{common::well_known_pstrs, Heap};
   use pretty_assertions::assert_eq;
 
   #[test]
   fn tests() {
     let heap = &mut Heap::new();
     let mut s = StringManager::new();
-    let a = heap.alloc_str_for_test("a");
-    let b = heap.alloc_str_for_test("b");
-    assert_eq!(a, s.allocate(heap, a).content);
-    assert_eq!(b, s.allocate(heap, b).content);
-    assert_eq!(a, s.allocate(heap, a).content);
+    assert_eq!(well_known_pstrs::LOWER_A, s.allocate(heap, well_known_pstrs::LOWER_A).content);
+    assert_eq!(well_known_pstrs::LOWER_B, s.allocate(heap, well_known_pstrs::LOWER_B).content);
+    assert_eq!(well_known_pstrs::LOWER_A, s.allocate(heap, well_known_pstrs::LOWER_A).content);
     assert_eq!(2, s.all_global_variables().len());
   }
 }

--- a/crates/samlang-core/src/compiler/hir_type_conversion.rs
+++ b/crates/samlang-core/src/compiler/hir_type_conversion.rs
@@ -399,6 +399,7 @@ mod tests {
   use crate::{
     ast::{hir::STRING_TYPE, source::test_builder, Location, Reason},
     checker::type_::test_type_builder,
+    common::well_known_pstrs,
   };
   use pretty_assertions::assert_eq;
 
@@ -406,9 +407,9 @@ mod tests {
   fn synthesizer_tests() {
     let heap = &mut Heap::new();
     let mut synthesizer = TypeSynthesizer::new();
-    let a = heap.alloc_str_for_test("A");
-    let b = heap.alloc_str_for_test("B");
-    let c = heap.alloc_str_for_test("C");
+    let a = well_known_pstrs::UPPER_A;
+    let b = well_known_pstrs::UPPER_B;
+    let c = well_known_pstrs::UPPER_C;
 
     assert_eq!(
       "$SyntheticIDType0",
@@ -481,23 +482,22 @@ mod tests {
 
   #[test]
   fn collect_used_generic_types_works() {
-    let heap = &mut Heap::new();
     let generic_types: HashSet<PStr> =
-      vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")].into_iter().collect();
+      vec![well_known_pstrs::UPPER_A, well_known_pstrs::UPPER_B].into_iter().collect();
 
     assert!(collect_used_generic_types(
       &Type::new_fn_unwrapped(
-        vec![INT_TYPE, Type::new_id(heap.alloc_str_for_test("C"), vec![INT_TYPE])],
-        Type::new_id_no_targs(heap.alloc_str_for_test("C")),
+        vec![INT_TYPE, Type::new_id(well_known_pstrs::UPPER_C, vec![INT_TYPE])],
+        Type::new_id_no_targs(well_known_pstrs::UPPER_C),
       ),
       &generic_types,
     )
     .is_empty());
 
     assert_eq!(
-      vec![heap.alloc_str_for_test("A")],
+      vec![well_known_pstrs::UPPER_A],
       collect_used_generic_types(
-        &Type::new_fn_unwrapped(vec![], Type::new_id_no_targs(heap.alloc_str_for_test("A"))),
+        &Type::new_fn_unwrapped(vec![], Type::new_id_no_targs(well_known_pstrs::UPPER_A)),
         &generic_types,
       )
       .into_iter()
@@ -505,9 +505,9 @@ mod tests {
       .collect_vec()
     );
     assert_eq!(
-      vec![heap.alloc_str_for_test("B")],
+      vec![well_known_pstrs::UPPER_B],
       collect_used_generic_types(
-        &Type::new_fn_unwrapped(vec![], Type::new_id_no_targs(heap.alloc_str_for_test("B"))),
+        &Type::new_fn_unwrapped(vec![], Type::new_id_no_targs(well_known_pstrs::UPPER_B)),
         &generic_types,
       )
       .into_iter()
@@ -515,11 +515,11 @@ mod tests {
       .collect_vec()
     );
     assert_eq!(
-      vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
+      vec![well_known_pstrs::UPPER_A, well_known_pstrs::UPPER_B],
       collect_used_generic_types(
         &Type::new_fn_unwrapped(
-          vec![Type::new_id_no_targs(heap.alloc_str_for_test("B"))],
-          Type::new_id_no_targs(heap.alloc_str_for_test("A"))
+          vec![Type::new_id_no_targs(well_known_pstrs::UPPER_B)],
+          Type::new_id_no_targs(well_known_pstrs::UPPER_A)
         ),
         &generic_types,
       )
@@ -528,13 +528,13 @@ mod tests {
       .collect_vec()
     );
     assert_eq!(
-      vec![heap.alloc_str_for_test("B")],
+      vec![well_known_pstrs::UPPER_B],
       collect_used_generic_types(
         &Type::new_fn_unwrapped(
           vec![],
           Type::new_id(
-            heap.alloc_str_for_test("A"),
-            vec![Type::new_id_no_targs(heap.alloc_str_for_test("B"))]
+            well_known_pstrs::UPPER_A,
+            vec![Type::new_id_no_targs(well_known_pstrs::UPPER_B)]
           )
         ),
         &generic_types,
@@ -548,14 +548,12 @@ mod tests {
   #[should_panic]
   #[test]
   fn solve_type_arguments_panic_tests() {
-    let heap = &mut Heap::new();
-
     solve_type_arguments(
       &vec![],
-      &Type::new_id_unwrapped(heap.alloc_str_for_test("A"), vec![INT_TYPE]),
+      &Type::new_id_unwrapped(well_known_pstrs::UPPER_A, vec![INT_TYPE]),
       &Type::new_id_unwrapped(
-        heap.alloc_str_for_test("A"),
-        vec![Type::new_id_no_targs(heap.alloc_str_for_test("B"))],
+        well_known_pstrs::UPPER_A,
+        vec![Type::new_id_no_targs(well_known_pstrs::UPPER_B)],
       ),
     );
   }
@@ -565,7 +563,7 @@ mod tests {
     let heap = &mut Heap::new();
 
     let actual = solve_type_arguments(
-      &vec![heap.alloc_str_for_test("A")],
+      &vec![well_known_pstrs::UPPER_A],
       &Type::new_id_unwrapped(
         heap.alloc_str_for_test("FF"),
         vec![
@@ -573,7 +571,7 @@ mod tests {
           INT_TYPE,
           Type::new_id(heap.alloc_str_for_test("Foo"), vec![STRING_TYPE]),
           INT_TYPE,
-          Type::new_id_no_targs(heap.alloc_str_for_test("B")),
+          Type::new_id_no_targs(well_known_pstrs::UPPER_B),
           STRING_TYPE,
         ],
       ),
@@ -583,8 +581,8 @@ mod tests {
           INT_TYPE,
           INT_TYPE,
           Type::new_id(heap.alloc_str_for_test("Foo"), vec![STRING_TYPE]),
-          Type::new_id_no_targs(heap.alloc_str_for_test("A")),
-          Type::new_id_no_targs(heap.alloc_str_for_test("B")),
+          Type::new_id_no_targs(well_known_pstrs::UPPER_A),
+          Type::new_id_no_targs(well_known_pstrs::UPPER_B),
           STRING_TYPE,
         ],
       ),
@@ -601,24 +599,24 @@ mod tests {
     assert_eq!(
       "A<int>",
       type_application(
-        &Type::new_id(heap.alloc_str_for_test("A"), vec![INT_TYPE]),
-        &HashMap::from([(heap.alloc_str_for_test("A"), INT_TYPE)])
+        &Type::new_id(well_known_pstrs::UPPER_A, vec![INT_TYPE]),
+        &HashMap::from([(well_known_pstrs::UPPER_A, INT_TYPE)])
       )
       .pretty_print(heap)
     );
     assert_eq!(
       "A",
       type_application(
-        &Type::new_id_no_targs(heap.alloc_str_for_test("A")),
-        &HashMap::from([(heap.alloc_str_for_test("B"), INT_TYPE)])
+        &Type::new_id_no_targs(well_known_pstrs::UPPER_A),
+        &HashMap::from([(well_known_pstrs::UPPER_B, INT_TYPE)])
       )
       .pretty_print(heap)
     );
     assert_eq!(
       "int",
       type_application(
-        &Type::new_id_no_targs(heap.alloc_str_for_test("A")),
-        &HashMap::from([(heap.alloc_str_for_test("A"), INT_TYPE)])
+        &Type::new_id_no_targs(well_known_pstrs::UPPER_A),
+        &HashMap::from([(well_known_pstrs::UPPER_A, INT_TYPE)])
       )
       .pretty_print(heap)
     );
@@ -627,12 +625,12 @@ mod tests {
       "(int) -> int",
       fn_type_application(
         &Type::new_fn_unwrapped(
-          vec![Type::new_id_no_targs(heap.alloc_str_for_test("A"))],
-          Type::new_id_no_targs(heap.alloc_str_for_test("B"))
+          vec![Type::new_id_no_targs(well_known_pstrs::UPPER_A)],
+          Type::new_id_no_targs(well_known_pstrs::UPPER_B)
         ),
         &HashMap::from([
-          (heap.alloc_str_for_test("A"), INT_TYPE),
-          (heap.alloc_str_for_test("B"), INT_TYPE)
+          (well_known_pstrs::UPPER_A, INT_TYPE),
+          (well_known_pstrs::UPPER_B, INT_TYPE)
         ])
       )
       .pretty_print(heap)
@@ -643,8 +641,8 @@ mod tests {
   #[test]
   fn encode_name_after_generics_specialization_panic_test() {
     let heap = &mut Heap::new();
-    let s = heap.alloc_str_for_test("");
-    let a = heap.alloc_str_for_test("A");
+    let s = well_known_pstrs::LOWER_A;
+    let a = well_known_pstrs::UPPER_A;
 
     encode_name_after_generics_specialization(heap, s, &vec![Type::new_id(a, vec![INT_TYPE])]);
   }
@@ -652,8 +650,8 @@ mod tests {
   #[test]
   fn encode_name_after_generics_specialization_tests() {
     let heap = &mut Heap::new();
-    let a = heap.alloc_str_for_test("A");
-    let b = heap.alloc_str_for_test("B");
+    let a = well_known_pstrs::UPPER_A;
+    let b = well_known_pstrs::UPPER_B;
 
     assert_eq!("A", encode_name_after_generics_specialization(heap, a, &vec![]));
     assert_eq!(
@@ -693,7 +691,7 @@ mod tests {
     );
 
     assert_eq!("DUMMY_A<int>", {
-      let t = builder.general_nominal_type(heap.alloc_str_for_test("A"), vec![builder.int_type()]);
+      let t = builder.general_nominal_type(well_known_pstrs::UPPER_A, vec![builder.int_type()]);
       manager.lower_source_type(heap, &t).pretty_print(heap)
     });
 
@@ -722,7 +720,7 @@ mod tests {
   fn type_lowering_manager_lower_type_definition_tests() {
     let heap = &mut Heap::new();
     let mut manager = TypeLoweringManager {
-      generic_types: HashSet::from([heap.alloc_str_for_test("A")]),
+      generic_types: HashSet::from([well_known_pstrs::UPPER_A]),
       type_synthesizer: TypeSynthesizer::new(),
     };
     let annot_builder = test_builder::create();
@@ -731,10 +729,10 @@ mod tests {
       loc: Location::dummy(),
       fields: vec![
         source::FieldDefinition {
-          name: source::Id::from(heap.alloc_str_for_test("a")),
+          name: source::Id::from(well_known_pstrs::LOWER_A),
           annotation: annot_builder.fn_annot(
             vec![annot_builder.fn_annot(
-              vec![annot_builder.simple_id_annot(heap.alloc_str_for_test("A"))],
+              vec![annot_builder.simple_id_annot(well_known_pstrs::UPPER_A)],
               annot_builder.bool_annot(),
             )],
             annot_builder.bool_annot(),
@@ -742,10 +740,10 @@ mod tests {
           is_public: true,
         },
         source::FieldDefinition {
-          name: source::Id::from(heap.alloc_str_for_test("b")),
+          name: source::Id::from(well_known_pstrs::LOWER_B),
           annotation: annot_builder.fn_annot(
             vec![annot_builder.fn_annot(
-              vec![annot_builder.simple_id_annot(heap.alloc_str_for_test("A"))],
+              vec![annot_builder.simple_id_annot(well_known_pstrs::UPPER_A)],
               annot_builder.bool_annot(),
             )],
             annot_builder.bool_annot(),
@@ -779,7 +777,7 @@ mod tests {
     let heap = &mut Heap::new();
 
     let mut manager = TypeLoweringManager {
-      generic_types: HashSet::from([heap.alloc_str_for_test("A")]),
+      generic_types: HashSet::from([well_known_pstrs::UPPER_A]),
       type_synthesizer: TypeSynthesizer::new(),
     };
     let builder = test_type_builder::create();

--- a/crates/samlang-core/src/compiler/lir_lowering.rs
+++ b/crates/samlang-core/src/compiler/lir_lowering.rs
@@ -758,14 +758,14 @@ mod tests {
         ONE, STRING_TYPE, ZERO,
       },
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
   };
   use pretty_assertions::assert_eq;
 
   #[test]
   fn boilterplate() {
     let heap = &mut Heap::new();
-    assert_eq!("A", super::lower_type(Type::Id(heap.alloc_str_for_test("A"))).pretty_print(heap));
+    assert_eq!("A", super::lower_type(Type::Id(well_known_pstrs::UPPER_A)).pretty_print(heap));
   }
 
   fn assert_lowered(sources: Sources, heap: &mut Heap, expected: &str) {
@@ -869,17 +869,14 @@ const {} = (v: any): number => {{ v.length = 0; return 0 }};
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("v1"),
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(
-                heap.alloc_str_for_test("a"),
-                obj_type.clone(),
-              ),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, obj_type.clone()),
               index: 0,
             },
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("v2"),
               type_: INT_TYPE,
               pointer_expression: Expression::var_name(
-                heap.alloc_str_for_test("b"),
+                well_known_pstrs::LOWER_B,
                 variant_type.clone(),
               ),
               index: 0,
@@ -888,7 +885,7 @@ const {} = (v: any): number => {{ v.length = 0; return 0 }};
               name: heap.alloc_str_for_test("v3"),
               type_: INT_TYPE,
               pointer_expression: Expression::var_name(
-                heap.alloc_str_for_test("b"),
+                well_known_pstrs::LOWER_B,
                 variant_type.clone(),
               ),
               index: 1,
@@ -897,7 +894,7 @@ const {} = (v: any): number => {{ v.length = 0; return 0 }};
               name: heap.alloc_str_for_test("v4"),
               type_: STRING_TYPE,
               pointer_expression: Expression::var_name(
-                heap.alloc_str_for_test("b"),
+                well_known_pstrs::LOWER_B,
                 variant_type.clone(),
               ),
               index: 1,

--- a/crates/samlang-core/src/compiler/lir_unused_name_elimination.rs
+++ b/crates/samlang-core/src/compiler/lir_unused_name_elimination.rs
@@ -178,6 +178,7 @@ mod tests {
         INT_TYPE, ZERO,
       },
     },
+    common::well_known_pstrs,
     Heap,
   };
   use itertools::Itertools;
@@ -225,17 +226,17 @@ mod tests {
           type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
           body: vec![
             Statement::Cast {
-              name: heap.alloc_str_for_test(""),
+              name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               assigned_expression: Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE),
             },
             Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               expression_list: vec![Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE)],
             },
             Statement::IndexedAccess {
-              name: heap.alloc_str_for_test(""),
+              name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               pointer_expression: Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE),
               index: 0,
@@ -254,13 +255,13 @@ mod tests {
             Statement::IfElse {
               condition: ZERO,
               s1: vec![Statement::binary(
-                heap.alloc_str_for_test(""),
+                well_known_pstrs::LOWER_A,
                 hir::Operator::GE,
                 Expression::Name(heap.alloc_str_for_test("foo"), INT_TYPE),
                 Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE),
               )],
               s2: vec![Statement::Cast {
-                name: heap.alloc_str_for_test(""),
+                name: well_known_pstrs::LOWER_A,
                 type_: INT_TYPE,
                 assigned_expression: ZERO,
               }],
@@ -273,13 +274,13 @@ mod tests {
             },
             Statement::While {
               loop_variables: vec![GenenalLoopVariable {
-                name: heap.alloc_str_for_test("f"),
+                name: well_known_pstrs::LOWER_F,
                 type_: INT_TYPE,
                 initial_value: ZERO,
                 loop_value: ZERO,
               }],
               statements: vec![],
-              break_collector: Some((heap.alloc_str_for_test("d"), INT_TYPE)),
+              break_collector: Some((well_known_pstrs::LOWER_D, INT_TYPE)),
             },
           ],
           return_value: Expression::Name(heap.alloc_str_for_test("bar"), INT_TYPE),

--- a/crates/samlang-core/src/compiler/mir_constant_param_elimination.rs
+++ b/crates/samlang-core/src/compiler/mir_constant_param_elimination.rs
@@ -390,6 +390,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, FunctionType, GenenalLoopVariable, Sources,
       Statement, Type, VariableName, INT_TYPE, ZERO,
     },
+    common::well_known_pstrs,
     Heap,
   };
   use pretty_assertions::assert_eq;
@@ -419,7 +420,7 @@ mod tests {
       functions: vec![
         Function {
           name: heap.alloc_str_for_test("otherwise_optimizable"),
-          parameters: vec![heap.alloc_str_for_test("a"), heap.alloc_str_for_test("b")],
+          parameters: vec![well_known_pstrs::LOWER_A, well_known_pstrs::LOWER_B],
           type_: FunctionType {
             argument_types: vec![INT_TYPE, INT_TYPE],
             return_type: Box::new(INT_TYPE),
@@ -429,30 +430,27 @@ mod tests {
         },
         Function {
           name: heap.alloc_str_for_test("str_const"),
-          parameters: vec![heap.alloc_str_for_test("a")],
+          parameters: vec![well_known_pstrs::LOWER_A],
           type_: FunctionType { argument_types: vec![INT_TYPE], return_type: Box::new(INT_TYPE) },
-          body: vec![Statement::Break(Expression::var_name(
-            heap.alloc_str_for_test("a"),
-            INT_TYPE,
-          ))],
+          body: vec![Statement::Break(Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE))],
           return_value: ZERO,
         },
         Function {
           name: heap.alloc_str_for_test("func_with_consts"),
           parameters: vec![
-            heap.alloc_str_for_test("a"),
-            heap.alloc_str_for_test("b"),
-            heap.alloc_str_for_test("c"),
-            heap.alloc_str_for_test("d"),
-            heap.alloc_str_for_test("e"),
+            well_known_pstrs::LOWER_A,
+            well_known_pstrs::LOWER_B,
+            well_known_pstrs::LOWER_C,
+            well_known_pstrs::LOWER_D,
+            well_known_pstrs::LOWER_E,
           ],
           type_: FunctionType {
             argument_types: vec![
-              Type::Id(heap.alloc_str_for_test("A")),
-              Type::Id(heap.alloc_str_for_test("B")),
-              Type::Id(heap.alloc_str_for_test("C")),
-              Type::Id(heap.alloc_str_for_test("D")),
-              Type::Id(heap.alloc_str_for_test("E")),
+              Type::Id(well_known_pstrs::UPPER_A),
+              Type::Id(well_known_pstrs::UPPER_B),
+              Type::Id(well_known_pstrs::UPPER_C),
+              Type::Id(well_known_pstrs::UPPER_D),
+              Type::Id(well_known_pstrs::UPPER_E),
             ],
             return_type: Box::new(INT_TYPE),
           },
@@ -460,13 +458,13 @@ mod tests {
             Statement::binary(
               dummy_name,
               Operator::PLUS,
-              Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-              Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
             ),
             Statement::IndexedAccess {
               name: dummy_name,
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 0,
             },
             Statement::ClosureInit {
@@ -501,8 +499,8 @@ mod tests {
                 ZERO,
                 Expression::int(1),
                 Expression::int(2),
-                Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE),
-                Expression::var_name(heap.alloc_str_for_test("e"), INT_TYPE),
+                Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE),
+                Expression::var_name(well_known_pstrs::LOWER_E, INT_TYPE),
               ],
               return_type: INT_TYPE,
               return_collector: None,
@@ -519,8 +517,8 @@ mod tests {
                 ZERO,
                 Expression::int(3),
                 Expression::int(3),
-                Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE),
-                Expression::var_name(heap.alloc_str_for_test("e"), INT_TYPE),
+                Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE),
+                Expression::var_name(well_known_pstrs::LOWER_E, INT_TYPE),
               ],
               return_type: INT_TYPE,
               return_collector: None,
@@ -547,7 +545,7 @@ mod tests {
               return_collector: None,
             },
             Statement::IfElse {
-              condition: Expression::var_name(heap.alloc_str_for_test("e"), INT_TYPE),
+              condition: Expression::var_name(well_known_pstrs::LOWER_E, INT_TYPE),
               s1: vec![Statement::Break(ZERO)],
               s2: vec![Statement::Break(ZERO)],
               final_assignments: vec![(dummy_name, INT_TYPE, ZERO, ZERO)],

--- a/crates/samlang-core/src/compiler/mir_generics_specialization.rs
+++ b/crates/samlang-core/src/compiler/mir_generics_specialization.rs
@@ -64,13 +64,13 @@ impl Rewriter {
     generics_replacement_map: &HashMap<PStr, mir::Type>,
   ) -> mir::Statement {
     match stmt {
-      hir::Statement::Binary(hir::Binary { name, operator, e1, e2 }) => {
-        mir::Statement::Binary(mir::Binary {
-          name: *name,
-          operator: *operator,
-          e1: self.rewrite_expr(heap, e1, generics_replacement_map),
-          e2: self.rewrite_expr(heap, e2, generics_replacement_map),
-        })
+      hir::Statement::Binary { name, operator, e1, e2 } => {
+        mir::Statement::Binary(mir::Statement::binary_unwrapped(
+          *name,
+          *operator,
+          self.rewrite_expr(heap, e1, generics_replacement_map),
+          self.rewrite_expr(heap, e2, generics_replacement_map),
+        ))
       }
       hir::Statement::IndexedAccess { name, type_, pointer_expression, index } => {
         mir::Statement::IndexedAccess {
@@ -535,7 +535,7 @@ sources.mains = [main]
       hir::Sources {
         global_variables: vec![GlobalVariable {
           name: heap.alloc_str_for_test("G1"),
-          content: heap.alloc_str_for_test(""),
+          content: well_known_pstrs::LOWER_A,
         }],
         closure_types: vec![],
         type_definitions: vec![hir::TypeDefinition {
@@ -563,7 +563,7 @@ sources.mains = [main]
         }],
       },
       heap,
-      r#"const G1 = '';
+      r#"const G1 = 'a';
 
 variant type _Str
 function main(): int {
@@ -669,8 +669,8 @@ sources.mains = [main]
   fn comprehensive_test() {
     let heap = &mut Heap::new();
 
-    let type_a = hir::Type::new_id_no_targs(heap.alloc_str_for_test("A"));
-    let type_b = hir::Type::new_id_no_targs(heap.alloc_str_for_test("B"));
+    let type_a = hir::Type::new_id_no_targs(well_known_pstrs::UPPER_A);
+    let type_b = hir::Type::new_id_no_targs(well_known_pstrs::UPPER_B);
     let type_j = hir::Type::new_id_no_targs(heap.alloc_str_for_test("J"));
     let type_ia =
       hir::Type::new_id(heap.alloc_str_for_test("I"), vec![type_a.clone(), hir::STRING_TYPE]);
@@ -684,22 +684,22 @@ sources.mains = [main]
         global_variables: vec![
           GlobalVariable {
             name: heap.alloc_str_for_test("G1"),
-            content: heap.alloc_str_for_test(""),
+            content: well_known_pstrs::LOWER_A,
           },
           GlobalVariable {
             name: heap.alloc_str_for_test("G2"),
-            content: heap.alloc_str_for_test(""),
+            content: well_known_pstrs::LOWER_A,
           },
         ],
         closure_types: vec![hir::ClosureTypeDefinition {
           identifier: heap.alloc_str_for_test("CC"),
-          type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
+          type_parameters: vec![well_known_pstrs::UPPER_A, well_known_pstrs::UPPER_B],
           function_type: hir::Type::new_fn_unwrapped(vec![type_a.clone()], type_b.clone()),
         }],
         type_definitions: vec![
           hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("I"),
-            type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
+            type_parameters: vec![well_known_pstrs::UPPER_A, well_known_pstrs::UPPER_B],
             names: vec![],
             mappings: hir::TypeDefinitionMappings::Enum,
           },
@@ -720,8 +720,8 @@ sources.mains = [main]
         functions: vec![
           hir::Function {
             name: heap.alloc_str_for_test("functor_fun"),
-            parameters: vec![heap.alloc_str_for_test("a")],
-            type_parameters: vec![heap.alloc_str_for_test("A")],
+            parameters: vec![well_known_pstrs::LOWER_A],
+            type_parameters: vec![well_known_pstrs::UPPER_A],
             type_: hir::Type::new_fn_unwrapped(vec![type_a.clone()], hir::INT_TYPE),
             body: vec![hir::Statement::Call {
               callee: hir::Callee::FunctionName(hir::FunctionName::new(
@@ -736,46 +736,46 @@ sources.mains = [main]
           },
           hir::Function {
             name: heap.alloc_str_for_test("_I$bar"),
-            parameters: vec![heap.alloc_str_for_test("a")],
-            type_parameters: vec![heap.alloc_str_for_test("A")],
+            parameters: vec![well_known_pstrs::LOWER_A],
+            type_parameters: vec![well_known_pstrs::UPPER_A],
             type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
             return_value: hir::ZERO,
           },
           hir::Function {
             name: heap.alloc_str_for_test("_J$bar"),
-            parameters: vec![heap.alloc_str_for_test("a")],
-            type_parameters: vec![heap.alloc_str_for_test("A")],
+            parameters: vec![well_known_pstrs::LOWER_A],
+            type_parameters: vec![well_known_pstrs::UPPER_A],
             type_: hir::Type::new_fn_unwrapped(vec![hir::INT_TYPE], hir::INT_TYPE),
             body: vec![],
             return_value: hir::ZERO,
           },
           hir::Function {
             name: heap.alloc_str_for_test("creatorIA"),
-            parameters: vec![heap.alloc_str_for_test("a")],
-            type_parameters: vec![heap.alloc_str_for_test("A")],
+            parameters: vec![well_known_pstrs::LOWER_A],
+            type_parameters: vec![well_known_pstrs::UPPER_A],
             type_: hir::Type::new_fn_unwrapped(vec![type_a.clone()], type_ia.clone()),
             body: vec![hir::Statement::StructInit {
               struct_variable_name: heap.alloc_str_for_test("v"),
               type_: type_ia.clone().into_id().unwrap(),
               expression_list: vec![
                 hir::Expression::int(0),
-                hir::Expression::var_name(heap.alloc_str_for_test("a"), type_a),
+                hir::Expression::var_name(well_known_pstrs::LOWER_A, type_a),
               ],
             }],
             return_value: hir::Expression::var_name(heap.alloc_str_for_test("v"), type_ia),
           },
           hir::Function {
             name: heap.alloc_str_for_test("creatorIB"),
-            parameters: vec![heap.alloc_str_for_test("b")],
-            type_parameters: vec![heap.alloc_str_for_test("B")],
+            parameters: vec![well_known_pstrs::LOWER_B],
+            type_parameters: vec![well_known_pstrs::UPPER_B],
             type_: hir::Type::new_fn_unwrapped(vec![type_b.clone()], type_ib.clone()),
             body: vec![hir::Statement::StructInit {
               struct_variable_name: heap.alloc_str_for_test("v"),
               type_: type_ib.clone().into_id().unwrap(),
               expression_list: vec![
                 hir::Expression::int(1),
-                hir::Expression::var_name(heap.alloc_str_for_test("b"), type_b),
+                hir::Expression::var_name(well_known_pstrs::LOWER_B, type_b),
               ],
             }],
             return_value: hir::Expression::var_name(heap.alloc_str_for_test("v"), type_ib),
@@ -796,7 +796,7 @@ sources.mains = [main]
                   }),
                   arguments: vec![hir::ZERO],
                   return_type: type_i.clone(),
-                  return_collector: Some(heap.alloc_str_for_test("a")),
+                  return_collector: Some(well_known_pstrs::LOWER_A),
                 },
                 hir::Statement::Call {
                   callee: hir::Callee::FunctionName(hir::FunctionName {
@@ -822,7 +822,7 @@ sources.mains = [main]
                   }),
                   arguments: vec![g1.clone()],
                   return_type: type_i.clone(),
-                  return_collector: Some(heap.alloc_str_for_test("b")),
+                  return_collector: Some(well_known_pstrs::LOWER_B),
                 },
                 hir::Statement::Call {
                   callee: hir::Callee::FunctionName(hir::FunctionName {
@@ -847,17 +847,14 @@ sources.mains = [main]
                 hir::Statement::IndexedAccess {
                   name: heap.alloc_str_for_test("v1"),
                   type_: hir::INT_TYPE,
-                  pointer_expression: hir::Expression::var_name(
-                    heap.alloc_str_for_test("a"),
-                    type_i,
-                  ),
+                  pointer_expression: hir::Expression::var_name(well_known_pstrs::LOWER_A, type_i),
                   index: 0,
                 },
                 hir::Statement::Cast {
                   name: heap.alloc_str_for_test("cast"),
                   type_: hir::INT_TYPE,
                   assigned_expression: hir::Expression::var_name(
-                    heap.alloc_str_for_test("a"),
+                    well_known_pstrs::LOWER_A,
                     hir::INT_TYPE,
                   ),
                 },
@@ -872,24 +869,21 @@ sources.mains = [main]
                   return_type: hir::INT_TYPE,
                   return_collector: None,
                 },
-                hir::Statement::binary(
-                  heap.alloc_str_for_test("v1"),
-                  Operator::PLUS,
-                  hir::ZERO,
-                  hir::ZERO,
-                ),
+                hir::Statement::Binary {
+                  name: heap.alloc_str_for_test("v1"),
+                  operator: Operator::PLUS,
+                  e1: hir::ZERO,
+                  e2: hir::ZERO,
+                },
                 hir::Statement::StructInit {
-                  struct_variable_name: heap.alloc_str_for_test("j"),
+                  struct_variable_name: well_known_pstrs::LOWER_J,
                   type_: type_j.clone().into_id().unwrap(),
                   expression_list: vec![hir::Expression::int(0)],
                 },
                 hir::Statement::IndexedAccess {
                   name: heap.alloc_str_for_test("v2"),
                   type_: hir::INT_TYPE,
-                  pointer_expression: hir::Expression::var_name(
-                    heap.alloc_str_for_test("j"),
-                    type_j,
-                  ),
+                  pointer_expression: hir::Expression::var_name(well_known_pstrs::LOWER_J, type_j),
                   index: 0,
                 },
                 hir::Statement::ClosureInit {
@@ -944,7 +938,7 @@ sources.mains = [main]
       },
       heap,
       r#"
-const G1 = '';
+const G1 = 'a';
 
 closure type CC__Str__Str = (_Str) -> _Str
 closure type CC_int__Str = (int) -> _Str
@@ -1023,7 +1017,7 @@ sources.mains = [main]"#,
         type_definitions: vec![
           hir::TypeDefinition {
             identifier: heap.alloc_str_for_test("I"),
-            type_parameters: vec![heap.alloc_str_for_test("A"), heap.alloc_str_for_test("B")],
+            type_parameters: vec![well_known_pstrs::UPPER_A, well_known_pstrs::UPPER_B],
             names: vec![],
             mappings: hir::TypeDefinitionMappings::Enum,
           },

--- a/crates/samlang-core/src/compiler/mir_tail_recursion_rewrite.rs
+++ b/crates/samlang-core/src/compiler/mir_tail_recursion_rewrite.rs
@@ -212,7 +212,10 @@ pub(super) fn optimize_function_by_tailrec_rewrite(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ast::mir::{FunctionName, INT_TYPE};
+  use crate::{
+    ast::mir::{FunctionName, INT_TYPE},
+    common::well_known_pstrs,
+  };
   use pretty_assertions::assert_eq;
 
   fn assert_optimization_failed(f: Function, heap: &mut Heap) {
@@ -233,7 +236,7 @@ mod tests {
         parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: vec![],
-        return_value: Expression::StringName(heap.alloc_str_for_test("")),
+        return_value: Expression::StringName(well_known_pstrs::LOWER_A),
       },
       heap,
     );
@@ -244,7 +247,7 @@ mod tests {
         parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: vec![],
-        return_value: Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        return_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       },
       heap,
     );
@@ -254,8 +257,8 @@ mod tests {
         name: heap.alloc_str_for_test("ff"),
         parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
-        body: vec![Statement::binary(heap.alloc_str_for_test(""), Operator::PLUS, ZERO, ZERO)],
-        return_value: Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        body: vec![Statement::binary(well_known_pstrs::LOWER_A, Operator::PLUS, ZERO, ZERO)],
+        return_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       },
       heap,
     );
@@ -266,12 +269,12 @@ mod tests {
         parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: vec![Statement::Call {
-          callee: Callee::Variable(VariableName::new(heap.alloc_str_for_test(""), INT_TYPE)),
+          callee: Callee::Variable(VariableName::new(well_known_pstrs::LOWER_A, INT_TYPE)),
           arguments: vec![],
           return_type: INT_TYPE,
           return_collector: None,
         }],
-        return_value: Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        return_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       },
       heap,
     );
@@ -283,14 +286,14 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: vec![Statement::Call {
           callee: Callee::FunctionName(FunctionName::new(
-            heap.alloc_str_for_test(""),
+            well_known_pstrs::LOWER_A,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           )),
           arguments: vec![],
           return_type: INT_TYPE,
           return_collector: None,
         }],
-        return_value: Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        return_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       },
       heap,
     );
@@ -306,7 +309,7 @@ mod tests {
           s2: vec![],
           final_assignments: vec![],
         }],
-        return_value: Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+        return_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
       },
       heap,
     );
@@ -357,7 +360,7 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![
           Statement::binary(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
             Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             ZERO,
@@ -367,7 +370,7 @@ mod tests {
               heap.alloc_str_for_test("loopy"),
               Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
             )),
-            arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+            arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
             return_type: INT_TYPE,
             return_collector: Some(heap.alloc_str_for_test("r")),
           },
@@ -396,7 +399,7 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![
           Statement::binary(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
             Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             ZERO,
@@ -406,7 +409,7 @@ mod tests {
               heap.alloc_str_for_test("loopy"),
               Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
             )),
-            arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+            arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
             return_type: INT_TYPE,
             return_collector: None,
           },
@@ -436,7 +439,7 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![
           Statement::binary(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
             Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             ZERO,
@@ -448,7 +451,7 @@ mod tests {
                 heap.alloc_str_for_test("loopy"),
                 Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
               )),
-              arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+              arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
               return_type: INT_TYPE,
               return_collector: Some(heap.alloc_str_for_test("r1")),
             }],
@@ -457,7 +460,7 @@ mod tests {
                 heap.alloc_str_for_test("loopy"),
                 Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
               )),
-              arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+              arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
               return_type: INT_TYPE,
               return_collector: Some(heap.alloc_str_for_test("r2")),
             }],
@@ -500,7 +503,7 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![
           Statement::binary(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
             Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             ZERO,
@@ -512,7 +515,7 @@ mod tests {
                 heap.alloc_str_for_test("loopy"),
                 Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
               )),
-              arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+              arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
               return_type: INT_TYPE,
               return_collector: Some(heap.alloc_str_for_test("r1")),
             }],
@@ -553,7 +556,7 @@ mod tests {
         type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
         body: vec![
           Statement::binary(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
             Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
             ZERO,
@@ -565,7 +568,7 @@ mod tests {
                 heap.alloc_str_for_test("loopy"),
                 Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
               )),
-              arguments: vec![Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE)],
+              arguments: vec![Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE)],
               return_type: INT_TYPE,
               return_collector: None,
             }],

--- a/crates/samlang-core/src/compiler/mir_type_deduplication.rs
+++ b/crates/samlang-core/src/compiler/mir_type_deduplication.rs
@@ -219,6 +219,7 @@ mod tests {
   use super::*;
   use crate::{
     ast::mir::{INT_TYPE, ONE, STRING_TYPE, ZERO},
+    common::well_known_pstrs,
     Heap,
   };
   use pretty_assertions::assert_eq;
@@ -265,22 +266,22 @@ mod tests {
       global_variables: vec![],
       closure_types: vec![
         ClosureTypeDefinition {
-          identifier: heap.alloc_str_for_test("A"),
+          identifier: well_known_pstrs::UPPER_A,
           function_type: Type::new_fn_unwrapped(vec![], INT_TYPE),
         },
         ClosureTypeDefinition {
-          identifier: heap.alloc_str_for_test("B"),
+          identifier: well_known_pstrs::UPPER_B,
           function_type: Type::new_fn_unwrapped(vec![], INT_TYPE),
         },
       ],
       type_definitions: vec![
         TypeDefinition {
-          identifier: heap.alloc_str_for_test("C"),
+          identifier: well_known_pstrs::UPPER_C,
           names: vec![],
           mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, STRING_TYPE]),
         },
         TypeDefinition {
-          identifier: heap.alloc_str_for_test("D"),
+          identifier: well_known_pstrs::UPPER_D,
           names: vec![],
           mappings: TypeDefinitionMappings::Struct(vec![INT_TYPE, STRING_TYPE]),
         },
@@ -301,7 +302,7 @@ mod tests {
             ),
             Statement::Call {
               callee: Callee::FunctionName(FunctionName {
-                name: heap.alloc_str_for_test("f"),
+                name: well_known_pstrs::LOWER_F,
                 type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
               }),
               arguments: vec![ZERO],
@@ -310,7 +311,7 @@ mod tests {
             },
             Statement::Call {
               callee: Callee::Variable(VariableName {
-                name: heap.alloc_str_for_test("f"),
+                name: well_known_pstrs::LOWER_F,
                 type_: INT_TYPE,
               }),
               arguments: vec![],
@@ -319,7 +320,7 @@ mod tests {
             },
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("_"),
-              type_: Type::Id(heap.alloc_str_for_test("B")),
+              type_: Type::Id(well_known_pstrs::UPPER_B),
               pointer_expression: ZERO,
               index: 0,
             },
@@ -332,18 +333,15 @@ mod tests {
             },
             Statement::StructInit {
               struct_variable_name: heap.alloc_str_for_test("_"),
-              type_name: heap.alloc_str_for_test("D"),
+              type_name: well_known_pstrs::UPPER_D,
               expression_list: vec![ZERO],
             },
             Statement::ClosureInit {
               closure_variable_name: heap.alloc_str_for_test("_"),
-              closure_type_name: heap.alloc_str_for_test("C"),
+              closure_type_name: well_known_pstrs::UPPER_C,
               function_name: FunctionName {
-                name: heap.alloc_str_for_test("f"),
-                type_: Type::new_fn_unwrapped(
-                  vec![Type::Id(heap.alloc_str_for_test("E"))],
-                  INT_TYPE,
-                ),
+                name: well_known_pstrs::LOWER_F,
+                type_: Type::new_fn_unwrapped(vec![Type::Id(well_known_pstrs::UPPER_E)], INT_TYPE),
               },
               context: Expression::var_name(heap.alloc_str_for_test("v"), INT_TYPE),
             },

--- a/crates/samlang-core/src/compiler/wasm_lowering.rs
+++ b/crates/samlang-core/src/compiler/wasm_lowering.rs
@@ -288,15 +288,13 @@ mod tests {
       hir::{GlobalVariable, Operator},
       lir::{Expression, Function, GenenalLoopVariable, Sources, Statement, Type, INT_TYPE, ZERO},
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
   };
   use pretty_assertions::assert_eq;
 
   #[test]
   fn boilterplate() {
-    let heap = &mut Heap::new();
-
-    assert!(super::LoopContext { break_collector: None, exit_label: heap.alloc_str_for_test("") }
+    assert!(super::LoopContext { break_collector: None, exit_label: well_known_pstrs::LOWER_A }
       .clone()
       .break_collector
       .is_none());
@@ -329,7 +327,7 @@ mod tests {
             condition: ZERO,
             s1: vec![],
             s2: vec![Statement::Cast {
-              name: heap.alloc_str_for_test("c"),
+              name: well_known_pstrs::LOWER_C,
               type_: INT_TYPE,
               assigned_expression: ZERO,
             }],
@@ -339,13 +337,13 @@ mod tests {
             condition: ZERO,
             s1: vec![Statement::While {
               loop_variables: vec![GenenalLoopVariable {
-                name: heap.alloc_str_for_test("i"),
+                name: well_known_pstrs::LOWER_I,
                 type_: INT_TYPE,
                 initial_value: ZERO,
                 loop_value: ZERO,
               }],
               statements: vec![Statement::Cast {
-                name: heap.alloc_str_for_test("c"),
+                name: well_known_pstrs::LOWER_C,
                 type_: INT_TYPE,
                 assigned_expression: ZERO,
               }],
@@ -359,7 +357,7 @@ mod tests {
                   invert_condition: false,
                   statements: vec![Statement::Break(ZERO)],
                 }],
-                break_collector: Some((heap.alloc_str_for_test("b"), INT_TYPE)),
+                break_collector: Some((well_known_pstrs::LOWER_B, INT_TYPE)),
               },
               Statement::While {
                 loop_variables: vec![],
@@ -372,7 +370,7 @@ mod tests {
               },
             ],
             final_assignments: vec![(
-              heap.alloc_str_for_test("f"),
+              well_known_pstrs::LOWER_F,
               INT_TYPE,
               Expression::Name(heap.alloc_str_for_test("FOO"), INT_TYPE),
               Expression::Name(heap.alloc_str_for_test("main"), Type::new_fn(vec![], INT_TYPE)),
@@ -381,7 +379,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("bin"),
             Operator::PLUS,
-            Expression::Variable(heap.alloc_str_for_test("f"), INT_TYPE),
+            Expression::Variable(well_known_pstrs::LOWER_F, INT_TYPE),
             ZERO,
           ),
           Statement::Call {
@@ -394,7 +392,7 @@ mod tests {
             return_collector: None,
           },
           Statement::Call {
-            callee: Expression::Variable(heap.alloc_str_for_test("f"), INT_TYPE),
+            callee: Expression::Variable(well_known_pstrs::LOWER_F, INT_TYPE),
             arguments: vec![ZERO],
             return_type: INT_TYPE,
             return_collector: Some(heap.alloc_str_for_test("rc")),

--- a/crates/samlang-core/src/errors.rs
+++ b/crates/samlang-core/src/errors.rs
@@ -332,7 +332,7 @@ mod tests {
     );
     error_set.report_name_already_bound_error(
       Location::dummy(),
-      heap.alloc_str_for_test("a"),
+      well_known_pstrs::LOWER_A,
       Location::dummy(),
     );
     error_set.report_non_exhausive_match_error(

--- a/crates/samlang-core/src/interpreter/lir_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/lir_interpreter.rs
@@ -329,7 +329,7 @@ mod tests {
         Expression, Function, GenenalLoopVariable, Sources, Statement, Type, INT_TYPE, ONE, ZERO,
       },
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
   };
   use pretty_assertions::assert_eq;
 
@@ -340,7 +340,7 @@ mod tests {
 
     let sources = Sources {
       global_variables: vec![GlobalVariable {
-        name: heap.alloc_str_for_test("A"),
+        name: well_known_pstrs::UPPER_A,
         content: heap.alloc_str_for_test("Ouch"),
       }],
       type_definitions: vec![],
@@ -354,7 +354,7 @@ mod tests {
             heap.alloc_string(common_names::encoded_fn_name_panic()),
             INT_TYPE,
           ),
-          arguments: vec![ZERO, Expression::Variable(heap.alloc_str_for_test("A"), INT_TYPE)],
+          arguments: vec![ZERO, Expression::Variable(well_known_pstrs::UPPER_A, INT_TYPE)],
           return_type: INT_TYPE,
           return_collector: None,
         }],
@@ -486,11 +486,11 @@ mod tests {
     assert_run_output(
       vec![
         GlobalVariable {
-          name: heap.alloc_str_for_test("A"),
+          name: well_known_pstrs::UPPER_A,
           content: heap.alloc_str_for_test("Hello "),
         },
         GlobalVariable {
-          name: heap.alloc_str_for_test("B"),
+          name: well_known_pstrs::UPPER_B,
           content: heap.alloc_str_for_test("World!"),
         },
       ],
@@ -552,14 +552,14 @@ mod tests {
           type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
           body: vec![
             Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test("a"),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               expression_list: vec![ZERO, ZERO],
             },
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("v"),
               type_: INT_TYPE,
-              pointer_expression: Expression::Variable(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::Variable(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 0,
             },
             Statement::Binary {
@@ -666,7 +666,7 @@ mod tests {
             },
             Statement::IndexedAssign {
               assigned_expression: Expression::Variable(heap.alloc_str_for_test("v"), INT_TYPE),
-              pointer_expression: Expression::Variable(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::Variable(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 1,
             },
             Statement::SingleIf {
@@ -677,7 +677,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("B"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_B, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -690,7 +690,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("A"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_A, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -702,7 +702,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("A"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_A, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -711,7 +711,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("B"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_B, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -724,7 +724,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("B"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_B, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -733,7 +733,7 @@ mod tests {
                   heap.alloc_string(common_names::encoded_fn_name_println()),
                   INT_TYPE,
                 ),
-                arguments: vec![ZERO, Expression::Name(heap.alloc_str_for_test("A"), INT_TYPE)],
+                arguments: vec![ZERO, Expression::Name(well_known_pstrs::UPPER_A, INT_TYPE)],
                 return_type: INT_TYPE,
                 return_collector: None,
               }],
@@ -810,8 +810,8 @@ mod tests {
                 INT_TYPE,
               ),
               arguments: vec![
-                Expression::Name(heap.alloc_str_for_test("A"), INT_TYPE),
-                Expression::Name(heap.alloc_str_for_test("B"), INT_TYPE),
+                Expression::Name(well_known_pstrs::UPPER_A, INT_TYPE),
+                Expression::Name(well_known_pstrs::UPPER_B, INT_TYPE),
               ],
               return_type: INT_TYPE,
               return_collector: Some(heap.alloc_str_for_test("hw_string")),

--- a/crates/samlang-core/src/interpreter/source_interpreter.rs
+++ b/crates/samlang-core/src/interpreter/source_interpreter.rs
@@ -588,7 +588,7 @@ mod tests {
       Value::Boolean(true),
       eval_expr_simple(heap, &expr::E::Literal(dummy_expr_common(), Literal::Bool(true)))
     );
-    let expr = expr::E::Literal(dummy_expr_common(), Literal::String(heap.alloc_str_for_test("a")));
+    let expr = expr::E::Literal(dummy_expr_common(), Literal::String(well_known_pstrs::LOWER_A));
     eval_expr_simple(heap, &expr);
   }
 
@@ -596,7 +596,7 @@ mod tests {
   #[test]
   fn this_panic_tests() {
     let heap = &mut Heap::new();
-    let expr = expr::E::LocalId(dummy_expr_common(), Id::from(heap.alloc_str_for_test("a")));
+    let expr = expr::E::LocalId(dummy_expr_common(), Id::from(well_known_pstrs::LOWER_A));
     eval_expr_simple(heap, &expr);
   }
 
@@ -614,16 +614,16 @@ mod tests {
   fn this_variable_class_id_passing_tests() {
     let mut cx = empty_cx();
     let mut heap = Heap::new();
-    cx.local_values.insert(heap.alloc_str_for_test("a"), Value::Int(1));
+    cx.local_values.insert(well_known_pstrs::LOWER_A, Value::Int(1));
     cx.local_values.insert(heap.alloc_str_for_test("this"), Value::Int(1));
     let expr = expr::E::LocalId(dummy_expr_common(), Id::from(heap.alloc_str_for_test("this")));
     assert_eq!(Value::Int(1), eval_expr(&mut cx, &mut heap, &expr));
-    let expr = expr::E::LocalId(dummy_expr_common(), Id::from(heap.alloc_str_for_test("a")));
+    let expr = expr::E::LocalId(dummy_expr_common(), Id::from(well_known_pstrs::LOWER_A));
     assert_eq!(Value::Int(1), eval_expr(&mut cx, &mut heap, &expr));
     let expr = expr::E::ClassId(
       dummy_expr_common(),
       ModuleReference::dummy(),
-      Id::from(heap.alloc_str_for_test("a")),
+      Id::from(well_known_pstrs::LOWER_A),
     );
     assert_eq!(Value::Int(0), eval_expr(&mut cx, &mut heap, &expr));
   }
@@ -638,7 +638,7 @@ mod tests {
       toplevels: vec![Toplevel::Interface(InterfaceDeclarationCommon {
         loc: Location::dummy(),
         associated_comments: NO_COMMENT_REFERENCE,
-        name: Id::from(heap.alloc_str_for_test("")),
+        name: Id::from(well_known_pstrs::LOWER_A),
         type_parameters: vec![],
         extends_or_implements_nodes: vec![],
         type_definition: (),

--- a/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
+++ b/crates/samlang-core/src/optimization/common_subexpression_elimination.rs
@@ -85,6 +85,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, Statement, Type, VariableName, INT_TYPE, ONE,
       ZERO,
     },
+    common::well_known_pstrs,
     Heap,
   };
   use itertools::Itertools;
@@ -92,7 +93,7 @@ mod tests {
 
   fn assert_correctly_optimized(stmts: Vec<Statement>, heap: &mut Heap, expected: &str) {
     let mut f = Function {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       parameters: vec![],
       type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       body: stmts,
@@ -110,10 +111,10 @@ mod tests {
 
     assert_correctly_optimized(
       vec![Statement::IfElse {
-        condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+        condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
         s1: vec![
           Statement::binary(heap.alloc_str_for_test("ddddd"), Operator::PLUS, ONE, ONE),
-          Statement::binary(heap.alloc_str_for_test("a"), Operator::PLUS, ONE, ZERO),
+          Statement::binary(well_known_pstrs::LOWER_A, Operator::PLUS, ONE, ZERO),
           Statement::IndexedAccess {
             name: heap.alloc_str_for_test("ddd"),
             type_: INT_TYPE,
@@ -126,7 +127,7 @@ mod tests {
               Type::new_fn_unwrapped(vec![], INT_TYPE),
             )),
             arguments: vec![
-              Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               Expression::var_name(heap.alloc_str_for_test("ddd"), INT_TYPE),
             ],
             return_type: INT_TYPE,

--- a/crates/samlang-core/src/optimization/conditional_constant_propagation.rs
+++ b/crates/samlang-core/src/optimization/conditional_constant_propagation.rs
@@ -550,8 +550,11 @@ pub(super) fn optimize_function(function: &mut Function, heap: &mut Heap) {
 mod boilterplate_tests {
   use super::{optimize_callee, BinaryExpression};
   use crate::{
-    ast::hir::Operator, ast::mir::*, common::INVALID_PSTR,
-    optimization::optimization_common::LocalValueContextForOptimization, Heap,
+    ast::hir::Operator,
+    ast::mir::*,
+    common::{well_known_pstrs, INVALID_PSTR},
+    optimization::optimization_common::LocalValueContextForOptimization,
+    Heap,
   };
 
   #[test]
@@ -574,28 +577,26 @@ mod boilterplate_tests {
     let mut value_cx = LocalValueContextForOptimization::new();
     let heap = &mut Heap::new();
     value_cx.checked_bind(
-      heap.alloc_str_for_test("a"),
-      Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+      well_known_pstrs::LOWER_A,
+      Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
     );
     value_cx.checked_bind(
-      heap.alloc_str_for_test("b"),
+      well_known_pstrs::LOWER_B,
       Expression::StringName(heap.alloc_str_for_test("1")),
     );
-    value_cx.checked_bind(
-      heap.alloc_str_for_test("c"),
-      Expression::StringName(heap.alloc_str_for_test("")),
+    value_cx
+      .checked_bind(well_known_pstrs::LOWER_C, Expression::StringName(well_known_pstrs::UPPER_A));
+    optimize_callee(
+      &mut value_cx,
+      &Callee::Variable(VariableName { name: well_known_pstrs::LOWER_A, type_: INT_TYPE }),
     );
     optimize_callee(
       &mut value_cx,
-      &Callee::Variable(VariableName { name: heap.alloc_str_for_test("a"), type_: INT_TYPE }),
+      &Callee::Variable(VariableName { name: well_known_pstrs::LOWER_B, type_: INT_TYPE }),
     );
     optimize_callee(
       &mut value_cx,
-      &Callee::Variable(VariableName { name: heap.alloc_str_for_test("b"), type_: INT_TYPE }),
-    );
-    optimize_callee(
-      &mut value_cx,
-      &Callee::Variable(VariableName { name: heap.alloc_str_for_test("c"), type_: INT_TYPE }),
+      &Callee::Variable(VariableName { name: well_known_pstrs::LOWER_C, type_: INT_TYPE }),
     );
   }
 }

--- a/crates/samlang-core/src/optimization/conditional_constant_propagation_tests.rs
+++ b/crates/samlang-core/src/optimization/conditional_constant_propagation_tests.rs
@@ -6,7 +6,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
   };
   use itertools::Itertools;
   use pretty_assertions::assert_eq;
@@ -18,7 +18,7 @@ mod tests {
     expected: &str,
   ) {
     let mut f = Function {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       parameters: vec![],
       type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       body: stmts,
@@ -316,7 +316,7 @@ return (a17: int);"#,
     assert_correctly_optimized(
       vec![
         Statement::StructInit {
-          struct_variable_name: heap.alloc_str_for_test("a"),
+          struct_variable_name: well_known_pstrs::LOWER_A,
           type_name: heap.alloc_str_for_test("Id"),
           expression_list: vec![ZERO, ONE],
         },
@@ -324,7 +324,7 @@ return (a17: int);"#,
           name: heap.alloc_str_for_test("v1"),
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Type::Id(heap.alloc_str_for_test("Id")),
           ),
           index: 0,
@@ -333,7 +333,7 @@ return (a17: int);"#,
           name: heap.alloc_str_for_test("v2"),
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Type::Id(heap.alloc_str_for_test("Id")),
           ),
           index: 1,
@@ -784,7 +784,7 @@ return 1;"#,
           Expression::int(3),
         ),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -806,7 +806,7 @@ return 1;"#,
           final_assignments: vec![],
         },
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("foo"),
@@ -833,7 +833,7 @@ return 1;"#,
           )],
         },
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![],
           s2: vec![],
           final_assignments: vec![(
@@ -987,9 +987,9 @@ return 6;"#,
             ONE,
           ),
         ],
-        break_collector: Some(VariableName { name: heap.alloc_str_for_test("b"), type_: INT_TYPE }),
+        break_collector: Some(VariableName { name: well_known_pstrs::LOWER_B, type_: INT_TYPE }),
       }],
-      Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+      Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
       heap,
       "\nreturn 0;",
     );
@@ -1141,7 +1141,7 @@ return (v: int);"#,
       vec![Statement::While {
         loop_variables: vec![],
         statements: vec![Statement::binary(
-          heap.alloc_str_for_test("a"),
+          well_known_pstrs::LOWER_A,
           Operator::PLUS,
           Expression::var_name(heap.alloc_str_for_test("v1"), INT_TYPE),
           Expression::var_name(heap.alloc_str_for_test("v2"), INT_TYPE),

--- a/crates/samlang-core/src/optimization/dead_code_elimination_tests.rs
+++ b/crates/samlang-core/src/optimization/dead_code_elimination_tests.rs
@@ -6,7 +6,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
     optimization::dead_code_elimination,
   };
   use itertools::Itertools;
@@ -20,7 +20,7 @@ mod tests {
     expected: &str,
   ) {
     let mut f = Function {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       parameters: vec![],
       type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       body: stmts,
@@ -45,7 +45,7 @@ mod tests {
       Statement::binary(heap.alloc_str_for_test("u3"), Operator::PLUS, ZERO, ONE),
       Statement::binary(heap.alloc_str_for_test("p"), Operator::PLUS, ZERO, ONE),
       Statement::IndexedAccess {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         type_: INT_TYPE,
         pointer_expression: Expression::var_name(heap.alloc_str_for_test("p"), INT_TYPE),
         index: 3,
@@ -103,7 +103,7 @@ return (ii: int);"#,
         Statement::binary(heap.alloc_str_for_test("u3"), Operator::PLUS, ZERO, ONE),
         Statement::binary(heap.alloc_str_for_test("p"), Operator::PLUS, ZERO, ONE),
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(heap.alloc_str_for_test("p"), INT_TYPE),
           index: 3,
@@ -175,9 +175,9 @@ return 0;"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -217,9 +217,9 @@ return 0;"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -267,9 +267,9 @@ return (ma: int);"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -311,9 +311,9 @@ return 0;"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
               heap.alloc_str_for_test("s1"),
@@ -358,9 +358,9 @@ return 0;"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::IfElse {
-          condition: Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          condition: Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           s1: vec![],
           s2: vec![],
           final_assignments: vec![],
@@ -378,7 +378,7 @@ return 0;"#,
 
     assert_correctly_optimized(
       vec![
-        Statement::binary(heap.alloc_str_for_test("b"), Operator::EQ, ZERO, ONE),
+        Statement::binary(well_known_pstrs::LOWER_B, Operator::EQ, ZERO, ONE),
         Statement::SingleIf {
           condition: Expression::var_name(heap.alloc_str_for_test("is_zero"), INT_TYPE),
           invert_condition: false,

--- a/crates/samlang-core/src/optimization/inlining_tests.rs
+++ b/crates/samlang-core/src/optimization/inlining_tests.rs
@@ -6,7 +6,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
   };
   use itertools::Itertools;
   use pretty_assertions::assert_eq;
@@ -32,7 +32,7 @@ mod tests {
     for _ in 0..100 {
       stmts.push(Statement::While {
         loop_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test(""),
+          name: well_known_pstrs::LOWER_A,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: ZERO,
@@ -41,7 +41,7 @@ mod tests {
           Statement::IndexedAccess {
             name: heap.alloc_str_for_test("i0"),
             type_: INT_TYPE,
-            pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+            pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
             index: 2,
           },
           Statement::binary(
@@ -75,15 +75,15 @@ mod tests {
           Statement::IfElse {
             condition: ZERO,
             s1: vec![Statement::binary(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Operator::PLUS,
-              Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               Expression::int(3),
             )],
             s2: vec![Statement::binary(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Operator::PLUS,
-              Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               Expression::int(3),
             )],
             final_assignments: vec![],
@@ -92,22 +92,22 @@ mod tests {
             condition: ZERO,
             s1: vec![],
             s2: vec![],
-            final_assignments: vec![(heap.alloc_str_for_test("a"), INT_TYPE, ZERO, ZERO)],
+            final_assignments: vec![(well_known_pstrs::LOWER_A, INT_TYPE, ZERO, ZERO)],
           },
           Statement::SingleIf {
             condition: ZERO,
             invert_condition: false,
             statements: vec![Statement::binary(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Operator::PLUS,
-              Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               Expression::int(3),
             )],
           },
           Statement::binary(
-            heap.alloc_str_for_test(""),
+            well_known_pstrs::LOWER_A,
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
             Expression::int(3),
           ),
         ],
@@ -123,7 +123,7 @@ mod tests {
 
     super::super::inlining::optimize_functions(
       vec![Function {
-        name: heap.alloc_str_for_test(""),
+        name: well_known_pstrs::LOWER_A,
         parameters: vec![],
         type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
         body: big_stmts(heap),
@@ -150,7 +150,7 @@ mod tests {
           return_value: ZERO,
         },
         Function {
-          name: heap.alloc_str_for_test(""),
+          name: well_known_pstrs::LOWER_A,
           parameters: vec![],
           type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
           body: big_stmts(heap),
@@ -173,13 +173,13 @@ mod tests {
           type_: Type::new_fn_unwrapped(vec![INT_TYPE, INT_TYPE], INT_TYPE),
           body: vec![
             Statement::binary(
-              heap.alloc_str_for_test("c"),
+              well_known_pstrs::LOWER_C,
               Operator::EQ,
               Expression::var_name(heap.alloc_str_for_test("n"), INT_TYPE),
               ZERO,
             ),
             Statement::IfElse {
-              condition: Expression::var_name(heap.alloc_str_for_test("c"), INT_TYPE),
+              condition: Expression::var_name(well_known_pstrs::LOWER_C, INT_TYPE),
               s1: vec![],
               s2: vec![
                 Statement::binary(
@@ -234,7 +234,7 @@ mod tests {
         },
         Function {
           name: heap.alloc_str_for_test("insanelyBigFunction"),
-          parameters: vec![heap.alloc_str_for_test("a")],
+          parameters: vec![well_known_pstrs::LOWER_A],
           type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
           body: vec![
             Statement::Call {
@@ -265,7 +265,7 @@ mod tests {
               return_collector: None,
             },
             Statement::Call {
-              callee: Callee::Variable(VariableName::new(heap.alloc_str_for_test("a"), INT_TYPE)),
+              callee: Callee::Variable(VariableName::new(well_known_pstrs::LOWER_A, INT_TYPE)),
               arguments: vec![],
               return_type: INT_TYPE,
               return_collector: None,
@@ -286,7 +286,7 @@ mod tests {
         },
         Function {
           name: heap.alloc_str_for_test("moveMove"),
-          parameters: vec![heap.alloc_str_for_test("a")],
+          parameters: vec![well_known_pstrs::LOWER_A],
           type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
           body: vec![
             Statement::Cast {
@@ -295,9 +295,9 @@ mod tests {
               assigned_expression: ZERO,
             },
             Statement::IndexedAccess {
-              name: heap.alloc_str_for_test("c"),
+              name: well_known_pstrs::LOWER_C,
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 0,
             },
           ],
@@ -310,15 +310,15 @@ mod tests {
           body: vec![Statement::IfElse {
             condition: ZERO,
             s1: vec![Statement::IndexedAccess {
-              name: heap.alloc_str_for_test("c"),
+              name: well_known_pstrs::LOWER_C,
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 0,
             }],
             s2: vec![Statement::IndexedAccess {
-              name: heap.alloc_str_for_test("c"),
+              name: well_known_pstrs::LOWER_C,
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 0,
             }],
             final_assignments: vec![],
@@ -330,7 +330,7 @@ mod tests {
           parameters: vec![],
           type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
           body: vec![Statement::Call {
-            callee: Callee::Variable(VariableName::new(heap.alloc_str_for_test("a"), INT_TYPE)),
+            callee: Callee::Variable(VariableName::new(well_known_pstrs::LOWER_A, INT_TYPE)),
             arguments: vec![],
             return_type: INT_TYPE,
             return_collector: None,
@@ -566,10 +566,10 @@ function main(): int {
             }],
             s2: vec![],
             final_assignments: vec![(
-              heap.alloc_str_for_test("b"),
+              well_known_pstrs::LOWER_B,
               INT_TYPE,
               ZERO,
-              Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
             )],
           }],
           return_value: ZERO,

--- a/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
+++ b/crates/samlang-core/src/optimization/local_value_numbering_tests.rs
@@ -6,7 +6,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
     optimization::local_value_numbering,
   };
   use itertools::Itertools;
@@ -19,7 +19,7 @@ mod tests {
     expected: &str,
   ) {
     let mut f = Function {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       parameters: vec![],
       type_: Type::new_fn_unwrapped(vec![], INT_TYPE),
       body: stmts,
@@ -43,13 +43,13 @@ mod tests {
         Statement::IndexedAccess {
           name: heap.alloc_str_for_test("i0"),
           type_: INT_TYPE,
-          pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+          pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           index: 2,
         },
         Statement::IndexedAccess {
           name: heap.alloc_str_for_test("i1"),
           type_: INT_TYPE,
-          pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+          pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           index: 2,
         },
         Statement::binary(
@@ -88,7 +88,7 @@ mod tests {
           closure_variable_name: heap.alloc_str_for_test("s"),
           closure_type_name: heap.alloc_str_for_test("S"),
           function_name: FunctionName::new(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           ),
           context: ZERO,
@@ -136,7 +136,7 @@ return (ss: int);"#,
         Statement::IndexedAccess {
           name: heap.alloc_str_for_test("i0"),
           type_: INT_TYPE,
-          pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+          pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           index: 2,
         },
         Statement::IfElse {
@@ -145,7 +145,7 @@ return (ss: int);"#,
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("i1"),
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 2,
             },
             Statement::IndexedAccess {
@@ -159,7 +159,7 @@ return (ss: int);"#,
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("i2"),
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 2,
             },
             Statement::IndexedAccess {
@@ -195,7 +195,7 @@ return 0;"#,
         Statement::IndexedAccess {
           name: heap.alloc_str_for_test("i0"),
           type_: INT_TYPE,
-          pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+          pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           index: 2,
         },
         Statement::IfElse {
@@ -204,7 +204,7 @@ return 0;"#,
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("i1"),
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 2,
             },
             Statement::IndexedAccess {
@@ -218,7 +218,7 @@ return 0;"#,
             Statement::IndexedAccess {
               name: heap.alloc_str_for_test("i2"),
               type_: INT_TYPE,
-              pointer_expression: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+              pointer_expression: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
               index: 2,
             },
             Statement::IndexedAccess {
@@ -280,7 +280,7 @@ return 0;"#,
               ONE,
             )],
             final_assignments: vec![
-              (heap.alloc_str_for_test("c"), INT_TYPE, ZERO, ONE),
+              (well_known_pstrs::LOWER_C, INT_TYPE, ZERO, ONE),
               (
                 heap.alloc_str_for_test("_tmp_n"),
                 INT_TYPE,
@@ -346,7 +346,7 @@ return 0;"#,
               ONE,
             )],
             final_assignments: vec![
-              (heap.alloc_str_for_test("c"), INT_TYPE, ZERO, ONE),
+              (well_known_pstrs::LOWER_C, INT_TYPE, ZERO, ONE),
               (
                 heap.alloc_str_for_test("_tmp_n"),
                 INT_TYPE,

--- a/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
+++ b/crates/samlang-core/src/optimization/loop_algebraic_optimization.rs
@@ -148,7 +148,7 @@ pub(super) fn optimize(
 mod tests {
   use crate::{
     ast::mir::{Expression, Statement, VariableName, INT_TYPE, ZERO},
-    common::Heap,
+    common::{well_known_pstrs, Heap},
     optimization::loop_induction_analysis::{
       BasicInductionVariableWithLoopGuard, GeneralBasicInductionVariable, GuardOperator,
       OptimizableWhileLoop, PotentialLoopInvariantExpression,
@@ -238,8 +238,8 @@ mod tests {
     assert_rejected(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
-          initial_value: Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+          name: well_known_pstrs::LOWER_I,
+          initial_value: Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           increment_amount: PotentialLoopInvariantExpression::Int(0),
           guard_operator: GuardOperator::LT,
           guard_expression: PotentialLoopInvariantExpression::Int(0),
@@ -256,7 +256,7 @@ mod tests {
     assert_rejected(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(0),
           guard_operator: GuardOperator::LT,
@@ -278,7 +278,7 @@ mod tests {
     assert_rejected(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(0),
           guard_operator: GuardOperator::LT,
@@ -316,7 +316,7 @@ mod tests {
     assert_optimized(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(0),
           guard_operator: GuardOperator::LT,
@@ -335,7 +335,7 @@ mod tests {
     assert_optimized(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: Expression::int(5),
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
@@ -354,7 +354,7 @@ mod tests {
     assert_optimized(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: Expression::int(5),
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
@@ -367,7 +367,7 @@ mod tests {
         break_collector: Some((
           heap.alloc_str_for_test("bc"),
           INT_TYPE,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
         )),
       },
       heap,
@@ -377,14 +377,14 @@ mod tests {
     assert_optimized(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: Expression::int(5),
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
           guard_expression: PotentialLoopInvariantExpression::Int(20),
         },
         general_induction_variables: vec![GeneralBasicInductionVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           initial_value: Expression::var_name(heap.alloc_str_for_test("j_init"), INT_TYPE),
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
             heap.alloc_str_for_test("outside"),
@@ -397,7 +397,7 @@ mod tests {
         break_collector: Some((
           heap.alloc_str_for_test("bc"),
           INT_TYPE,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
         )),
       },
       heap,
@@ -407,14 +407,14 @@ mod tests {
     assert_optimized(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: Expression::int(5),
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
           guard_expression: PotentialLoopInvariantExpression::Int(20),
         },
         general_induction_variables: vec![GeneralBasicInductionVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           initial_value: Expression::var_name(heap.alloc_str_for_test("j_init"), INT_TYPE),
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
             heap.alloc_str_for_test("outside"),

--- a/crates/samlang-core/src/optimization/loop_induction_analysis.rs
+++ b/crates/samlang-core/src/optimization/loop_induction_analysis.rs
@@ -653,7 +653,10 @@ pub(super) fn extract_optimizable_while_loop(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ast::mir::{Callee, FunctionName, INT_TYPE, ONE, ZERO};
+  use crate::{
+    ast::mir::{Callee, FunctionName, INT_TYPE, ONE, ZERO},
+    common::well_known_pstrs,
+  };
   use pretty_assertions::assert_eq;
 
   #[test]
@@ -671,7 +674,7 @@ mod tests {
     assert!(get_guard_operator(Operator::EQ, true).is_none());
 
     assert!(!BasicInductionVariableWithLoopGuard {
-      name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
       initial_value: ZERO,
       increment_amount: PotentialLoopInvariantExpression::Int(0),
       guard_operator: GuardOperator::GE,
@@ -682,8 +685,8 @@ mod tests {
     .debug_print(heap)
     .is_empty());
     DerivedInductionVariableWithName {
-      name: heap.alloc_str_for_test(""),
-      base_name: heap.alloc_str_for_test(""),
+      name: well_known_pstrs::LOWER_A,
+      base_name: well_known_pstrs::LOWER_A,
       multiplier: PotentialLoopInvariantExpression::Int(0),
       immediate: PotentialLoopInvariantExpression::Int(0),
     }
@@ -751,12 +754,12 @@ mod tests {
 
     assert!(merge_variable_addition_into_derived_induction_variable(
       &DerivedInductionVariable {
-        base_name: heap.alloc_str_for_test("a"),
+        base_name: well_known_pstrs::LOWER_A,
         multiplier: PotentialLoopInvariantExpression::Int(1),
         immediate: PotentialLoopInvariantExpression::Int(1),
       },
       &DerivedInductionVariable {
-        base_name: heap.alloc_str_for_test("a"),
+        base_name: well_known_pstrs::LOWER_A,
         multiplier: PotentialLoopInvariantExpression::Var(VariableName::new(
           heap.alloc_str_for_test("vv"),
           INT_TYPE
@@ -768,12 +771,12 @@ mod tests {
 
     let successful = merge_variable_addition_into_derived_induction_variable(
       &DerivedInductionVariable {
-        base_name: heap.alloc_str_for_test("a"),
+        base_name: well_known_pstrs::LOWER_A,
         multiplier: PotentialLoopInvariantExpression::Int(1),
         immediate: PotentialLoopInvariantExpression::Int(1),
       },
       &DerivedInductionVariable {
-        base_name: heap.alloc_str_for_test("a"),
+        base_name: well_known_pstrs::LOWER_A,
         multiplier: PotentialLoopInvariantExpression::Int(2),
         immediate: PotentialLoopInvariantExpression::Int(1),
       },
@@ -785,24 +788,22 @@ mod tests {
 
   #[test]
   fn loop_invariant_tests() {
-    let heap = &mut crate::Heap::new();
-
     assert!(!expression_is_loop_invariant(
-      &Expression::StringName(heap.alloc_str_for_test("")),
-      &HashSet::from([heap.alloc_str_for_test("a")])
+      &Expression::StringName(well_known_pstrs::LOWER_B),
+      &HashSet::from([well_known_pstrs::LOWER_A])
     ));
     assert!(!expression_is_loop_invariant(
-      &Expression::StringName(heap.alloc_str_for_test(""),),
-      &HashSet::from([heap.alloc_str_for_test("a")])
+      &Expression::StringName(well_known_pstrs::LOWER_B),
+      &HashSet::from([well_known_pstrs::LOWER_A])
     ));
-    assert!(expression_is_loop_invariant(&ZERO, &HashSet::from([heap.alloc_str_for_test("a")])));
+    assert!(expression_is_loop_invariant(&ZERO, &HashSet::from([well_known_pstrs::LOWER_A])));
     assert!(expression_is_loop_invariant(
-      &Expression::var_name(heap.alloc_str_for_test(""), INT_TYPE),
-      &HashSet::from([heap.alloc_str_for_test("a")])
+      &Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
+      &HashSet::from([well_known_pstrs::LOWER_A])
     ));
     assert!(!expression_is_loop_invariant(
-      &Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-      &HashSet::from([heap.alloc_str_for_test("a")])
+      &Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+      &HashSet::from([well_known_pstrs::LOWER_A])
     ));
   }
 
@@ -811,16 +812,16 @@ mod tests {
     let heap = &mut crate::Heap::new();
 
     assert!(extract_basic_induction_variables(
-      &heap.alloc_str_for_test("i"),
+      &well_known_pstrs::LOWER_I,
       &vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: ZERO
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: ZERO
@@ -832,16 +833,16 @@ mod tests {
     .is_none());
 
     assert!(extract_basic_induction_variables(
-      &heap.alloc_str_for_test("i"),
+      &well_known_pstrs::LOWER_I,
       &vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -851,20 +852,20 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
-          Expression::StringName(heap.alloc_str_for_test(""))
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
+          Expression::StringName(well_known_pstrs::LOWER_A)
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
-          Expression::StringName(heap.alloc_str_for_test("")),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
+          Expression::StringName(well_known_pstrs::LOWER_A),
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j")
       ]),
@@ -876,16 +877,16 @@ mod tests {
       all_basic_induction_variables,
       basic_induction_variable_with_associated_loop_guard,
     } = extract_basic_induction_variables(
-      &heap.alloc_str_for_test("i"),
+      &well_known_pstrs::LOWER_I,
       &vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -895,20 +896,20 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE,
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           Expression::int(3),
         ),
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j"),
       ]),
@@ -941,13 +942,13 @@ mod tests {
       extract_derived_induction_variables(
         &[
           GeneralBasicInductionVariableWithLoopValueCollector {
-            name: heap.alloc_str_for_test("i"),
+            name: well_known_pstrs::LOWER_I,
             initial_value: ZERO,
             increment_amount: PotentialLoopInvariantExpression::Int(1),
             loop_value_collector: heap.alloc_str_for_test("tmp_i"),
           },
           GeneralBasicInductionVariableWithLoopValueCollector {
-            name: heap.alloc_str_for_test("j"),
+            name: well_known_pstrs::LOWER_J,
             initial_value: ZERO,
             increment_amount: PotentialLoopInvariantExpression::Int(3),
             loop_value_collector: heap.alloc_str_for_test("tmp_j"),
@@ -957,13 +958,13 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE
           ),
           Statement::binary(
             heap.alloc_str_for_test("tmp_j"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
             Expression::int(3),
           ),
           Statement::binary(
@@ -980,7 +981,7 @@ mod tests {
           ),
           Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Type::new_fn_unwrapped(vec![], INT_TYPE),
             )),
             arguments: vec![Expression::var_name(heap.alloc_str_for_test("tmp_x"), INT_TYPE)],
@@ -989,7 +990,7 @@ mod tests {
           },
           Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Type::new_fn_unwrapped(vec![], INT_TYPE),
             )),
             arguments: vec![Expression::var_name(heap.alloc_str_for_test("tmp_x"), INT_TYPE)],
@@ -1029,14 +1030,14 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_useless_6"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
-            Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           ),
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j"),
           heap.alloc_str_for_test("tmp_x"),
@@ -1051,7 +1052,7 @@ mod tests {
 
     assert!(extract_derived_induction_variables(
       &[GeneralBasicInductionVariableWithLoopValueCollector {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         initial_value: ZERO,
         increment_amount: PotentialLoopInvariantExpression::Int(1),
         loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1060,20 +1061,20 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           Expression::var_name(heap.alloc_str_for_test("outside"), INT_TYPE),
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j")
       ]),
@@ -1082,7 +1083,7 @@ mod tests {
 
     assert!(extract_derived_induction_variables(
       &[GeneralBasicInductionVariableWithLoopValueCollector {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         initial_value: ZERO,
         increment_amount: PotentialLoopInvariantExpression::Int(1),
         loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1091,20 +1092,20 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           Expression::StringName(heap.alloc_str_for_test("outside")),
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j")
       ]),
@@ -1115,7 +1116,7 @@ mod tests {
       vec!["{name: tmp_j, base_name: i, multiplier: 1, immediate: (outside: int)}"],
       extract_derived_induction_variables(
         &[GeneralBasicInductionVariableWithLoopValueCollector {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1124,7 +1125,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("outside"), INT_TYPE)
           ),
           Statement::binary(
@@ -1135,9 +1136,9 @@ mod tests {
           )
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j")
         ]),
@@ -1151,7 +1152,7 @@ mod tests {
       vec!["{name: tmp_j, base_name: i, multiplier: 1, immediate: (outside: int)}"],
       extract_derived_induction_variables(
         &[GeneralBasicInductionVariableWithLoopValueCollector {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1160,20 +1161,20 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO,
           ),
           Statement::binary(
             heap.alloc_str_for_test("tmp_j"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("outside"), INT_TYPE)
           )
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j")
         ]),
@@ -1187,7 +1188,7 @@ mod tests {
       vec!["{name: tmp_j, base_name: i, multiplier: 1, immediate: (outside: int)}"],
       extract_derived_induction_variables(
         &[GeneralBasicInductionVariableWithLoopValueCollector {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
             heap.alloc_str_for_test("outside"),
@@ -1199,7 +1200,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("outside"), INT_TYPE)
           ),
           Statement::binary(
@@ -1210,9 +1211,9 @@ mod tests {
           )
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j")
         ]),
@@ -1224,7 +1225,7 @@ mod tests {
 
     assert!(extract_derived_induction_variables(
       &[GeneralBasicInductionVariableWithLoopValueCollector {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         initial_value: ZERO,
         increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
           heap.alloc_str_for_test("outside"),
@@ -1236,7 +1237,7 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::var_name(heap.alloc_str_for_test("outside"), INT_TYPE)
         ),
         Statement::binary(
@@ -1247,9 +1248,9 @@ mod tests {
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j")
       ]),
@@ -1260,7 +1261,7 @@ mod tests {
       vec!["{name: tmp_j, base_name: i, multiplier: (outside: int), immediate: (outside: int)}"],
       extract_derived_induction_variables(
         &[GeneralBasicInductionVariableWithLoopValueCollector {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
             heap.alloc_str_for_test("outside"),
@@ -1272,7 +1273,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE
           ),
           Statement::binary(
@@ -1283,9 +1284,9 @@ mod tests {
           )
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j")
         ]),
@@ -1297,7 +1298,7 @@ mod tests {
 
     assert!(extract_derived_induction_variables(
       &[GeneralBasicInductionVariableWithLoopValueCollector {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         initial_value: ZERO,
         increment_amount: PotentialLoopInvariantExpression::Int(2),
         loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1306,7 +1307,7 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(2)
         ),
         Statement::binary(
@@ -1317,9 +1318,9 @@ mod tests {
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j")
       ]),
@@ -1330,7 +1331,7 @@ mod tests {
       vec!["{name: t1, base_name: i, multiplier: 1, immediate: 2}"],
       extract_derived_induction_variables(
         &[GeneralBasicInductionVariableWithLoopValueCollector {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ZERO,
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1339,7 +1340,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE
           ),
           Statement::binary(
@@ -1350,9 +1351,9 @@ mod tests {
           )
         ],
         &HashSet::from([
-          heap.alloc_str_for_test(""),
-          heap.alloc_str_for_test("i"),
-          heap.alloc_str_for_test("j"),
+          well_known_pstrs::LOWER_A,
+          well_known_pstrs::LOWER_I,
+          well_known_pstrs::LOWER_J,
           heap.alloc_str_for_test("tmp_i"),
           heap.alloc_str_for_test("tmp_j"),
           heap.alloc_str_for_test("t1")
@@ -1365,7 +1366,7 @@ mod tests {
 
     assert!(extract_derived_induction_variables(
       &[GeneralBasicInductionVariableWithLoopValueCollector {
-        name: heap.alloc_str_for_test("i"),
+        name: well_known_pstrs::LOWER_I,
         initial_value: ZERO,
         increment_amount: PotentialLoopInvariantExpression::Int(1),
         loop_value_collector: heap.alloc_str_for_test("tmp_i"),
@@ -1374,7 +1375,7 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE
         ),
         Statement::binary(
@@ -1385,9 +1386,9 @@ mod tests {
         )
       ],
       &HashSet::from([
-        heap.alloc_str_for_test(""),
-        heap.alloc_str_for_test("i"),
-        heap.alloc_str_for_test("j"),
+        well_known_pstrs::LOWER_A,
+        well_known_pstrs::LOWER_I,
+        well_known_pstrs::LOWER_J,
         heap.alloc_str_for_test("tmp_i"),
         heap.alloc_str_for_test("tmp_j"),
         heap.alloc_str_for_test("t1")
@@ -1403,13 +1404,13 @@ mod tests {
     remove_dead_code_inside_loop(
       &vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test(""),
+          name: well_known_pstrs::LOWER_A,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: ZERO,
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test(""),
+          name: well_known_pstrs::LOWER_A,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("name"), INT_TYPE),
@@ -1424,9 +1425,9 @@ mod tests {
     let heap = &mut crate::Heap::new();
 
     let non_loop_invariant_variables = HashSet::from([
-      heap.alloc_str_for_test(""),
-      heap.alloc_str_for_test("a"),
-      heap.alloc_str_for_test("b"),
+      well_known_pstrs::LOWER_A,
+      well_known_pstrs::LOWER_A,
+      well_known_pstrs::LOWER_B,
       heap.alloc_str_for_test("cc"),
     ]);
 
@@ -1436,12 +1437,12 @@ mod tests {
       (
         &vec![
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           },
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           }
@@ -1457,7 +1458,7 @@ mod tests {
         &vec![Statement::binary(
           heap.alloc_str_for_test("cc"),
           Operator::LT,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ZERO
         ),],
         &None
@@ -1470,12 +1471,12 @@ mod tests {
       (
         &vec![
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           },
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           }
@@ -1489,9 +1490,9 @@ mod tests {
     assert!(extract_loop_guard_structure(
       (
         &vec![
-          Statement::binary(heap.alloc_str_for_test(""), Operator::PLUS, ZERO, ZERO),
+          Statement::binary(well_known_pstrs::LOWER_A, Operator::PLUS, ZERO, ZERO),
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           }
@@ -1508,11 +1509,11 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           }
@@ -1529,11 +1530,11 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::StructInit {
-            struct_variable_name: heap.alloc_str_for_test(""),
+            struct_variable_name: well_known_pstrs::LOWER_A,
             type_name: heap.alloc_str_for_test("T"),
             expression_list: vec![],
           },
@@ -1551,7 +1552,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf { condition: ZERO, invert_condition: false, statements: vec![] }
@@ -1568,7 +1569,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1589,7 +1590,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1610,7 +1611,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1623,7 +1624,7 @@ mod tests {
             condition: ZERO,
             invert_condition: false,
             statements: vec![Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("I"),
               expression_list: vec![]
             }]
@@ -1631,19 +1632,19 @@ mod tests {
           Statement::IfElse {
             condition: ZERO,
             s1: vec![Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("I"),
               expression_list: vec![]
             }],
             s2: vec![Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("I"),
               expression_list: vec![]
             }],
             final_assignments: vec![]
           },
           Statement::IndexedAccess {
-            name: heap.alloc_str_for_test(""),
+            name: well_known_pstrs::LOWER_A,
             type_: INT_TYPE,
             pointer_expression: ZERO,
             index: 0
@@ -1651,12 +1652,12 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Type::new_fn_unwrapped(vec![], INT_TYPE)
             )),
             arguments: vec![],
@@ -1677,7 +1678,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::EQ,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1698,14 +1699,14 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
             condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("I"),
               expression_list: vec![]
             }]
@@ -1723,14 +1724,14 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
             condition: Expression::StringName(heap.alloc_str_for_test("cc")),
             invert_condition: false,
             statements: vec![Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("I"),
               expression_list: vec![]
             }]
@@ -1754,7 +1755,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1776,7 +1777,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::EQ,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1787,7 +1788,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           )
         ],
@@ -1804,7 +1805,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1815,7 +1816,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           )
         ],
@@ -1832,7 +1833,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::GE,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO
           ),
           Statement::SingleIf {
@@ -1843,7 +1844,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE
           ),
         ],
@@ -1869,13 +1870,13 @@ mod tests {
       (
         vec![
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("i"),
+            name: well_known_pstrs::LOWER_I,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
           },
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("j"),
+            name: well_known_pstrs::LOWER_J,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -1891,7 +1892,7 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::GE,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ZERO,
           ),
           Statement::SingleIf {
@@ -1902,13 +1903,13 @@ mod tests {
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE,
           ),
           Statement::binary(
             heap.alloc_str_for_test("tmp_j"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
             Expression::int(3),
           ),
           Statement::binary(

--- a/crates/samlang-core/src/optimization/loop_induction_variable_elimination.rs
+++ b/crates/samlang-core/src/optimization/loop_induction_variable_elimination.rs
@@ -196,7 +196,7 @@ mod tests {
       Callee, Expression, FunctionName, GenenalLoopVariable, Statement, Type, VariableName,
       INT_TYPE, ONE, ZERO,
     },
-    common::Heap,
+    common::{well_known_pstrs, Heap},
     optimization::loop_induction_analysis::{
       BasicInductionVariableWithLoopGuard, DerivedInductionVariableWithName, GuardOperator,
       OptimizableWhileLoop, PotentialLoopInvariantExpression,
@@ -212,7 +212,7 @@ mod tests {
     assert!(super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(2),
           guard_operator: GuardOperator::LT,
@@ -220,10 +220,10 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test(""),
+          name: well_known_pstrs::LOWER_A,
           type_: INT_TYPE,
           initial_value: ZERO,
-          loop_value: Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE)
+          loop_value: Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE)
         }],
         derived_induction_variables: vec![],
         statements: vec![],
@@ -236,7 +236,7 @@ mod tests {
     assert!(super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(2),
           guard_operator: GuardOperator::LT,
@@ -247,9 +247,9 @@ mod tests {
         derived_induction_variables: vec![],
         statements: vec![],
         break_collector: Some((
-          heap.alloc_str_for_test(""),
+          well_known_pstrs::LOWER_A,
           INT_TYPE,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE)
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE)
         ))
       },
       heap,
@@ -259,7 +259,7 @@ mod tests {
     assert!(super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(2),
           guard_operator: GuardOperator::LT,
@@ -270,12 +270,12 @@ mod tests {
         derived_induction_variables: vec![],
         statements: vec![
           Statement::IndexedAccess {
-            name: heap.alloc_str_for_test(""),
+            name: well_known_pstrs::LOWER_A,
             type_: INT_TYPE,
             pointer_expression: ZERO,
             index: 3
           },
-          Statement::binary(heap.alloc_str_for_test(""), Operator::NE, ZERO, ZERO),
+          Statement::binary(well_known_pstrs::LOWER_A, Operator::NE, ZERO, ZERO),
           Statement::IfElse {
             condition: ZERO,
             s1: vec![Statement::SingleIf {
@@ -284,31 +284,31 @@ mod tests {
               statements: vec![Statement::Break(ZERO)]
             }],
             s2: vec![Statement::ClosureInit {
-              closure_variable_name: heap.alloc_str_for_test(""),
+              closure_variable_name: well_known_pstrs::LOWER_A,
               closure_type_name: heap.alloc_str_for_test("I"),
               function_name: FunctionName::new(
-                heap.alloc_str_for_test(""),
+                well_known_pstrs::LOWER_A,
                 Type::new_fn_unwrapped(vec![], INT_TYPE)
               ),
               context: ZERO
             }],
-            final_assignments: vec![(heap.alloc_str_for_test(""), INT_TYPE, ZERO, ZERO)]
+            final_assignments: vec![(well_known_pstrs::LOWER_A, INT_TYPE, ZERO, ZERO)]
           },
           Statement::While {
             loop_variables: vec![GenenalLoopVariable {
-              name: heap.alloc_str_for_test(""),
+              name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               initial_value: ZERO,
               loop_value: ZERO
             }],
             statements: vec![
               Statement::Cast {
-                name: heap.alloc_str_for_test(""),
+                name: well_known_pstrs::LOWER_A,
                 type_: INT_TYPE,
                 assigned_expression: ZERO,
               },
               Statement::StructInit {
-                struct_variable_name: heap.alloc_str_for_test(""),
+                struct_variable_name: well_known_pstrs::LOWER_A,
                 type_name: heap.alloc_str_for_test("I"),
                 expression_list: vec![ZERO]
               }
@@ -317,7 +317,7 @@ mod tests {
           },
           Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
-              heap.alloc_str_for_test(""),
+              well_known_pstrs::LOWER_A,
               Type::new_fn_unwrapped(vec![], INT_TYPE)
             )),
             arguments: vec![ZERO],
@@ -325,7 +325,7 @@ mod tests {
             return_collector: None
           },
           Statement::Call {
-            callee: Callee::Variable(VariableName::new(heap.alloc_str_for_test(""), INT_TYPE)),
+            callee: Callee::Variable(VariableName::new(well_known_pstrs::LOWER_A, INT_TYPE)),
             arguments: vec![ZERO],
             return_type: INT_TYPE,
             return_collector: None
@@ -340,7 +340,7 @@ mod tests {
     assert!(super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(2),
           guard_operator: GuardOperator::LT,
@@ -348,7 +348,7 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE)
@@ -356,13 +356,13 @@ mod tests {
         derived_induction_variables: vec![
           DerivedInductionVariableWithName {
             name: heap.alloc_str_for_test("tmp_j"),
-            base_name: heap.alloc_str_for_test("i"),
+            base_name: well_known_pstrs::LOWER_I,
             multiplier: PotentialLoopInvariantExpression::Int(3),
             immediate: PotentialLoopInvariantExpression::Int(5)
           },
           DerivedInductionVariableWithName {
             name: heap.alloc_str_for_test("tmp_k"),
-            base_name: heap.alloc_str_for_test("i"),
+            base_name: well_known_pstrs::LOWER_I,
             multiplier: PotentialLoopInvariantExpression::Int(3),
             immediate: PotentialLoopInvariantExpression::Int(5)
           }
@@ -377,10 +377,10 @@ mod tests {
     assert!(super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
-            heap.alloc_str_for_test(""),
+            well_known_pstrs::LOWER_A,
             INT_TYPE
           )),
           guard_operator: GuardOperator::LT,
@@ -388,16 +388,16 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
         }],
         derived_induction_variables: vec![DerivedInductionVariableWithName {
           name: heap.alloc_str_for_test("tmp_j"),
-          base_name: heap.alloc_str_for_test("i"),
+          base_name: well_known_pstrs::LOWER_I,
           multiplier: PotentialLoopInvariantExpression::Var(VariableName::new(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             INT_TYPE
           )),
           immediate: PotentialLoopInvariantExpression::Int(5),
@@ -417,7 +417,7 @@ mod tests {
     let optimized = super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(2),
           guard_operator: GuardOperator::LT,
@@ -425,14 +425,14 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
         }],
         derived_induction_variables: vec![DerivedInductionVariableWithName {
           name: heap.alloc_str_for_test("tmp_j"),
-          base_name: heap.alloc_str_for_test("i"),
+          base_name: well_known_pstrs::LOWER_I,
           multiplier: PotentialLoopInvariantExpression::Int(3),
           immediate: PotentialLoopInvariantExpression::Int(5),
         }],
@@ -472,7 +472,7 @@ mod tests {
     let optimized = super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
@@ -480,16 +480,16 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
         }],
         derived_induction_variables: vec![DerivedInductionVariableWithName {
           name: heap.alloc_str_for_test("tmp_j"),
-          base_name: heap.alloc_str_for_test("i"),
+          base_name: well_known_pstrs::LOWER_I,
           multiplier: PotentialLoopInvariantExpression::Var(VariableName::new(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             INT_TYPE,
           )),
           immediate: PotentialLoopInvariantExpression::Int(5),
@@ -528,10 +528,10 @@ mod tests {
     let optimized = super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
-            heap.alloc_str_for_test("a"),
+            well_known_pstrs::LOWER_A,
             INT_TYPE,
           )),
           guard_operator: GuardOperator::LT,
@@ -539,14 +539,14 @@ mod tests {
         },
         general_induction_variables: vec![],
         loop_variables_that_are_not_basic_induction_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
         }],
         derived_induction_variables: vec![DerivedInductionVariableWithName {
           name: heap.alloc_str_for_test("tmp_j"),
-          base_name: heap.alloc_str_for_test("i"),
+          base_name: well_known_pstrs::LOWER_I,
           multiplier: PotentialLoopInvariantExpression::Int(1),
           immediate: PotentialLoopInvariantExpression::Int(5),
         }],

--- a/crates/samlang-core/src/optimization/loop_invariant_code_motion.rs
+++ b/crates/samlang-core/src/optimization/loop_invariant_code_motion.rs
@@ -139,6 +139,7 @@ mod tests {
       Callee, Expression, FunctionName, GenenalLoopVariable, Statement, Type, VariableName,
       INT_TYPE, ONE, ZERO,
     },
+    common::well_known_pstrs,
     Heap,
   };
   use itertools::Itertools;
@@ -155,13 +156,13 @@ mod tests {
     } = super::optimize((
       vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -189,7 +190,7 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("cc"),
           Operator::LT,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ZERO,
         ),
         Statement::SingleIf {
@@ -200,19 +201,19 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE,
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           Expression::int(3),
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_x"),
           Operator::MUL,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(5),
         ),
         Statement::binary(
@@ -223,7 +224,7 @@ mod tests {
         ),
         Statement::Call {
           callee: Callee::FunctionName(FunctionName::new(
-            heap.alloc_str_for_test("f"),
+            well_known_pstrs::LOWER_F,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           )),
           arguments: vec![Expression::var_name(heap.alloc_str_for_test("tmp_x"), INT_TYPE)],
@@ -232,7 +233,7 @@ mod tests {
         },
         Statement::Call {
           callee: Callee::FunctionName(FunctionName::new(
-            heap.alloc_str_for_test("f"),
+            well_known_pstrs::LOWER_F,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           )),
           arguments: vec![Expression::var_name(heap.alloc_str_for_test("tmp_x"), INT_TYPE)],
@@ -246,34 +247,34 @@ mod tests {
           Expression::var_name(heap.alloc_str_for_test("tmp_y"), INT_TYPE),
         ),
         Statement::binary(
-          heap.alloc_str_for_test("c"),
+          well_known_pstrs::LOWER_C,
           Operator::MINUS,
-          Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
-          Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
         ),
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("d"),
+          name: well_known_pstrs::LOWER_D,
           type_: INT_TYPE,
-          pointer_expression: Expression::var_name(heap.alloc_str_for_test("c"), INT_TYPE),
+          pointer_expression: Expression::var_name(well_known_pstrs::LOWER_C, INT_TYPE),
           index: 0,
         },
         Statement::IndexedAccess {
-          name: heap.alloc_str_for_test("e"),
+          name: well_known_pstrs::LOWER_E,
           type_: INT_TYPE,
           pointer_expression: Expression::var_name(heap.alloc_str_for_test("x"), INT_TYPE),
           index: 0,
         },
         Statement::binary(
-          heap.alloc_str_for_test("f"),
+          well_known_pstrs::LOWER_F,
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("b"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_B, INT_TYPE),
           Expression::var_name(heap.alloc_str_for_test("x"), INT_TYPE),
         ),
         Statement::ClosureInit {
-          closure_variable_name: heap.alloc_str_for_test("g"),
+          closure_variable_name: well_known_pstrs::LOWER_G,
           closure_type_name: heap.alloc_str_for_test("I"),
           function_name: FunctionName::new(
-            heap.alloc_str_for_test("f"),
+            well_known_pstrs::LOWER_F,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           ),
           context: Expression::var_name(heap.alloc_str_for_test("x"), INT_TYPE),
@@ -282,10 +283,10 @@ mod tests {
           closure_variable_name: heap.alloc_str_for_test("h"),
           closure_type_name: heap.alloc_str_for_test("I"),
           function_name: FunctionName::new(
-            heap.alloc_str_for_test("f"),
+            well_known_pstrs::LOWER_F,
             Type::new_fn_unwrapped(vec![], INT_TYPE),
           ),
-          context: Expression::var_name(heap.alloc_str_for_test("d"), INT_TYPE),
+          context: Expression::var_name(well_known_pstrs::LOWER_D, INT_TYPE),
         },
         Statement::StructInit {
           struct_variable_name: heap.alloc_str_for_test("kk"),
@@ -295,7 +296,7 @@ mod tests {
         Statement::StructInit {
           struct_variable_name: heap.alloc_str_for_test("kk2"),
           type_name: heap.alloc_str_for_test("I"),
-          expression_list: vec![Expression::var_name(heap.alloc_str_for_test("g"), INT_TYPE)],
+          expression_list: vec![Expression::var_name(well_known_pstrs::LOWER_G, INT_TYPE)],
         },
         Statement::Cast {
           name: heap.alloc_str_for_test("l1"),
@@ -305,7 +306,7 @@ mod tests {
         Statement::Cast {
           name: heap.alloc_str_for_test("l2"),
           type_: INT_TYPE,
-          assigned_expression: Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          assigned_expression: Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
         },
         Statement::IfElse {
           condition: ZERO,

--- a/crates/samlang-core/src/optimization/loop_optimizations.rs
+++ b/crates/samlang-core/src/optimization/loop_optimizations.rs
@@ -233,7 +233,7 @@ mod tests {
       Callee, Expression, Function, FunctionName, GenenalLoopVariable, Statement, Type,
       VariableName, INT_TYPE, ONE, ZERO,
     },
-    common::INVALID_PSTR,
+    common::{well_known_pstrs, INVALID_PSTR},
     Heap,
   };
   use itertools::Itertools;
@@ -280,13 +280,13 @@ mod tests {
     (
       vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -296,7 +296,7 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("cc"),
           Operator::GE,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(10),
         ),
         Statement::Cast {
@@ -308,20 +308,20 @@ mod tests {
           condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
-            heap.alloc_str_for_test("j"),
+            well_known_pstrs::LOWER_J,
             INT_TYPE,
           ))],
         },
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE,
         ),
         Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE),
           Expression::int(10),
         ),
       ],
@@ -335,13 +335,13 @@ mod tests {
     (
       vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -351,21 +351,21 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("cc"),
           Operator::GE,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(10),
         ),
         Statement::SingleIf {
           condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
-            heap.alloc_str_for_test("j"),
+            well_known_pstrs::LOWER_J,
             INT_TYPE,
           ))],
         },
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE,
         ),
         Statement::binary(
@@ -385,19 +385,19 @@ mod tests {
     (
       vec![
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
         },
         GenenalLoopVariable {
-          name: heap.alloc_str_for_test("k"),
+          name: well_known_pstrs::LOWER_K,
           type_: INT_TYPE,
           initial_value: ZERO,
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_k"), INT_TYPE),
@@ -407,21 +407,21 @@ mod tests {
         Statement::binary(
           heap.alloc_str_for_test("cc"),
           Operator::GE,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(10),
         ),
         Statement::SingleIf {
           condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
           invert_condition: false,
           statements: vec![Statement::Break(Expression::var_name(
-            heap.alloc_str_for_test("j"),
+            well_known_pstrs::LOWER_J,
             INT_TYPE,
           ))],
         },
         Statement::binary(
           heap.alloc_str_for_test("tmp_i"),
           Operator::PLUS,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           ONE,
         ),
         Statement::binary(
@@ -447,7 +447,7 @@ mod tests {
     assert_loop_optimized(
       (
         vec![],
-        vec![Statement::binary(heap.alloc_str_for_test("a"), Operator::PLUS, ZERO, ZERO)],
+        vec![Statement::binary(well_known_pstrs::LOWER_A, Operator::PLUS, ZERO, ZERO)],
         None,
       ),
       heap,
@@ -518,13 +518,13 @@ while (true) {
       (
         vec![
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("i"),
+            name: well_known_pstrs::LOWER_I,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
           },
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("j"),
+            name: well_known_pstrs::LOWER_J,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -534,27 +534,27 @@ while (true) {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(10),
           ),
           Statement::SingleIf {
             condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
-              heap.alloc_str_for_test("j"),
+              well_known_pstrs::LOWER_J,
               INT_TYPE,
             ))],
           },
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
-            Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
           ),
           Statement::binary(
             heap.alloc_str_for_test("tmp_j"),
             Operator::MUL,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(2),
           ),
         ],
@@ -583,13 +583,13 @@ while (true) {
       (
         vec![
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("i"),
+            name: well_known_pstrs::LOWER_I,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
           },
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("j"),
+            name: well_known_pstrs::LOWER_J,
             type_: INT_TYPE,
             initial_value: ZERO,
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_j"), INT_TYPE),
@@ -599,21 +599,21 @@ while (true) {
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(10),
           ),
           Statement::SingleIf {
             condition: Expression::var_name(heap.alloc_str_for_test("cc"), INT_TYPE),
             invert_condition: false,
             statements: vec![Statement::Break(Expression::var_name(
-              heap.alloc_str_for_test("j"),
+              well_known_pstrs::LOWER_J,
               INT_TYPE,
             ))],
           },
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE,
           ),
           Statement::binary(
@@ -657,7 +657,7 @@ while (true) {
         s2: vec![Statement::binary(
           heap.alloc_str_for_test("tmp_j"),
           Operator::MUL,
-          Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+          Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
           Expression::int(2),
         )],
         final_assignments: vec![],
@@ -731,7 +731,7 @@ return (bc: int);"#,
       vec![Statement::While {
         loop_variables: vec![
           GenenalLoopVariable {
-            name: heap.alloc_str_for_test("i"),
+            name: well_known_pstrs::LOWER_I,
             type_: INT_TYPE,
             initial_value: Expression::int(4),
             loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
@@ -747,7 +747,7 @@ return (bc: int);"#,
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             ONE,
           ),
           Statement::SingleIf {
@@ -761,13 +761,13 @@ return (bc: int);"#,
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(-1),
           ),
           Statement::binary(
             heap.alloc_str_for_test("tmp_j"),
             Operator::MUL,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("acc"), INT_TYPE),
           ),
         ],
@@ -786,7 +786,7 @@ return (bc: int);"#,
     assert_stmts_optimized(
       vec![Statement::While {
         loop_variables: vec![GenenalLoopVariable {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           type_: INT_TYPE,
           initial_value: Expression::var_name(heap.alloc_str_for_test("init_i"), INT_TYPE),
           loop_value: Expression::var_name(heap.alloc_str_for_test("tmp_i"), INT_TYPE),
@@ -795,7 +795,7 @@ return (bc: int);"#,
           Statement::binary(
             heap.alloc_str_for_test("cc"),
             Operator::LT,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("L"), INT_TYPE),
           ),
           Statement::SingleIf {
@@ -806,28 +806,28 @@ return (bc: int);"#,
           Statement::binary(
             heap.alloc_str_for_test("t"),
             Operator::MUL,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(3),
           ),
           Statement::binary(
-            heap.alloc_str_for_test("j"),
+            well_known_pstrs::LOWER_J,
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("a"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_A, INT_TYPE),
             Expression::var_name(heap.alloc_str_for_test("t"), INT_TYPE),
           ),
           Statement::Call {
             callee: Callee::FunctionName(FunctionName::new(
-              heap.alloc_str_for_test("f"),
+              well_known_pstrs::LOWER_F,
               Type::new_fn_unwrapped(vec![], INT_TYPE),
             )),
-            arguments: vec![Expression::var_name(heap.alloc_str_for_test("j"), INT_TYPE)],
+            arguments: vec![Expression::var_name(well_known_pstrs::LOWER_J, INT_TYPE)],
             return_type: INT_TYPE,
             return_collector: None,
           },
           Statement::binary(
             heap.alloc_str_for_test("tmp_i"),
             Operator::PLUS,
-            Expression::var_name(heap.alloc_str_for_test("i"), INT_TYPE),
+            Expression::var_name(well_known_pstrs::LOWER_I, INT_TYPE),
             Expression::int(2),
           ),
         ],

--- a/crates/samlang-core/src/optimization/loop_strength_reduction.rs
+++ b/crates/samlang-core/src/optimization/loop_strength_reduction.rs
@@ -88,6 +88,7 @@ pub(super) fn optimize(
 mod tests {
   use crate::{
     ast::mir::{VariableName, INT_TYPE, ONE},
+    common::well_known_pstrs,
     optimization::loop_induction_analysis::{
       BasicInductionVariableWithLoopGuard, DerivedInductionVariableWithName,
       GeneralBasicInductionVariable, GuardOperator, OptimizableWhileLoop,
@@ -108,17 +109,17 @@ mod tests {
     } = super::optimize(
       OptimizableWhileLoop {
         basic_induction_variable_with_loop_guard: BasicInductionVariableWithLoopGuard {
-          name: heap.alloc_str_for_test("i"),
+          name: well_known_pstrs::LOWER_I,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Int(1),
           guard_operator: GuardOperator::LT,
           guard_expression: PotentialLoopInvariantExpression::Int(10),
         },
         general_induction_variables: vec![GeneralBasicInductionVariable {
-          name: heap.alloc_str_for_test("j"),
+          name: well_known_pstrs::LOWER_J,
           initial_value: ONE,
           increment_amount: PotentialLoopInvariantExpression::Var(VariableName::new(
-            heap.alloc_str_for_test("c"),
+            well_known_pstrs::LOWER_C,
             INT_TYPE,
           )),
         }],
@@ -126,25 +127,25 @@ mod tests {
         derived_induction_variables: vec![
           DerivedInductionVariableWithName {
             name: heap.alloc_str_for_test("x"),
-            base_name: heap.alloc_str_for_test("i"),
+            base_name: well_known_pstrs::LOWER_I,
             multiplier: PotentialLoopInvariantExpression::Var(VariableName::new(
-              heap.alloc_str_for_test("a"),
+              well_known_pstrs::LOWER_A,
               INT_TYPE,
             )),
             immediate: PotentialLoopInvariantExpression::Var(VariableName::new(
-              heap.alloc_str_for_test("b"),
+              well_known_pstrs::LOWER_B,
               INT_TYPE,
             )),
           },
           DerivedInductionVariableWithName {
             name: heap.alloc_str_for_test("y"),
-            base_name: heap.alloc_str_for_test("j"),
+            base_name: well_known_pstrs::LOWER_J,
             multiplier: PotentialLoopInvariantExpression::Var(VariableName::new(
-              heap.alloc_str_for_test("a"),
+              well_known_pstrs::LOWER_A,
               INT_TYPE,
             )),
             immediate: PotentialLoopInvariantExpression::Var(VariableName::new(
-              heap.alloc_str_for_test("b"),
+              well_known_pstrs::LOWER_B,
               INT_TYPE,
             )),
           },

--- a/crates/samlang-core/src/optimization/optimization_common.rs
+++ b/crates/samlang-core/src/optimization/optimization_common.rs
@@ -61,6 +61,8 @@ pub(super) fn single_if_or_null(
 
 #[cfg(test)]
 mod tests {
+  use crate::common::well_known_pstrs;
+
   use super::*;
   use std::{collections::hash_map::DefaultHasher, hash::Hash};
 
@@ -92,8 +94,7 @@ mod tests {
   #[test]
   fn local_value_context_for_optimization_panic() {
     let mut cx = LocalValueContextForOptimization::new();
-    let heap = &mut crate::common::Heap::new();
-    cx.checked_bind(heap.alloc_str_for_test("a"), ZERO);
-    cx.checked_bind(heap.alloc_str_for_test("a"), ZERO);
+    cx.checked_bind(well_known_pstrs::LOWER_A, ZERO);
+    cx.checked_bind(well_known_pstrs::LOWER_A, ZERO);
   }
 }

--- a/crates/samlang-core/src/optimization/unused_name_elimination.rs
+++ b/crates/samlang-core/src/optimization/unused_name_elimination.rs
@@ -222,6 +222,7 @@ mod tests {
       Sources, Statement, Type, TypeDefinition, TypeDefinitionMappings, VariableName, INT_TYPE,
       ZERO,
     },
+    common::well_known_pstrs,
     Heap,
   };
   use itertools::Itertools;
@@ -300,12 +301,12 @@ mod tests {
           type_: Type::new_fn_unwrapped(vec![INT_TYPE], INT_TYPE),
           body: vec![
             Statement::StructInit {
-              struct_variable_name: heap.alloc_str_for_test(""),
+              struct_variable_name: well_known_pstrs::LOWER_A,
               type_name: heap.alloc_str_for_test("Foo"),
               expression_list: vec![Expression::StringName(heap.alloc_str_for_test("bar"))],
             },
             Statement::ClosureInit {
-              closure_variable_name: heap.alloc_str_for_test(""),
+              closure_variable_name: well_known_pstrs::LOWER_A,
               closure_type_name: heap.alloc_str_for_test("Foo"),
               function_name: (FunctionName::new(
                 heap.alloc_str_for_test("foo"),
@@ -314,13 +315,13 @@ mod tests {
               context: ZERO,
             },
             Statement::IndexedAccess {
-              name: heap.alloc_str_for_test(""),
+              name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               pointer_expression: Expression::StringName(heap.alloc_str_for_test("bar")),
               index: 0,
             },
             Statement::Cast {
-              name: heap.alloc_str_for_test(""),
+              name: well_known_pstrs::LOWER_A,
               type_: INT_TYPE,
               assigned_expression: Expression::StringName(heap.alloc_str_for_test("bar")),
             },
@@ -342,13 +343,13 @@ mod tests {
             Statement::IfElse {
               condition: ZERO,
               s1: vec![Statement::binary(
-                heap.alloc_str_for_test(""),
+                well_known_pstrs::LOWER_A,
                 crate::ast::hir::Operator::GE,
                 Expression::StringName(heap.alloc_str_for_test("foo")),
                 Expression::StringName(heap.alloc_str_for_test("bar")),
               )],
               s2: vec![Statement::binary(
-                heap.alloc_str_for_test(""),
+                well_known_pstrs::LOWER_A,
                 crate::ast::hir::Operator::GE,
                 Expression::StringName(heap.alloc_str_for_test("foo")),
                 Expression::StringName(heap.alloc_str_for_test("bar")),
@@ -362,15 +363,15 @@ mod tests {
             },
             Statement::While {
               loop_variables: vec![GenenalLoopVariable {
-                name: heap.alloc_str_for_test("f"),
+                name: well_known_pstrs::LOWER_F,
                 type_: INT_TYPE,
                 initial_value: ZERO,
                 loop_value: ZERO,
               }],
               statements: vec![],
               break_collector: Some(VariableName {
-                name: heap.alloc_str_for_test("d"),
-                type_: Type::Id(heap.alloc_str_for_test("A")),
+                name: well_known_pstrs::LOWER_D,
+                type_: Type::Id(well_known_pstrs::UPPER_A),
               }),
             },
             Statement::While { loop_variables: vec![], statements: vec![], break_collector: None },

--- a/crates/samlang-core/src/services/ast_differ.rs
+++ b/crates/samlang-core/src/services/ast_differ.rs
@@ -427,6 +427,7 @@ mod tests {
   use super::*;
   use crate::{
     ast::source::{test_builder, Id, InterfaceDeclarationCommon, NO_COMMENT_REFERENCE},
+    common::well_known_pstrs,
     errors::ErrorSet,
     parser,
   };
@@ -509,7 +510,7 @@ mod tests {
 
     let import = ModuleMembersImport {
       loc: Location::dummy(),
-      imported_members: vec![Id::from(heap.alloc_str_for_test("A"))],
+      imported_members: vec![Id::from(well_known_pstrs::UPPER_A)],
       imported_module: ModuleReference::dummy(),
       imported_module_loc: Location::dummy(),
     };
@@ -523,7 +524,7 @@ mod tests {
     let toplevel = Toplevel::Interface(InterfaceDeclarationCommon {
       loc: Location::dummy(),
       associated_comments: NO_COMMENT_REFERENCE,
-      name: Id::from(heap.alloc_str_for_test("A")),
+      name: Id::from(well_known_pstrs::UPPER_A),
       type_parameters: vec![],
       extends_or_implements_nodes: vec![],
       type_definition: (),

--- a/crates/samlang-core/src/services/global_searcher.rs
+++ b/crates/samlang-core/src/services/global_searcher.rs
@@ -230,7 +230,8 @@ mod tests {
   use std::collections::HashMap;
 
   use crate::{
-    checker::type_check_sources, errors::ErrorSet, parser::parse_source_module_from_text, Heap,
+    checker::type_check_sources, common::well_known_pstrs, errors::ErrorSet,
+    parser::parse_source_module_from_text, Heap,
   };
 
   #[test]
@@ -373,7 +374,7 @@ mod tests {
       &super::GlobalNameSearchRequest::Property(
         mod_ref,
         heap.alloc_str_for_test("Foo"),
-        heap.alloc_str_for_test("a"),
+        well_known_pstrs::LOWER_A,
       ),
     );
   }

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -324,7 +324,7 @@ mod tests {
       source::{expr, Id, Literal, Module},
       Location, Position,
     },
-    common::{Heap, ModuleReference},
+    common::{well_known_pstrs, Heap, ModuleReference},
     errors::ErrorSet,
     parser::parse_source_module_from_text,
     printer,
@@ -334,20 +334,19 @@ mod tests {
   #[should_panic]
   #[test]
   fn coverage_booster_tests() {
-    let mut heap = Heap::new();
     apply_expr_renaming(
       &expr::E::MethodAccess(expr::MethodAccess {
         common: expr::ExpressionCommon::dummy(()),
         explicit_type_arguments: vec![],
         inferred_type_arguments: vec![],
         object: Box::new(expr::E::Literal(expr::ExpressionCommon::dummy(()), Literal::Int(0))),
-        method_name: Id::from(heap.alloc_str_for_test("")),
+        method_name: Id::from(well_known_pstrs::LOWER_A),
       }),
       &DefinitionAndUses {
         definition_location: Location::dummy(),
         use_locations: vec![Location::dummy()],
       },
-      heap.alloc_str_for_test(""),
+      well_known_pstrs::LOWER_A,
     );
   }
 


### PR DESCRIPTION
[repo] Various cleanup

After the recent HIR & MIR split, HIR becomes more intermediate and much less depended by optimizations. As a result, we can cleanup some constructor functions and structures around binary. Also did some drive-by PStr cleanup.
