### PR TITLE
[checker][refactor] Move type subst helper into type_system module

### DIFF
--- a/crates/samlang-core/src/checker/checker_utils_tests.rs
+++ b/crates/samlang-core/src/checker/checker_utils_tests.rs
@@ -8,53 +8,6 @@ mod tests {
   use pretty_assertions::assert_eq;
   use std::{collections::HashMap, rc::Rc};
 
-  #[test]
-  fn type_substitution_tests() {
-    let heap = Heap::new();
-    let builder = test_type_builder::create();
-
-    assert_eq!(
-      "(A<int, C<int>>, int, E<F>, int) -> int",
-      perform_type_substitution(
-        &builder.fun_type(
-          vec![
-            builder.general_nominal_type(
-              well_known_pstrs::UPPER_A,
-              vec![
-                builder.generic_type(well_known_pstrs::UPPER_B),
-                builder.general_nominal_type(well_known_pstrs::UPPER_C, vec![builder.int_type()])
-              ]
-            ),
-            builder.generic_type(well_known_pstrs::UPPER_D),
-            builder.general_nominal_type(
-              well_known_pstrs::UPPER_E,
-              vec![builder.simple_nominal_type(well_known_pstrs::UPPER_F)]
-            ),
-            builder.int_type()
-          ],
-          builder.int_type()
-        ),
-        &HashMap::from([
-          (well_known_pstrs::UPPER_A, builder.int_type()),
-          (well_known_pstrs::UPPER_B, builder.int_type()),
-          (well_known_pstrs::UPPER_C, builder.int_type()),
-          (well_known_pstrs::UPPER_D, builder.int_type()),
-          (well_known_pstrs::UPPER_E, builder.int_type()),
-        ])
-      )
-      .pretty_print(&heap)
-    );
-
-    assert_eq!(
-      "A",
-      perform_nominal_type_substitution(
-        &builder.simple_nominal_type_unwrapped(well_known_pstrs::UPPER_A),
-        &HashMap::new()
-      )
-      .pretty_print(&heap)
-    );
-  }
-
   fn solver_test(
     concrete: &Type,
     generic: &Type,

--- a/crates/samlang-core/src/checker/typing_context.rs
+++ b/crates/samlang-core/src/checker/typing_context.rs
@@ -1,10 +1,10 @@
 use super::{
-  checker_utils::perform_type_substitution,
   global_signature, ssa_analysis,
   type_::{
     EnumVariantDefinitionSignature, GlobalSignature, ISourceType, MemberSignature, NominalType,
     StructItemDefinitionSignature, Type, TypeDefinitionSignature, TypeParameterSignature,
   },
+  type_system,
 };
 use crate::{
   ast::{Location, Position, Reason},
@@ -334,7 +334,7 @@ impl<'a> TypingContext<'a> {
           .iter()
           .map(|item| StructItemDefinitionSignature {
             name: item.name,
-            type_: perform_type_substitution(&item.type_, &subst_map),
+            type_: type_system::subst_type(&item.type_, &subst_map),
             is_public: item.is_public || nominal_type.id.eq(&self.current_class),
           })
           .collect(),
@@ -344,11 +344,7 @@ impl<'a> TypingContext<'a> {
           .iter()
           .map(|variant| EnumVariantDefinitionSignature {
             name: variant.name,
-            types: variant
-              .types
-              .iter()
-              .map(|it| perform_type_substitution(it, &subst_map))
-              .collect(),
+            types: variant.types.iter().map(|it| type_system::subst_type(it, &subst_map)).collect(),
           })
           .collect(),
       )),


### PR DESCRIPTION
[checker][refactor] Move type subst helper into type_system module

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1040).
* #1041
* __->__ #1040