### PR TITLE
[checker] Remove need to use heap for type parameter mismatch errors

### DIFF
--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -1153,7 +1153,6 @@ fn validate_tparams_signature_type_instantiation(
 }
 
 fn check_class_member_conformance_with_signature(
-  heap: &Heap,
   error_set: &mut ErrorSet,
   expected: &MemberSignature,
   actual: &ClassMemberDeclaration,
@@ -1183,7 +1182,7 @@ fn check_class_member_conformance_with_signature(
   if has_type_parameter_conformance_errors {
     error_set.report_type_parameter_mismatch_error(
       actual.type_.location,
-      TypeParameterSignature::pretty_print_list(&expected.type_parameters, heap),
+      expected.type_parameters.iter().map(TypeParameterSignature::to_description).collect(),
     );
   } else {
     let actual_fn_type = FunctionType::from_annotation(&actual.type_);
@@ -1304,7 +1303,7 @@ pub(crate) fn type_check_module(
           member.name.name,
         );
         for expected in &resolved {
-          check_class_member_conformance_with_signature(heap, error_set, expected, member);
+          check_class_member_conformance_with_signature(error_set, expected, member);
         }
         !resolved.is_empty()
       } else {

--- a/crates/samlang-core/src/checker/type_.rs
+++ b/crates/samlang-core/src/checker/type_.rs
@@ -303,13 +303,12 @@ impl TypeParameterSignature {
     tparam_sigs
   }
 
+  pub(crate) fn to_description(&self) -> Description {
+    Description::TypeParameter(self.name, self.bound.as_ref().map(|t| Box::new(t.to_description())))
+  }
+
   pub(crate) fn pretty_print(&self, heap: &Heap) -> String {
-    match &self.bound {
-      Option::None => self.name.as_str(heap).to_string(),
-      Option::Some(t) => {
-        format!("{} : {}", self.name.as_str(heap), t.pretty_print(heap))
-      }
-    }
+    self.to_description().pretty_print(heap)
   }
 
   pub(crate) fn pretty_print_list(list: &Vec<TypeParameterSignature>, heap: &Heap) -> String {
@@ -408,6 +407,7 @@ pub(crate) struct MemberSignature {
 }
 
 impl MemberSignature {
+  #[cfg(test)]
   pub(crate) fn to_string(&self, heap: &Heap) -> String {
     let access_str = if self.is_public { "public" } else { "private" };
     let tparam_str = TypeParameterSignature::pretty_print_list(&self.type_parameters, heap);
@@ -490,6 +490,7 @@ pub(crate) struct InterfaceSignature {
 }
 
 impl InterfaceSignature {
+  #[cfg(test)]
   pub(crate) fn to_string(&self, heap: &Heap) -> String {
     let mut lines = vec![];
     lines.push(format!(
@@ -570,6 +571,7 @@ pub(crate) struct ModuleSignature {
 }
 
 impl ModuleSignature {
+  #[cfg(test)]
   pub(crate) fn to_string(&self, heap: &Heap) -> String {
     let mut lines = vec![];
     lines.push("\ninterfaces:".to_string());


### PR DESCRIPTION
[checker] Remove need to use heap for type parameter mismatch errors

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1045).
* #1047
* #1046
* __->__ #1045