### PR TITLE
[syntax] Use `let` instead of `val` for local binding

### DIFF
--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -200,25 +200,25 @@ pub(crate) mod pattern {
   use super::{Id, Location};
 
   #[derive(Clone, PartialEq, Eq)]
-  pub(crate) struct TuplePatternDestructuredName<T: Clone> {
-    pub(crate) pattern: Box<DestructuringPattern<T>>,
+  pub(crate) struct TuplePatternElement<Base: Clone, T: Clone> {
+    pub(crate) pattern: Box<Base>,
     pub(crate) type_: T,
   }
 
   #[derive(Clone, PartialEq, Eq)]
-  pub(crate) struct ObjectPatternDestucturedName<T: Clone> {
+  pub(crate) struct ObjectPatternElement<Base: Clone, T: Clone> {
     pub(crate) loc: Location,
     pub(crate) field_order: usize,
     pub(crate) field_name: Id,
-    pub(crate) pattern: Box<DestructuringPattern<T>>,
+    pub(crate) pattern: Box<Base>,
     pub(crate) shorthand: bool,
     pub(crate) type_: T,
   }
 
   #[derive(Clone, PartialEq, Eq)]
   pub(crate) enum DestructuringPattern<T: Clone> {
-    Tuple(Location, Vec<TuplePatternDestructuredName<T>>),
-    Object(Location, Vec<ObjectPatternDestucturedName<T>>),
+    Tuple(Location, Vec<TuplePatternElement<DestructuringPattern<T>, T>>),
+    Object(Location, Vec<ObjectPatternElement<DestructuringPattern<T>, T>>),
     Id(Id),
     Wildcard(Location),
   }

--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -233,6 +233,36 @@ pub(crate) mod pattern {
       }
     }
   }
+
+  #[derive(Clone, PartialEq, Eq)]
+  pub(crate) struct VariantPattern<T: Clone> {
+    pub(crate) loc: Location,
+    pub(crate) tag_order: usize,
+    pub(crate) tag: Id,
+    pub(crate) data_variables: Vec<MatchingPattern<T>>,
+    pub(crate) type_: T,
+  }
+
+  #[derive(Clone, PartialEq, Eq)]
+  pub(crate) enum MatchingPattern<T: Clone> {
+    Tuple(Location, Vec<TuplePatternElement<DestructuringPattern<T>, T>>),
+    Object(Location, Vec<ObjectPatternElement<DestructuringPattern<T>, T>>),
+    Variant(VariantPattern<T>),
+    Id(Id),
+    Wildcard(Location),
+  }
+
+  impl<T: Clone> MatchingPattern<T> {
+    pub(crate) fn loc(&self) -> &Location {
+      match self {
+        Self::Tuple(loc, _)
+        | Self::Object(loc, _)
+        | Self::Variant(VariantPattern { loc, .. })
+        | Self::Id(Id { loc, .. })
+        | Self::Wildcard(loc) => loc,
+      }
+    }
+  }
 }
 
 #[derive(Clone, PartialEq, Eq)]

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -205,7 +205,7 @@ mod tests {
           associated_comments: NO_COMMENT_REFERENCE,
           pattern: pattern::DestructuringPattern::Object(
             Location::dummy(),
-            vec![pattern::ObjectPatternDestucturedName {
+            vec![pattern::ObjectPatternElement {
               loc: Location::dummy(),
               field_order: 0,
               field_name: Id::from(heap.alloc_str_for_test("name")),
@@ -228,7 +228,7 @@ mod tests {
           associated_comments: NO_COMMENT_REFERENCE,
           pattern: pattern::DestructuringPattern::Tuple(
             Location::dummy(),
-            vec![pattern::TuplePatternDestructuredName {
+            vec![pattern::TuplePatternElement {
               pattern: Box::new(pattern::DestructuringPattern::Id(Id::from(
                 heap.alloc_str_for_test("name"),
               ))),

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -40,15 +40,48 @@ mod tests {
     assert_eq!("!", expr::UnaryOperator::NOT.clone().to_string());
     assert_eq!("-", expr::UnaryOperator::NEG.clone().to_string());
 
-    let mut pattern: pattern::DestructuringPattern<()> =
+    let mut destructuring_pattern: pattern::DestructuringPattern<()> =
       pattern::DestructuringPattern::Object(Location::dummy(), vec![]);
-    assert_eq!(*pattern.loc(), Location::dummy());
-    pattern = pattern::DestructuringPattern::Tuple(Location::dummy(), vec![]);
-    assert_eq!(*pattern.loc(), Location::dummy());
-    pattern = pattern::DestructuringPattern::Id(Id::from(PStr::LOWER_A));
-    assert_eq!(*pattern.loc(), Location::dummy());
-    pattern = pattern::DestructuringPattern::Wildcard(Location::dummy());
-    assert_eq!(*pattern.loc(), Location::dummy());
+    assert_eq!(*destructuring_pattern.loc(), Location::dummy());
+    destructuring_pattern = pattern::DestructuringPattern::Tuple(Location::dummy(), vec![]);
+    assert_eq!(*destructuring_pattern.loc(), Location::dummy());
+    destructuring_pattern = pattern::DestructuringPattern::Id(Id::from(PStr::LOWER_A));
+    assert_eq!(*destructuring_pattern.loc(), Location::dummy());
+    destructuring_pattern = pattern::DestructuringPattern::Wildcard(Location::dummy());
+    assert_eq!(*destructuring_pattern.loc(), Location::dummy());
+
+    let mut matching_pattern: pattern::MatchingPattern<()> =
+      pattern::MatchingPattern::Object(Location::dummy(), vec![]);
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Tuple(Location::dummy(), vec![]);
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Variant(pattern::VariantPattern {
+      loc: Location::dummy(),
+      tag_order: 0,
+      tag: Id::from(PStr::UPPER_A),
+      data_variables: vec![],
+      type_: (),
+    });
+    assert_eq!(*matching_pattern.clone().loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Id(Id::from(PStr::LOWER_A));
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Wildcard(Location::dummy());
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    assert!(
+      pattern::MatchingPattern::Variant(pattern::VariantPattern {
+        loc: Location::dummy(),
+        tag_order: 0,
+        tag: Id::from(PStr::UPPER_A),
+        data_variables: vec![],
+        type_: (),
+      }) == pattern::MatchingPattern::Variant(pattern::VariantPattern {
+        loc: Location::dummy(),
+        tag_order: 0,
+        tag: Id::from(PStr::UPPER_A),
+        data_variables: vec![],
+        type_: (),
+      })
+    );
 
     let list = [
       expr::BinaryOperator::MUL,

--- a/crates/samlang-core/src/checker.rs
+++ b/crates/samlang-core/src/checker.rs
@@ -7,6 +7,8 @@ mod checker_tests;
 mod global_signature;
 /// The main checker that connects everything together.
 mod main_checker;
+/// The module that verify the usefulness and exhausiveness of patterns.
+mod pattern_matching;
 /// Computing the SSA graph.
 mod ssa_analysis;
 mod ssa_analysis_tests;

--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -682,22 +682,22 @@ Found 1 error.
     );
 
     assert_checks(heap, "this", &builder.int_type());
-    assert_checks(heap, "{ val foo = 3; foo }", &builder.int_type());
+    assert_checks(heap, "{ let foo = 3; foo }", &builder.int_type());
     assert_errors(
       heap,
-      "{ val foo = true; foo }",
+      "{ let foo = true; foo }",
       &builder.int_type(),
       r#"
 Error ----------------------------------- DUMMY.sam:1:1-1:24
 
 `bool` [1] is incompatible with `int` .
 
-  1| { val foo = true; foo }
+  1| { let foo = true; foo }
      ^^^^^^^^^^^^^^^^^^^^^^^
 
   [1] DUMMY.sam:1:1-1:24
   ----------------------
-  1| { val foo = true; foo }
+  1| { let foo = true; foo }
      ^^^^^^^^^^^^^^^^^^^^^^^
 
 
@@ -714,21 +714,21 @@ Found 1 error.
     assert_errors_full_customization(
       heap,
       r#"{
-  val _: int = [1, 1].e1;
-  val _: int = [1, 1, 1].e2;
-  val _: int = [1, 1, 1, 1].e3;
-  val _: int = [1, 1, 1, 1, 1].e4;
-  val _: int = [1, 1, 1, 1, 1, 1].e5;
-  val _: int = [1, 1, 1, 1, 1, 1, 1].e6;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1].e7;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1].e8;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e9;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e10;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e11;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e12;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e13;
-  val _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
-  val _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e15;
+  let _: int = [1, 1].e1;
+  let _: int = [1, 1, 1].e2;
+  let _: int = [1, 1, 1, 1].e3;
+  let _: int = [1, 1, 1, 1, 1].e4;
+  let _: int = [1, 1, 1, 1, 1, 1].e5;
+  let _: int = [1, 1, 1, 1, 1, 1, 1].e6;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1].e7;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1].e8;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e9;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e10;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e11;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e12;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e13;
+  let _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
+  let _: int = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e15;
 }"#,
       &builder.unit_type(),
       r#"
@@ -736,17 +736,17 @@ Error --------------------------------- DUMMY.sam:15:3-15:67
 
 `int` [1] is incompatible with `bool` [2].
 
-  15|   val _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
+  15|   let _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   [1] DUMMY.sam:15:17-15:66
   -------------------------
-  15|   val _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
+  15|   let _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   [2] DUMMY.sam:15:10-15:14
   -------------------------
-  15|   val _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
+  15|   let _: bool = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1].e14;
                ^^^^
 
 
@@ -906,7 +906,7 @@ Found 1 error.
     assert_checks(heap, "Test.init(true, 3)", &builder.simple_nominal_type(test_str));
     assert_checks(
       heap,
-      "{ val foo=true; Test.init(foo, 3) }",
+      "{ let foo=true; Test.init(foo, 3) }",
       &builder.simple_nominal_type(test_str),
     );
     assert_errors_full_customization(
@@ -1154,14 +1154,14 @@ Found 1 error.
     );
     assert_errors(
       heap,
-      "{ val _ = (t3: Test3<bool>) -> t3.bar; }",
+      "{ let _ = (t3: Test3<bool>) -> t3.bar; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:35-1:38
 
 Cannot find member `bar` on `Test3`.
 
-  1| { val _ = (t3: Test3<bool>) -> t3.bar; }
+  1| { let _ = (t3: Test3<bool>) -> t3.bar; }
                                        ^^^
 
 
@@ -1393,14 +1393,14 @@ Found 1 error.
 
     assert_errors(
       heap,
-      "{ val _ = (t) -> t.foo; }",
+      "{ let _ = (t) -> t.foo; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:12-1:13
 
 There is not enough context information to decide the type of this expression.
 
-  1| { val _ = (t) -> t.foo; }
+  1| { let _ = (t) -> t.foo; }
                 ^
 
 
@@ -1409,14 +1409,14 @@ Found 1 error.
     );
     assert_errors(
       heap,
-      "{ val _ = (t) -> t.bar; }",
+      "{ let _ = (t) -> t.bar; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:12-1:13
 
 There is not enough context information to decide the type of this expression.
 
-  1| { val _ = (t) -> t.bar; }
+  1| { let _ = (t) -> t.bar; }
                 ^
 
 
@@ -1425,14 +1425,14 @@ Found 1 error.
     );
     assert_errors(
       heap,
-      "{ val _ = (t) -> t.baz; }",
+      "{ let _ = (t) -> t.baz; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:12-1:13
 
 There is not enough context information to decide the type of this expression.
 
-  1| { val _ = (t) -> t.baz; }
+  1| { let _ = (t) -> t.baz; }
                 ^
 
 
@@ -1669,7 +1669,7 @@ Found 1 error.
     assert_checks(heap, "true == false", &builder.bool_type());
     assert_checks(heap, "false != true", &builder.bool_type());
     assert_checks(heap, "\"\" != \"3\"", &builder.bool_type());
-    assert_checks(heap, "{ val _ = (t: Str, f: Str) -> t == f; }", &builder.unit_type());
+    assert_checks(heap, "{ let _ = (t: Str, f: Str) -> t == f; }", &builder.unit_type());
 
     assert_errors(
       heap,
@@ -2232,24 +2232,24 @@ Found 1 error.
     );
     assert_errors(
       heap,
-      "{ val _ = (t: int, f: bool) -> t == f; }",
+      "{ let _ = (t: int, f: bool) -> t == f; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:37-1:38
 
 `bool` [1] is incompatible with `int` [2].
 
-  1| { val _ = (t: int, f: bool) -> t == f; }
+  1| { let _ = (t: int, f: bool) -> t == f; }
                                          ^
 
   [1] DUMMY.sam:1:37-1:38
   -----------------------
-  1| { val _ = (t: int, f: bool) -> t == f; }
+  1| { let _ = (t: int, f: bool) -> t == f; }
                                          ^
 
   [2] DUMMY.sam:1:32-1:33
   -----------------------
-  1| { val _ = (t: int, f: bool) -> t == f; }
+  1| { let _ = (t: int, f: bool) -> t == f; }
                                     ^
 
 
@@ -2583,17 +2583,17 @@ Found 1 error.
     assert_checks(heap, "if false then \"\" else \"\"", &builder.string_type());
     assert_checks(
       heap,
-      "{ val _ = (b: bool, t: int, f: int) -> if b then t else f; }",
+      "{ let _ = (b: bool, t: int, f: int) -> if b then t else f; }",
       &builder.unit_type(),
     );
     assert_checks(
       heap,
-      "{ val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(s) -> 2 }; }",
+      "{ let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(s) -> 2 }; }",
       &builder.unit_type(),
     );
     assert_errors_full_customization(
       heap,
-      "{ val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(s) -> 2 }; }",
+      "{ let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(s) -> 2 }; }",
       &builder.unit_type(),
       "",
       "Test2",
@@ -2601,7 +2601,7 @@ Found 1 error.
     );
     assert_errors_full_customization(
       heap,
-      "{ val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(d) -> 2 }; }",
+      "{ let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Bar(d) -> 2 }; }",
       &builder.unit_type(),
       "",
       "Test2",
@@ -2689,7 +2689,7 @@ Found 1 error.
     assert_errors(
       heap,
       r#"{
-  val _ = (b: bool, t: bool, f: int) -> (
+  let _ = (b: bool, t: bool, f: int) -> (
     if b then t else f
   );
 }"#,
@@ -2766,7 +2766,7 @@ Found 2 errors.
     );
     assert_errors_full_customization(
       heap,
-      "{ val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }",
+      "{ let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:25-1:64
@@ -2774,7 +2774,7 @@ Error ---------------------------------- DUMMY.sam:1:25-1:64
 The match is not exhausive. The following variants have not been handled:
 - `Bar`
 
-  1| { val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }
+  1| { let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
@@ -2782,7 +2782,7 @@ Error ---------------------------------- DUMMY.sam:1:50-1:53
 
 Cannot find member `Baz` on `Test2`.
 
-  1| { val _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }
+  1| { let _ = (t: Test2) -> match (t) { Foo(_) -> 1, Baz(s) -> 2, }; }
                                                       ^^^
 
 
@@ -2800,7 +2800,7 @@ Found 2 errors.
 
     assert_checks(
       heap,
-      "{val _ = (a: (int) -> bool, b: int, c: int) -> if a(b + 1) then b else c;}",
+      "{let _ = (a: (int) -> bool, b: int, c: int) -> if a(b + 1) then b else c;}",
       &builder.unit_type(),
     );
     assert_checks(
@@ -2880,29 +2880,29 @@ Found 2 errors.
 
     assert_errors_full_customization(
       heap,
-      "{val {a, b as c} = A.init();}",
+      "{let {a, b as c} = A.init();}",
       &builder.unit_type(),
       "",
       "A",
       false,
     );
-    assert_checks(heap, "{val a = 1;}", &builder.unit_type());
-    assert_checks(heap, "{val a = 1; val b = true;}", &builder.unit_type());
-    assert_checks(heap, "{val a = 1; a}", &builder.int_type());
+    assert_checks(heap, "{let a = 1;}", &builder.unit_type());
+    assert_checks(heap, "{let a = 1; let b = true;}", &builder.unit_type());
+    assert_checks(heap, "{let a = 1; a}", &builder.int_type());
     assert_checks(heap, "{1}", &builder.int_type());
     assert_checks(heap, "{}", &builder.unit_type());
     assert_checks(heap, "{{{{}}}}", &builder.unit_type());
 
     assert_errors(
       heap,
-      "{val [a, b, c] = A.init();}",
+      "{let [a, b, c] = A.init();}",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:10-1:11
 
 Cannot access member of `A` at index 1.
 
-  1| {val [a, b, c] = A.init();}
+  1| {let [a, b, c] = A.init();}
               ^
 
 
@@ -2910,7 +2910,7 @@ Error ---------------------------------- DUMMY.sam:1:13-1:14
 
 Cannot access member of `A` at index 2.
 
-  1| {val [a, b, c] = A.init();}
+  1| {let [a, b, c] = A.init();}
                  ^
 
 
@@ -2919,14 +2919,14 @@ Found 2 errors.
     );
     assert_errors(
       heap,
-      "{val {a, b as c} = A.init();}",
+      "{let {a, b as c} = A.init();}",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:10-1:11
 
 Cannot find member `b` on `A`.
 
-  1| {val {a, b as c} = A.init();}
+  1| {let {a, b as c} = A.init();}
               ^
 
 
@@ -2935,14 +2935,14 @@ Found 1 error.
     );
     assert_errors(
       heap,
-      "{val {a, b as c} = C.init();}",
+      "{let {a, b as c} = C.init();}",
       &builder.unit_type(),
       r#"
 Error ------------------------------------ DUMMY.sam:1:7-1:8
 
 Cannot find member `a` on `C`.
 
-  1| {val {a, b as c} = C.init();}
+  1| {let {a, b as c} = C.init();}
            ^
 
 
@@ -2950,7 +2950,7 @@ Error ---------------------------------- DUMMY.sam:1:10-1:11
 
 Cannot find member `b` on `C`.
 
-  1| {val {a, b as c} = C.init();}
+  1| {let {a, b as c} = C.init();}
               ^
 
 
@@ -2959,14 +2959,14 @@ Found 2 errors.
     );
     assert_errors(
       heap,
-      "{val {a, b as c} = 1;}",
+      "{let {a, b as c} = 1;}",
       &builder.unit_type(),
       r#"
 Error ------------------------------------ DUMMY.sam:1:7-1:8
 
 Cannot find member `a` on `int`.
 
-  1| {val {a, b as c} = 1;}
+  1| {let {a, b as c} = 1;}
            ^
 
 
@@ -2974,7 +2974,7 @@ Error ---------------------------------- DUMMY.sam:1:10-1:11
 
 Cannot find member `b` on `int`.
 
-  1| {val {a, b as c} = 1;}
+  1| {let {a, b as c} = 1;}
               ^
 
 
@@ -2983,14 +2983,14 @@ Found 2 errors.
     );
     assert_errors(
       heap,
-      "{val {a, d as c} = A.init();}",
+      "{let {a, d as c} = A.init();}",
       &builder.unit_type(),
       r#"
 Error ---------------------------------- DUMMY.sam:1:10-1:11
 
 Cannot find member `d` on `A`.
 
-  1| {val {a, d as c} = A.init();}
+  1| {let {a, d as c} = A.init();}
               ^
 
 
@@ -3006,18 +3006,18 @@ Found 1 error.
     assert_errors(
       &mut Heap::new(),
       r#"{
-  val _ = (() -> true)(1);
-  val _: Str = Test.generic1(
+  let _ = (() -> true)(1);
+  let _: Str = Test.generic1(
     (() -> 0)(),
     {true},
     match (Test2.Foo(false)) { Foo(_, _) -> false, Bar(_) -> false, }
   );
-  val _ = Test.generic1(0, if true then true else false, false);
-  val _ = Test.generic2((a: int) -> 1, 1);
-  val _ = Test.generic2((a) -> 1, 1);
-  val _ = Test.generic3((a: int) -> 1);
-  val _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
-  val _ = Test.generic4((a: int, b) -> 1);
+  let _ = Test.generic1(0, if true then true else false, false);
+  let _ = Test.generic2((a: int) -> 1, 1);
+  let _ = Test.generic2((a) -> 1, 1);
+  let _ = Test.generic3((a: int) -> 1);
+  let _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
+  let _ = Test.generic4((a: int, b) -> 1);
 }
 "#,
       &builder.unit_type(),
@@ -3026,7 +3026,7 @@ Error ---------------------------------- DUMMY.sam:2:12-2:26
 
 Function parameter arity of 1 is incompatible with function parameter arity of 0.
 
-  2|   val _ = (() -> true)(1);
+  2|   let _ = (() -> true)(1);
                 ^^^^^^^^^^^^^^
 
 
@@ -3042,7 +3042,7 @@ Error ---------------------------------- DUMMY.sam:8:11-8:64
 
 There is not enough context information to decide the type of this expression.
 
-  8|   val _ = Test.generic1(0, if true then true else false, false);
+  8|   let _ = Test.generic1(0, if true then true else false, false);
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
@@ -3050,7 +3050,7 @@ Error -------------------------------- DUMMY.sam:12:63-12:64
 
 There is not enough context information to decide the type of this expression.
 
-  12|   val _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
+  12|   let _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
                                                                     ^
 
 
@@ -3058,7 +3058,7 @@ Error -------------------------------- DUMMY.sam:12:83-12:84
 
 There is not enough context information to decide the type of this expression.
 
-  12|   val _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
+  12|   let _ = Test.generic3(match (Test2.Foo(false)) { Foo(_) -> (a) -> 1, Bar(_) -> (a) -> 1, });
                                                                                         ^
 
 
@@ -3074,11 +3074,11 @@ Found 5 errors.
     assert_checks(
       &mut Heap::new(),
       r#"{
-  val f = (a: int, b: int, c: int) -> {
-    val f = (d: int, e: int) -> a + b + c + d + e;
+  let f = (a: int, b: int, c: int) -> {
+    let f = (d: int, e: int) -> a + b + c + d + e;
     f(1, 2)
   };
-  val _ = (b: bool, t: int, f: int) -> if b then t else f;
+  let _ = (b: bool, t: int, f: int) -> if b then t else f;
   f(3, 4, 5)
 }
 "#,
@@ -3157,7 +3157,7 @@ Found 5 errors.
   class Main { function main(): bool = true }
   class Useless {
     function main(): unit = {
-      val _ = (foo: Useless) -> {};
+      let _ = (foo: Useless) -> {};
     }
   }
   interface Bar {}

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -1062,7 +1062,7 @@ fn check_destructuring_pattern(
     pattern::DestructuringPattern::Tuple(pattern_loc, destructured_names) => {
       let fields = cx.resolve_struct_definitions(pattern_type);
       let mut checked_destructured_names = vec![];
-      for (index, pattern::TuplePatternDestructuredName { pattern, type_: _ }) in
+      for (index, pattern::TuplePatternElement { pattern, type_: _ }) in
         destructured_names.iter().enumerate()
       {
         let loc = pattern.loc();
@@ -1071,7 +1071,7 @@ fn check_destructuring_pattern(
             cx.error_set.report_element_missing_error(*loc, pattern_type.to_description(), index);
           }
           let checked = Box::new(check_destructuring_pattern(cx, pattern, &field_sig.type_));
-          checked_destructured_names.push(pattern::TuplePatternDestructuredName {
+          checked_destructured_names.push(pattern::TuplePatternElement {
             pattern: checked,
             type_: Rc::new(field_sig.type_.reposition(*loc)),
           });
@@ -1080,8 +1080,7 @@ fn check_destructuring_pattern(
         cx.error_set.report_element_missing_error(*loc, pattern_type.to_description(), index);
         let type_ = Rc::new(Type::Any(Reason::new(*loc, Some(*loc)), false));
         let checked = Box::new(check_destructuring_pattern(cx, pattern, &type_));
-        checked_destructured_names
-          .push(pattern::TuplePatternDestructuredName { pattern: checked, type_ });
+        checked_destructured_names.push(pattern::TuplePatternElement { pattern: checked, type_ });
       }
       pattern::DestructuringPattern::Tuple(*pattern_loc, checked_destructured_names)
     }
@@ -1094,7 +1093,7 @@ fn check_destructuring_pattern(
         field_mappings.insert(field.name, (field.type_, field.is_public));
       }
       let mut checked_destructured_names = vec![];
-      for pattern::ObjectPatternDestucturedName {
+      for pattern::ObjectPatternElement {
         loc,
         field_order,
         field_name,
@@ -1113,7 +1112,7 @@ fn check_destructuring_pattern(
           }
           let checked = Box::new(check_destructuring_pattern(cx, pattern, field_type));
           let field_order = field_order_mapping.get(&field_name.name).unwrap();
-          checked_destructured_names.push(pattern::ObjectPatternDestucturedName {
+          checked_destructured_names.push(pattern::ObjectPatternElement {
             loc: *loc,
             field_order: *field_order,
             field_name: *field_name,
@@ -1130,7 +1129,7 @@ fn check_destructuring_pattern(
         );
         let type_ = Rc::new(Type::Any(Reason::new(*loc, Some(*loc)), false));
         let checked = Box::new(check_destructuring_pattern(cx, pattern, &type_));
-        checked_destructured_names.push(pattern::ObjectPatternDestucturedName {
+        checked_destructured_names.push(pattern::ObjectPatternElement {
           loc: *loc,
           field_order: *field_order,
           field_name: *field_name,

--- a/crates/samlang-core/src/checker/pattern_matching.rs
+++ b/crates/samlang-core/src/checker/pattern_matching.rs
@@ -1,0 +1,455 @@
+use itertools::Itertools;
+use samlang_collections::list::{cons, list, one, PersistentList};
+use samlang_heap::{ModuleReference, PStr};
+use std::{
+  collections::{HashMap, VecDeque},
+  rc::Rc,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(super) struct VariantPatternConstructor {
+  pub(super) module_reference: ModuleReference,
+  pub(super) class_name: PStr,
+  pub(super) variant_name: PStr,
+}
+
+#[derive(Debug)]
+enum AbstractPatternNodeInner {
+  // We assume the elements are normalized to add wildcard to not-mentioned fields.
+  StructLike {
+    variant: Option<VariantPatternConstructor>,
+    elements: PersistentList<AbstractPatternNode>,
+  },
+  Wildcard,
+  Or(Vec<AbstractPatternNode>),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AbstractPatternNode(Rc<AbstractPatternNodeInner>);
+
+impl AbstractPatternNode {
+  pub(super) fn wildcard() -> Self {
+    Self(Rc::new(AbstractPatternNodeInner::Wildcard))
+  }
+
+  pub(super) fn tuple(elements: Vec<AbstractPatternNode>) -> Self {
+    Self(Rc::new(AbstractPatternNodeInner::StructLike { variant: None, elements: list(elements) }))
+  }
+
+  pub(super) fn variant(c: VariantPatternConstructor, elements: Vec<AbstractPatternNode>) -> Self {
+    Self(Rc::new(AbstractPatternNodeInner::StructLike {
+      variant: Some(c),
+      elements: list(elements),
+    }))
+  }
+
+  pub(super) fn enum_(c: VariantPatternConstructor) -> Self {
+    Self(Rc::new(AbstractPatternNodeInner::StructLike {
+      variant: Some(c),
+      elements: PersistentList::NULL,
+    }))
+  }
+
+  pub(super) fn or(possibilities: Vec<AbstractPatternNode>) -> Self {
+    Self(Rc::new(AbstractPatternNodeInner::Or(possibilities)))
+  }
+}
+
+struct PatternVector(PersistentList<AbstractPatternNode>);
+
+struct PatternMatrix(Vec<PatternVector>);
+
+pub(super) trait PatternMatchingContext {
+  fn is_variant_signature_complete(
+    module_reference: ModuleReference,
+    class_name: PStr,
+    variant_name: &[PStr],
+  ) -> bool;
+}
+
+pub(super) fn is_additional_pattern_useful<CX: PatternMatchingContext>(
+  existing_patterns: &[AbstractPatternNode],
+  pattern: AbstractPatternNode,
+) -> bool {
+  useful_internal::<CX>(
+    &PatternMatrix(existing_patterns.iter().map(|p| PatternVector(one(p.clone()))).collect_vec()),
+    PatternVector(one(pattern)),
+  )
+}
+
+/// http://moscova.inria.fr/~maranget/papers/warn/warn.pdf
+fn useful_internal<CX: PatternMatchingContext>(p: &PatternMatrix, q: PatternVector) -> bool {
+  if p.0.is_empty() {
+    return true;
+  }
+  let Some((q_first, q_rest)) = q.0.pop() else {
+    return p.0.is_empty();
+  };
+  match q_first.0.as_ref() {
+    AbstractPatternNodeInner::StructLike { variant, elements: rs } => {
+      let rs_len = rs.len();
+      useful_internal::<CX>(
+        &convert_into_specialized_matrix(p, *variant, rs_len),
+        PatternVector(rs.clone().append(q_rest)),
+      )
+    }
+    AbstractPatternNodeInner::Wildcard => {
+      let mut root_constructors = HashMap::new();
+      let mut find_constructor_pattern_queue =
+        p.0.iter().filter_map(|r| r.0.first()).collect::<VecDeque<_>>();
+      while let Some(pattern) = find_constructor_pattern_queue.pop_front() {
+        match pattern.0.as_ref() {
+          AbstractPatternNodeInner::Wildcard => {}
+          AbstractPatternNodeInner::StructLike { variant, elements } => {
+            root_constructors.insert(*variant, elements.len());
+          }
+          AbstractPatternNodeInner::Or(possibilities) => {
+            find_constructor_pattern_queue.extend(possibilities.iter())
+          }
+        }
+      }
+      if is_signature_complete::<CX>(&root_constructors) {
+        for (variant, rs_len) in root_constructors {
+          let mut new_q = q_rest.clone();
+          for _ in 0..rs_len {
+            new_q = cons(AbstractPatternNode::wildcard(), new_q);
+          }
+          if useful_internal::<CX>(
+            &convert_into_specialized_matrix(p, variant, rs_len),
+            PatternVector(new_q),
+          ) {
+            return true;
+          }
+        }
+        false
+      } else {
+        let mut default_matrix_rows = vec![];
+        let mut convert_to_default_matrix_queue =
+          p.0.iter().map(|PatternVector(r)| r.clone()).collect::<VecDeque<_>>();
+        while let Some(p_row) = convert_to_default_matrix_queue.pop_front() {
+          match p_row.first().unwrap().0.as_ref() {
+            AbstractPatternNodeInner::StructLike { .. } => { /* skip */ }
+            AbstractPatternNodeInner::Wildcard => {
+              default_matrix_rows.push(PatternVector(p_row.rest()));
+            }
+            AbstractPatternNodeInner::Or(possibilities) => {
+              for r in possibilities {
+                convert_to_default_matrix_queue.push_front(cons(r.clone(), p_row.rest()));
+              }
+            }
+          }
+        }
+        useful_internal::<CX>(&PatternMatrix(default_matrix_rows), PatternVector(q_rest))
+      }
+    }
+    AbstractPatternNodeInner::Or(possibilities) => possibilities
+      .iter()
+      .any(|r| useful_internal::<CX>(p, PatternVector(cons(r.clone(), q_rest.clone())))),
+  }
+}
+
+fn convert_into_specialized_matrix_row(
+  new_rows: &mut Vec<PatternVector>,
+  PatternVector(p_row): &PatternVector,
+  variant: Option<VariantPatternConstructor>,
+  rs_len: usize,
+) {
+  let p_first = p_row.first().unwrap();
+  match p_first.0.as_ref() {
+    AbstractPatternNodeInner::StructLike { variant: p_last_variant, elements: rs } => {
+      match (p_last_variant.as_ref(), variant) {
+        (Some(a), Some(b)) if a != &b => {
+          // Different constructors. Skip
+        }
+        _ => {
+          debug_assert_eq!(rs_len, rs.len());
+          new_rows.push(PatternVector(rs.clone().append(p_row.rest())));
+        }
+      }
+    }
+    AbstractPatternNodeInner::Wildcard => {
+      let mut new_row = p_row.rest();
+      for _ in 0..rs_len {
+        new_row = cons(AbstractPatternNode::wildcard(), new_row);
+      }
+      new_rows.push(PatternVector(new_row));
+    }
+    AbstractPatternNodeInner::Or(possibilities) => {
+      for r in possibilities {
+        convert_into_specialized_matrix_row(
+          new_rows,
+          &PatternVector(cons(r.clone(), p_row.rest())),
+          variant,
+          rs_len,
+        )
+      }
+    }
+  }
+}
+
+fn convert_into_specialized_matrix(
+  p: &PatternMatrix,
+  variant: Option<VariantPatternConstructor>,
+  rs_len: usize,
+) -> PatternMatrix {
+  let mut new_rows = vec![];
+  for p_row in &p.0 {
+    convert_into_specialized_matrix_row(&mut new_rows, p_row, variant, rs_len)
+  }
+  PatternMatrix(new_rows)
+}
+
+fn is_signature_complete<CX: PatternMatchingContext>(
+  root_constructors: &HashMap<Option<VariantPatternConstructor>, usize>,
+) -> bool {
+  if root_constructors.contains_key(&None) {
+    return true;
+  }
+  if root_constructors.is_empty() {
+    return false;
+  }
+  let mut variants_grouped = vec![];
+  for (key, group) in
+    &root_constructors.keys().filter_map(|c| *c).group_by(|c| (c.module_reference, c.class_name))
+  {
+    variants_grouped.push((key, group.map(|g| g.variant_name).collect_vec()));
+  }
+  assert!(variants_grouped.len() == 1);
+  let ((mod_ref, class_name), variants) =
+    variants_grouped.pop().expect("Already checked it's non-empty.");
+  CX::is_variant_signature_complete(mod_ref, class_name, &variants)
+}
+
+#[cfg(test)]
+mod tests {
+  use samlang_heap::{ModuleReference, PStr};
+
+  use super::{AbstractPatternNode as P, PatternMatchingContext, VariantPatternConstructor};
+
+  const OPTION: PStr = PStr::six_letter_literal(b"Option");
+  const SOME: PStr = PStr::four_letter_literal(b"Some");
+  const NONE: PStr = PStr::four_letter_literal(b"None");
+
+  const OPTION_SOME: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: OPTION,
+    variant_name: SOME,
+  };
+  const OPTION_NONE: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: OPTION,
+    variant_name: NONE,
+  };
+
+  const LETTERS: PStr = PStr::seven_letter_literal(b"Letters");
+
+  const LETTERS_A: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_A,
+  };
+  const LETTERS_B: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_B,
+  };
+  const LETTERS_C: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_C,
+  };
+  const LETTERS_D: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_D,
+  };
+  const LETTERS_E: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_E,
+  };
+  const LETTERS_F: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_F,
+  };
+  const LETTERS_G: VariantPatternConstructor = VariantPatternConstructor {
+    module_reference: ModuleReference::ROOT,
+    class_name: LETTERS,
+    variant_name: PStr::UPPER_G,
+  };
+
+  struct MockingPatternMatchingContext;
+
+  impl PatternMatchingContext for MockingPatternMatchingContext {
+    fn is_variant_signature_complete(
+      _module_reference: ModuleReference,
+      class_name: PStr,
+      variant_name: &[PStr],
+    ) -> bool {
+      if class_name == OPTION {
+        variant_name.contains(&SOME) && variant_name.contains(&NONE)
+      } else if class_name == LETTERS {
+        variant_name.contains(&PStr::UPPER_A)
+          && variant_name.contains(&PStr::UPPER_B)
+          && variant_name.contains(&PStr::UPPER_C)
+          && variant_name.contains(&PStr::UPPER_D)
+          && variant_name.contains(&PStr::UPPER_E)
+          && variant_name.contains(&PStr::UPPER_F)
+          && variant_name.contains(&PStr::UPPER_G)
+      } else {
+        false
+      }
+    }
+  }
+
+  fn useful(matrix: &[&[P]], vector: &[P]) -> bool {
+    super::useful_internal::<MockingPatternMatchingContext>(
+      &super::PatternMatrix(
+        matrix.iter().map(|r| super::PatternVector(super::list(r.to_vec()))).collect(),
+      ),
+      super::PatternVector(super::list(vector.to_vec())),
+    )
+  }
+
+  #[test]
+  fn boilterplate() {
+    assert!(!format!("{:?}", OPTION_NONE).is_empty());
+    assert!(!format!("{:?}", P::wildcard()).is_empty());
+    assert_eq!(LETTERS, LETTERS_A.clone().class_name);
+    assert!(!MockingPatternMatchingContext::is_variant_signature_complete(
+      ModuleReference::ROOT,
+      PStr::PANIC,
+      &[],
+    ));
+  }
+
+  #[test]
+  fn test_base_case() {
+    assert!(useful(&[], &[]));
+    assert!(!useful(&[&[]], &[]));
+  }
+
+  #[test]
+  fn test_two_wildcards() {
+    assert!(useful(&[], &[P::wildcard()]));
+    assert!(!useful(&[&[P::wildcard()]], &[P::wildcard()]));
+  }
+
+  #[test]
+  fn test_simple_enums() {
+    assert!(useful(
+      &[
+        &[P::enum_(LETTERS_A)],
+        &[P::enum_(LETTERS_B)],
+        &[P::enum_(LETTERS_C)],
+        &[P::enum_(LETTERS_D)],
+        &[P::enum_(LETTERS_E)],
+      ],
+      &[P::or(vec![P::enum_(LETTERS_F), P::enum_(LETTERS_G)])]
+    ));
+    assert!(!useful(
+      &[
+        &[P::enum_(LETTERS_A)],
+        &[P::enum_(LETTERS_B)],
+        &[P::or(vec![P::enum_(LETTERS_C), P::enum_(LETTERS_D)])],
+        &[P::enum_(LETTERS_E)],
+        &[P::enum_(LETTERS_F)],
+        &[P::enum_(LETTERS_G)],
+      ],
+      &[P::wildcard()]
+    ));
+  }
+
+  #[test]
+  fn test_simple_enums_two_columns() {
+    assert!(useful(
+      &[
+        &[P::enum_(LETTERS_A), P::wildcard()],
+        &[P::enum_(LETTERS_B), P::wildcard()],
+        &[P::enum_(LETTERS_C), P::wildcard()],
+        &[P::enum_(LETTERS_D), P::wildcard()],
+        &[P::enum_(LETTERS_E), P::wildcard()],
+        &[P::enum_(LETTERS_F), P::wildcard()],
+        &[P::enum_(LETTERS_G), P::or(vec![P::enum_(LETTERS_A), P::enum_(LETTERS_B)])],
+      ],
+      &[P::wildcard(), P::wildcard()],
+    ));
+    assert!(useful(
+      &[
+        &[P::wildcard(), P::enum_(LETTERS_A)],
+        &[P::wildcard(), P::enum_(LETTERS_B)],
+        &[P::wildcard(), P::enum_(LETTERS_C)],
+        &[P::wildcard(), P::enum_(LETTERS_D)],
+        &[P::wildcard(), P::enum_(LETTERS_E)],
+        &[P::wildcard(), P::enum_(LETTERS_F)],
+        &[P::or(vec![P::enum_(LETTERS_A), P::enum_(LETTERS_B)]), P::enum_(LETTERS_G)],
+      ],
+      &[P::wildcard(), P::wildcard()],
+    ));
+  }
+
+  #[test]
+  fn option_test_1() {
+    // None, _         => useful
+    // _, None         => useful
+    // Some _, Some _  => useful
+    // _, _            => useless
+
+    assert!(useful(&[], &[P::enum_(OPTION_NONE), P::wildcard()]));
+    assert!(useful(
+      &[&[P::enum_(OPTION_NONE), P::wildcard()]],
+      &[P::wildcard(), P::enum_(OPTION_NONE)]
+    ));
+    assert!(useful(
+      &[&[P::enum_(OPTION_NONE), P::wildcard()], &[P::wildcard(), P::enum_(OPTION_NONE)],],
+      &[P::variant(OPTION_SOME, vec![P::wildcard()]), P::variant(OPTION_SOME, vec![P::wildcard()])]
+    ));
+    assert!(!useful(
+      &[
+        &[P::enum_(OPTION_NONE), P::wildcard()],
+        &[P::wildcard(), P::enum_(OPTION_NONE)],
+        &[
+          P::variant(OPTION_SOME, vec![P::wildcard()]),
+          P::variant(OPTION_SOME, vec![P::wildcard()])
+        ],
+      ],
+      &[P::wildcard(), P::wildcard()]
+    ));
+  }
+
+  #[test]
+  fn option_test_2() {
+    // (None, _)         => useful
+    // (_, None)         => useful
+    // (Some _, Some _)  => useful
+    // _                 => useless
+
+    assert!(useful(&[], &[P::tuple(vec![P::enum_(OPTION_NONE), P::wildcard()])]));
+    assert!(useful(
+      &[&[P::tuple(vec![P::enum_(OPTION_NONE), P::wildcard()])]],
+      &[P::tuple(vec![P::wildcard(), P::enum_(OPTION_NONE)])]
+    ));
+    assert!(useful(
+      &[
+        &[P::tuple(vec![P::enum_(OPTION_NONE), P::wildcard()])],
+        &[P::tuple(vec![P::wildcard(), P::enum_(OPTION_NONE)])]
+      ],
+      &[P::tuple(vec![
+        P::variant(OPTION_SOME, vec![P::wildcard()]),
+        P::variant(OPTION_SOME, vec![P::wildcard()])
+      ])]
+    ));
+    assert!(!super::is_additional_pattern_useful::<MockingPatternMatchingContext>(
+      &[
+        P::tuple(vec![P::enum_(OPTION_NONE), P::wildcard()]),
+        P::tuple(vec![P::wildcard(), P::enum_(OPTION_NONE)]),
+        P::tuple(vec![
+          P::variant(OPTION_SOME, vec![P::wildcard()]),
+          P::variant(OPTION_SOME, vec![P::wildcard()]),
+        ]),
+      ],
+      P::wildcard()
+    ));
+  }
+}

--- a/crates/samlang-core/src/checker/ssa_analysis.rs
+++ b/crates/samlang-core/src/checker/ssa_analysis.rs
@@ -329,7 +329,7 @@ impl<'a> SsaAnalysisState<'a> {
   fn visit_pattern(&mut self, pattern: &pattern::DestructuringPattern<()>) {
     match pattern {
       pattern::DestructuringPattern::Tuple(_, names) => {
-        for pattern::TuplePatternDestructuredName { pattern, type_: _ } in names {
+        for pattern::TuplePatternElement { pattern, type_: _ } in names {
           self.visit_pattern(pattern);
         }
       }

--- a/crates/samlang-core/src/checker/ssa_analysis_tests.rs
+++ b/crates/samlang-core/src/checker/ssa_analysis_tests.rs
@@ -40,10 +40,10 @@ mod tests {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
     let expr_str = r#"{
-  val a: int = 3;
-  val b = true;
-  val c = a;
-  val _ = if a && b then {
+  let a: int = 3;
+  let b = true;
+  let c = a;
+  let _ = if a && b then {
     match (!c) {
       Foo(d) -> d + a,
       Bar(_) -> b
@@ -51,8 +51,8 @@ mod tests {
   } else {
     (p1: Foo, p2) -> Baz.ouch<Foo>(p2).ahha<Foo>(p1) + a
   };
-  val a = 3;
-  val {o1, o2 as o3} = {};
+  let a = 3;
+  let {o1, o2 as o3} = {};
   o1 + o3
 }"#;
     let (_, expr) = parser::parse_source_expression_from_text(

--- a/crates/samlang-core/src/compiler/hir_lowering.rs
+++ b/crates/samlang-core/src/compiler/hir_lowering.rs
@@ -2113,7 +2113,7 @@ return (_t7: DUMMY_Dummy);"#,
                 pattern: source::pattern::DestructuringPattern::Object(
                   Location::dummy(),
                   vec![
-                    source::pattern::ObjectPatternDestucturedName {
+                    source::pattern::ObjectPatternElement {
                       loc: Location::dummy(),
                       field_order: 0,
                       field_name: source::Id::from(PStr::LOWER_A),
@@ -2123,7 +2123,7 @@ return (_t7: DUMMY_Dummy);"#,
                       shorthand: true,
                       type_: builder.int_type(),
                     },
-                    source::pattern::ObjectPatternDestucturedName {
+                    source::pattern::ObjectPatternElement {
                       loc: Location::dummy(),
                       field_order: 1,
                       field_name: source::Id::from(PStr::LOWER_B),
@@ -2168,7 +2168,7 @@ return 0;"#,
             pattern: source::pattern::DestructuringPattern::Object(
               Location::dummy(),
               vec![
-                source::pattern::ObjectPatternDestucturedName {
+                source::pattern::ObjectPatternElement {
                   loc: Location::dummy(),
                   field_order: 0,
                   field_name: source::Id::from(PStr::LOWER_A),
@@ -2178,7 +2178,7 @@ return 0;"#,
                   shorthand: true,
                   type_: builder.int_type(),
                 },
-                source::pattern::ObjectPatternDestucturedName {
+                source::pattern::ObjectPatternElement {
                   loc: Location::dummy(),
                   field_order: 1,
                   field_name: source::Id::from(PStr::LOWER_B),
@@ -2199,13 +2199,13 @@ return 0;"#,
             pattern: source::pattern::DestructuringPattern::Tuple(
               Location::dummy(),
               vec![
-                source::pattern::TuplePatternDestructuredName {
+                source::pattern::TuplePatternElement {
                   pattern: Box::new(source::pattern::DestructuringPattern::Id(source::Id::from(
                     PStr::LOWER_D,
                   ))),
                   type_: builder.int_type(),
                 },
-                source::pattern::TuplePatternDestructuredName {
+                source::pattern::TuplePatternElement {
                   pattern: Box::new(source::pattern::DestructuringPattern::Wildcard(
                     Location::dummy(),
                   )),

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -29,10 +29,10 @@ mod tests {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val a: int = "3".toInt();
-    val b: Str = Str.fromInt(3);
-    val c: unit = Process.println("3");
-    val d: Main = Process.panic("3");
+    let a: int = "3".toInt();
+    let b: Str = Str.fromInt(3);
+    let c: unit = Process.println("3");
+    let d: Main = Process.panic("3");
   }
 }
 "#,
@@ -50,8 +50,8 @@ class C(val v: bool) {
 
 class Main {
   function main(): unit = {
-    val _ = A.b();
-    val _ = C.create();
+    let _ = A.b();
+    let _ = C.create();
   }
 }
 "#,
@@ -192,20 +192,20 @@ class Main {
         source_code: r#"
 class Fields(val a: int, private val b: bool) {
   function get(): Fields = {
-    val f = Fields.init(3, true);
-    val {a, b} = f;
-    val _ = f.a;
-    val _ = f.b;
+    let f = Fields.init(3, true);
+    let {a, b} = f;
+    let _ = f.a;
+    let _ = f.b;
     f
   }
 }
 
 class Main {
   function main(): unit = {
-    val f = Fields.get();
-    val {a, b} = f;
-    val _ = f.a;
-    val _ = f.b;
+    let f = Fields.get();
+    let {a, b} = f;
+    let _ = f.a;
+    let _ = f.b;
   }
 }
 "#,
@@ -232,8 +232,8 @@ class FunctionParametersConflict {
 
 class Main {
   function main(): unit = {
-    val a = 42;
-    val a = 42;
+    let a = 42;
+    let a = 42;
   }
 }
 "#,
@@ -244,7 +244,7 @@ class Main {
 
 class Main {
   function main(): unit = {
-    val _ = this;
+    let _ = this;
   }
 }
 "#,
@@ -255,7 +255,7 @@ class Main {
 class NotEnoughTypeInfo {
   function <T> randomFunction(): T = Process.panic("I can be any type!")
   function main(): unit = {
-    val _ = NotEnoughTypeInfo.randomFunction();
+    let _ = NotEnoughTypeInfo.randomFunction();
   }
 }
 class Main {
@@ -272,7 +272,7 @@ class Option<T>(Some(T), None(bool)) {
 }
 class Main {
   function main(): unit = {
-    val a = Option.none();
+    let a = Option.none();
   }
 }
 "#,
@@ -299,9 +299,9 @@ class SamObject<T>(val sam: T, val good: bool, val linesOfCode: int) {
 
 class Main {
   function main(): unit = {
-    val sam = SamObject.create("sam zhou").withDifferentLOC(100001);
-    val s = sam.getSam();
-    val linesOfCode = if (sam.isGood()) then sam.getLinesOfCode() else 0;
+    let sam = SamObject.create("sam zhou").withDifferentLOC(100001);
+    let s = sam.getSam();
+    let linesOfCode = if (sam.isGood()) then sam.getLinesOfCode() else 0;
   }
 }
 "#,
@@ -327,12 +327,12 @@ class Main {
         source_code: r#"
 class HelloWorld(val message: Str) {
   private method getMessage(): Str = {
-    val { message } = this;
+    let { message } = this;
     message
   }
 
   function getGlobalMessage(): Str = {
-    val hw = HelloWorld.init("Hello World!");
+    let hw = HelloWorld.init("Hello World!");
     hw.getMessage()
   }
 }
@@ -348,7 +348,7 @@ class Main {
 class NewYear2019<T>(val message: T) {
   function create(): NewYear2019<Str> = NewYear2019.init("Hello World!")
   method getMessage(): T = {
-    val { message as msg } = this; msg
+    let { message as msg } = this; msg
   }
 }
 
@@ -372,7 +372,7 @@ class Main {
   function <A, B, C> pipe(a: A, f1: (A)->B, f2: (B)->C): C = f2(f1(a))
 
   function main(): unit = {
-    val _ = Main.pipe(1, (n) -> Str.fromInt(n), (s) -> s.toInt());
+    let _ = Main.pipe(1, (n) -> Str.fromInt(n), (s) -> s.toInt());
   }
 }
 "#,
@@ -388,12 +388,12 @@ class Option<T>(Some(T), None) {
 class Main {
   function main(): Option<Str> = Option.none<Str>().toSome("hi")
   function main2(): Option<Str> = {
-    val a = Option.none<Str>();
+    let a = Option.none<Str>();
     a.toSome("hi")
   }
 
   function main3(): Option<Str> = {
-    val a: Option<Str> = Option.none();
+    let a: Option<Str> = Option.none();
     a.toSome("hi")
   }
 }
@@ -414,8 +414,8 @@ class Developer(
   val projects: List<Str>,
 ) {
   function sam(): Developer = {
-    val l = List.of("SAMLANG").cons("...");
-    val github = "SamChou19815";
+    let l = List.of("SAMLANG").cons("...");
+    let github = "SamChou19815";
     Developer.init("Sam Zhou", github, l)
   }
 }
@@ -442,7 +442,7 @@ class Main {
  */
 class Main {
   function main(): unit = {
-    val _: ((int) -> bool, int, int) -> int = (a, b, c) -> if a(b + 1) then b else c;
+    let _: ((int) -> bool, int, int) -> int = (a, b, c) -> if a(b + 1) then b else c;
   }
 }
 "#,
@@ -457,10 +457,10 @@ class Main {
   function <T> id(v: T): T = v
 
   function main(): unit = {
-    val _ = Main.reduce((acc, n) -> acc + n, Main.getInt());
-    val _: (int) -> int = Main.id((x) -> x);
-    val _: (int) -> int = Main.id(Main.id((x) -> x));
-    val _: (int) -> int = Main.id(Main.id(Main.id((x) -> x)));
+    let _ = Main.reduce((acc, n) -> acc + n, Main.getInt());
+    let _: (int) -> int = Main.id((x) -> x);
+    let _: (int) -> int = Main.id(Main.id((x) -> x));
+    let _: (int) -> int = Main.id(Main.id(Main.id((x) -> x)));
   }
 }
 "#,
@@ -488,7 +488,7 @@ Error ---------------- access-private-member.sam:12:15-12:16
 
 Cannot find member `b` on `A`.
 
-  12|     val _ = A.b();
+  12|     let _ = A.b();
                     ^
 
 
@@ -936,7 +936,7 @@ Error --------- illegal-private-field-access.sam:15:13-15:14
 
 Cannot find member `b` on `Fields`.
 
-  15|     val {a, b} = f;
+  15|     let {a, b} = f;
                   ^
 
 
@@ -944,7 +944,7 @@ Error --------- illegal-private-field-access.sam:17:15-17:16
 
 Cannot find member `b` on `Fields`.
 
-  17|     val _ = f.b;
+  17|     let _ = f.b;
                     ^
 
 
@@ -1004,12 +1004,12 @@ Error ------------------------ illegal-shadow.sam:22:9-22:10
 
 Name `a` collides with a previously defined name at [1].
 
-  22|     val a = 42;
+  22|     let a = 42;
               ^
 
   [1] illegal-shadow.sam:21:9-21:10
   ---------------------------------
-  21|     val a = 42;
+  21|     let a = 42;
               ^
 
 
@@ -1017,7 +1017,7 @@ Error --------------------------- illegal-this.sam:5:13-5:17
 
 Name `this` is not resolved.
 
-  5|     val _ = this;
+  5|     let _ = this;
                  ^^^^
 
 
@@ -1025,7 +1025,7 @@ Error ----------------- insufficient-type-info.sam:5:13-5:47
 
 There is not enough context information to decide the type of this expression.
 
-  5|     val _ = NotEnoughTypeInfo.randomFunction();
+  5|     let _ = NotEnoughTypeInfo.randomFunction();
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
@@ -1033,7 +1033,7 @@ Error ------------ insufficient-type-info-none.sam:8:13-8:26
 
 There is not enough context information to decide the type of this expression.
 
-  8|     val a = Option.none();
+  8|     let a = Option.none();
                  ^^^^^^^^^^^^^
 
 
@@ -1174,15 +1174,15 @@ Found 51 errors.
         source_code: r#"
 class Main {
   function main(): unit = {
-    val i = 1;
-    val j = 2;
+    let i = 1;
+    let j = 2;
     if (i < j && i > 0 && j > 0) then {
-      val a = 3;
-      val b = 4;
+      let a = 3;
+      let b = 4;
       if (a > b || a + b > 0 && true) then Process.println("one") else Process.println("two")
     } else {
-      val a = 3;
-      val b = 4;
+      let a = 3;
+      let b = 4;
       if (a == 2 || b == 4) then {
         Process.println("three")
       } else {
@@ -1200,9 +1200,9 @@ class Main {
 class Main {
   function main(): unit =
     if (true) then {
-      val _ = Main.main2();
-      val _ = Main.main3();
-      val _ = 3;
+      let _ = Main.main2();
+      let _ = Main.main3();
+      let _ = 3;
       {}
     } else {
       {}
@@ -1210,7 +1210,7 @@ class Main {
 
   function main2(): int =
     if (true) then {
-      val _ = 3;
+      let _ = 3;
       3
     } else {
       2
@@ -1218,7 +1218,7 @@ class Main {
 
   function main3(): unit =
     if (true) then {
-      val _ = 3;
+      let _ = 3;
     } else {
       // Do nothing...
     }
@@ -1231,8 +1231,8 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val value = Str.fromInt("42".toInt())::"!";
-    val _ = Process.println(value);
+    let value = Str.fromInt("42".toInt())::"!";
+    let _ = Process.println(value);
   }
 }
 "#,
@@ -1255,7 +1255,7 @@ class Main {
 class Main {
   function main(): unit = {
     // 35
-    val increase = (1+2*3-4/5%10000000/12334) + (1+2*3-4/5%10000000/12334) +
+    let increase = (1+2*3-4/5%10000000/12334) + (1+2*3-4/5%10000000/12334) +
                    (1+2*3-4/5%10000000/12334) + (1+2*3-4/5%10000000/12334) +
                    (1+2*3-4/5%10000000/12334);
     Process.println(Str.fromInt(2 + increase))
@@ -1287,12 +1287,12 @@ class Main {
         source_code: r#"
 class Main {
   function crash(a: Str, b: Str): unit = {
-    val _ = Process.println("different:");
-    val _ = Process.println("a:");
-    val _ = Process.println(a);
-    val _ = Process.println("b:");
-    val _ = Process.println(b);
-    val _ = Process.panic<unit>("crash!");
+    let _ = Process.println("different:");
+    let _ = Process.println("a:");
+    let _ = Process.println(a);
+    let _ = Process.println("b:");
+    let _ = Process.println(b);
+    let _ = Process.panic<unit>("crash!");
   }
 
   function checkInt(a: int, b: int): unit =
@@ -1305,54 +1305,54 @@ class Main {
     if (a == b) then {} else Main.crash(Main.boolToString(a), Main.boolToString(b))
 
   function checkAll(): unit = {
-    val _ = Main.checkInt(42, 21 * 2);
-    val _ = Main.checkInt(42, 84 / 2);
-    val _ = Main.checkInt(42, 91 % 49);
-    val _ = Main.checkInt(42, 20 + 22);
-    val _ = Main.checkInt(42, 50 - 8);
+    let _ = Main.checkInt(42, 21 * 2);
+    let _ = Main.checkInt(42, 84 / 2);
+    let _ = Main.checkInt(42, 91 % 49);
+    let _ = Main.checkInt(42, 20 + 22);
+    let _ = Main.checkInt(42, 50 - 8);
 
-    val _ = Main.checkBool(false, false);
-    val _ = Main.checkBool(true, true);
+    let _ = Main.checkBool(false, false);
+    let _ = Main.checkBool(true, true);
 
-    val _ = Main.checkBool(false, false && false);
-    val _ = Main.checkBool(false, true && false);
-    val _ = Main.checkBool(false, false && true);
-    val _ = Main.checkBool(true, true && true);
-    val _ = Main.checkBool(false, false || false);
-    val _ = Main.checkBool(true, true || false);
-    val _ = Main.checkBool(true, false || true);
-    val _ = Main.checkBool(true, true || true);
+    let _ = Main.checkBool(false, false && false);
+    let _ = Main.checkBool(false, true && false);
+    let _ = Main.checkBool(false, false && true);
+    let _ = Main.checkBool(true, true && true);
+    let _ = Main.checkBool(false, false || false);
+    let _ = Main.checkBool(true, true || false);
+    let _ = Main.checkBool(true, false || true);
+    let _ = Main.checkBool(true, true || true);
 
-    val _ = Main.checkBool(true, 42 < 50);
-    val _ = Main.checkBool(false, 42 > 42);
-    val _ = Main.checkBool(false, 42 > 50);
-    val _ = Main.checkBool(true, 42 <= 42);
-    val _ = Main.checkBool(true, 42 <= 43);
-    val _ = Main.checkBool(false, 42 <= 41);
-    val _ = Main.checkBool(true, 50 > 42);
-    val _ = Main.checkBool(false, 42 < 42);
-    val _ = Main.checkBool(false, 50 < 42);
-    val _ = Main.checkBool(true, 42 >= 42);
-    val _ = Main.checkBool(true, 43 >= 42);
-    val _ = Main.checkBool(false, 41 >= 42);
+    let _ = Main.checkBool(true, 42 < 50);
+    let _ = Main.checkBool(false, 42 > 42);
+    let _ = Main.checkBool(false, 42 > 50);
+    let _ = Main.checkBool(true, 42 <= 42);
+    let _ = Main.checkBool(true, 42 <= 43);
+    let _ = Main.checkBool(false, 42 <= 41);
+    let _ = Main.checkBool(true, 50 > 42);
+    let _ = Main.checkBool(false, 42 < 42);
+    let _ = Main.checkBool(false, 50 < 42);
+    let _ = Main.checkBool(true, 42 >= 42);
+    let _ = Main.checkBool(true, 43 >= 42);
+    let _ = Main.checkBool(false, 41 >= 42);
 
-    val _ = Main.checkBool(true, 1 == 1);
-    val _ = Main.checkBool(false, 1 == 2);
-    val _ = Main.checkBool(false, 1 != 1);
-    val _ = Main.checkBool(true, 1 != 2);
-    val _ = Main.checkBool(true, true == true);
-    val _ = Main.checkBool(false, true == false);
-    val _ = Main.checkBool(false, true != true);
-    val _ = Main.checkBool(true, true != false);
+    let _ = Main.checkBool(true, 1 == 1);
+    let _ = Main.checkBool(false, 1 == 2);
+    let _ = Main.checkBool(false, 1 != 1);
+    let _ = Main.checkBool(true, 1 != 2);
+    let _ = Main.checkBool(true, true == true);
+    let _ = Main.checkBool(false, true == false);
+    let _ = Main.checkBool(false, true != true);
+    let _ = Main.checkBool(true, true != false);
 
-    val c = 21;
-    val _ = Main.checkInt(-42, -(c * 2)); // prevent constant folding!
-    val _ = Main.checkBool(true, !false);
-    val _ = Main.checkBool(false, !true);
+    let c = 21;
+    let _ = Main.checkInt(-42, -(c * 2)); // prevent constant folding!
+    let _ = Main.checkBool(true, !false);
+    let _ = Main.checkBool(false, !true);
   }
 
   function main(): unit = {
-    val _ = Main.checkAll();
+    let _ = Main.checkAll();
     Process.println("OK")
   }
 }
@@ -1371,7 +1371,7 @@ class List(Nil(unit), Cons(Pair<int, List>)) {
   ])
 }
 
-class Main { function main(): unit = { val _: List = List.of(1); Process.println("hello") }  }
+class Main { function main(): unit = { let _: List = List.of(1); Process.println("hello") }  }
 "#,
       },
       CompilerTestCase {
@@ -1382,9 +1382,9 @@ class Main {
   function printInt(i: int): unit = Process.println(Str.fromInt(i))
 
   function test(a: int, b: int): unit = {
-    val _ = Main.printInt((a * b + a) + (a * b + a));
-    val _ = Main.printInt(a * b);
-    val _ = Main.printInt(a * b + a);
+    let _ = Main.printInt((a * b + a) + (a * b + a));
+    let _ = Main.printInt(a * b);
+    let _ = Main.printInt(a * b + a);
   }
 
   function main(): unit = Main.test(3, 4)
@@ -1404,13 +1404,13 @@ class Main {
     else {}
 
   function test(first: bool, a: int, b: int, aTimesB: int): unit = {
-    val t = if (first) then a * b else a * b;
-    val _ = Main.check(a * b, aTimesB);
+    let t = if (first) then a * b else a * b;
+    let _ = Main.check(a * b, aTimesB);
   }
 
   function main(): unit = {
-    val _ = Main.test(true, 3, 4, 12);
-    val _ = Main.test(false, 3, 4, 12);
+    let _ = Main.test(true, 3, 4, 12);
+    let _ = Main.test(false, 3, 4, 12);
     Process.println("OK")
   }
 }
@@ -1453,9 +1453,9 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val megagrams: int = 141332443;
-    val kilograms: int = megagrams / 1000;
-    val grams: int = (megagrams / 1000) / 1000;
+    let megagrams: int = 141332443;
+    let kilograms: int = megagrams / 1000;
+    let grams: int = (megagrams / 1000) / 1000;
     Process.println(Str.fromInt(grams))
   }
 }
@@ -1470,12 +1470,12 @@ class Main {
     if (i >= 4) then
       totalOddNumbers
     else {
-      val iMod64 = i % 64;
-      val iMod32 = (i % 64) % 32;
-      val iMod16 = ((i % 64) % 32) % 16;
-      val iMod8 = (((i % 64) % 32) % 16) % 8;
-      val iMod4 = ((((i % 64) % 32) % 16) % 8) % 4;
-      val iMod2 = (((((i % 64) % 32) % 16) % 8) % 4) % 2;
+      let iMod64 = i % 64;
+      let iMod32 = (i % 64) % 32;
+      let iMod16 = ((i % 64) % 32) % 16;
+      let iMod8 = (((i % 64) % 32) % 16) % 8;
+      let iMod4 = ((((i % 64) % 32) % 16) % 8) % 4;
+      let iMod2 = (((((i % 64) % 32) % 16) % 8) % 4) % 2;
       Main.test(totalOddNumbers + iMod2, i + 1)
     }
   }
@@ -1497,15 +1497,15 @@ class Main {
     else {}
 
   function test(first: bool, a: int, b: int, aTimesB: int): unit = {
-    val _ = if (first) then {
-      val _ = a * b;
+    let _ = if (first) then {
+      let _ = a * b;
     } else {};
-    val _ = Main.check(a * b, aTimesB);
+    let _ = Main.check(a * b, aTimesB);
   }
 
   function main(): unit = {
-    val _ = Main.test(true, 3, 4, 12);
-    val _ = Main.test(false, 3, 4, 12);
+    let _ = Main.test(true, 3, 4, 12);
+    let _ = Main.test(false, 3, 4, 12);
     Process.println("OK")
   }
 }
@@ -1555,7 +1555,7 @@ class FunctionExample {
 class Box<T>(val content: T) {
   function <T> create(content: T): Box<T> = Box.init(content)
   method getContent(): T = {
-    val { content } = this; content
+    let { content } = this; content
   }
 }
 
@@ -1586,19 +1586,19 @@ class Main {
     if (e1 == e2) then {} else Process.panic(Str.fromInt(e1)::" "::Str.fromInt(e2)::" "::message)
 
   private function consistencyTest(): unit = {
-    val _ = Main.assertEquals(Option.getSome(3).map((i) -> i + 1).forceValue(), 4, "Ah1");
-    val _ = Main.assertEquals(Box.create(42).getContent(), 42, "Ah2");
-    val _ = Main.assertEquals(FunctionExample.getIdentityFunction<int>()(42), 42, "Ah3");
-    val _ = Main.assertEquals(Student.dummyStudent().getAge(), 0, "Ah4");
-    val _ = Main.assertEquals(Math.plus(2, 2), 4, "Ah5");
-    val _ = Main.assertFalse(PrimitiveType.getUnit().isTruthy(), "Ah6");
-    val _ = Main.assertTrue(PrimitiveType.getInteger().isTruthy(), "Ah7");
-    val _ = Main.assertTrue(PrimitiveType.getString().isTruthy(), "Ah8");
-    val _ = Main.assertFalse(PrimitiveType.getBool().isTruthy(), "Ah9");
+    let _ = Main.assertEquals(Option.getSome(3).map((i) -> i + 1).forceValue(), 4, "Ah1");
+    let _ = Main.assertEquals(Box.create(42).getContent(), 42, "Ah2");
+    let _ = Main.assertEquals(FunctionExample.getIdentityFunction<int>()(42), 42, "Ah3");
+    let _ = Main.assertEquals(Student.dummyStudent().getAge(), 0, "Ah4");
+    let _ = Main.assertEquals(Math.plus(2, 2), 4, "Ah5");
+    let _ = Main.assertFalse(PrimitiveType.getUnit().isTruthy(), "Ah6");
+    let _ = Main.assertTrue(PrimitiveType.getInteger().isTruthy(), "Ah7");
+    let _ = Main.assertTrue(PrimitiveType.getString().isTruthy(), "Ah8");
+    let _ = Main.assertFalse(PrimitiveType.getBool().isTruthy(), "Ah9");
   }
 
   function main(): unit = {
-    val _ = Main.consistencyTest();
+    let _ = Main.consistencyTest();
     Process.println("OK")
   }
 }
@@ -1622,11 +1622,11 @@ class Option<T>(None(unit), Some(T)) {
 
 class Obj(private val d: int, val e: int) {
   function valExample(): int = {
-    val a: int = 1;
-    val b = 2;
-    val c = 3;
-    val { e as d } = Obj.init(5, 4); // d = 4
-    val _ = 42;
+    let a: int = 1;
+    let b = 2;
+    let c = 3;
+    let { e as d } = Obj.init(5, 4); // d = 4
+    let _ = 42;
     // 1 + 2 * 3 / 4 = 1 + 6/4 = 1 + 1 = 2
     a + b * c / d
   }
@@ -1636,7 +1636,7 @@ class Main {
   function identity(a: int): int = a
 
   function random(): int = {
-    val a = 42; // very random
+    let a = 42; // very random
     a
   }
 
@@ -1650,10 +1650,10 @@ class Main {
     )
 
   function nestedVal(): int = {
-    val a = {
-      val b = 4;
-      val c = {
-        val c = b;
+    let a = {
+      let b = 4;
+      let c = {
+        let c = b;
         b
       }; // c = 4
       c
@@ -1711,36 +1711,36 @@ class Main {
 class Main {
   // return a random number, print order
   function intIdentity(order: int): int = {
-    val _ = Process.println(Str.fromInt(order));
+    let _ = Process.println(Str.fromInt(order));
     2
   }
 
   // return a random bool, print order
   function boolIdentity(item: bool, order: int): bool = {
-    val _ = Process.println(Str.fromInt(order));
+    let _ = Process.println(Str.fromInt(order));
     item
   }
 
   // return the string back, print str
   function stringIdentity(str: Str): Str = {
-    val _ = Process.println("surprise!");
+    let _ = Process.println("surprise!");
     str
   }
 
   function binaryExpressionTest(): unit = {
-    val _ = Main.intIdentity(0) + Main.intIdentity(1);
-    val _ = Main.intIdentity(2) - Main.intIdentity(3);
-    val _ = Main.intIdentity(4) * Main.intIdentity(5);
-    val _ = Main.intIdentity(6) / Main.intIdentity(7);
-    val _ = Main.intIdentity(8) % Main.intIdentity(9);
-    val _ = Main.intIdentity(10) < Main.intIdentity(11);
-    val _ = Main.intIdentity(12) <= Main.intIdentity(13);
-    val _ = Main.intIdentity(14) > Main.intIdentity(15);
-    val _ = Main.intIdentity(16) >= Main.intIdentity(17);
-    val _ = Main.intIdentity(18) == Main.intIdentity(19);
-    val _ = Main.intIdentity(20) != Main.intIdentity(21);
-    val _ = Main.boolIdentity(false, 22) || Main.boolIdentity(false, 23);
-    val _ = Main.boolIdentity(true, 24) && Main.boolIdentity(true, 25);
+    let _ = Main.intIdentity(0) + Main.intIdentity(1);
+    let _ = Main.intIdentity(2) - Main.intIdentity(3);
+    let _ = Main.intIdentity(4) * Main.intIdentity(5);
+    let _ = Main.intIdentity(6) / Main.intIdentity(7);
+    let _ = Main.intIdentity(8) % Main.intIdentity(9);
+    let _ = Main.intIdentity(10) < Main.intIdentity(11);
+    let _ = Main.intIdentity(12) <= Main.intIdentity(13);
+    let _ = Main.intIdentity(14) > Main.intIdentity(15);
+    let _ = Main.intIdentity(16) >= Main.intIdentity(17);
+    let _ = Main.intIdentity(18) == Main.intIdentity(19);
+    let _ = Main.intIdentity(20) != Main.intIdentity(21);
+    let _ = Main.boolIdentity(false, 22) || Main.boolIdentity(false, 23);
+    let _ = Main.boolIdentity(true, 24) && Main.boolIdentity(true, 25);
   }
 
   function main(): unit = Main.binaryExpressionTest()
@@ -1753,12 +1753,12 @@ class Main {
         source_code: r#"
 class Main {
   function hi(): int = {
-    val _ = Process.println("hi");
+    let _ = Process.println("hi");
     5
   }
 
   function main(): unit = {
-    val _ = Main.hi();
+    let _ = Main.hi();
   }
 }
 "#,
@@ -1769,14 +1769,14 @@ class Main {
         source_code: r#"
 class GenericObject<T1, T2>(val v1: T1, val v2: T2) {
   function main(): unit = {
-    val f = (v2: int) -> (
+    let f = (v2: int) -> (
       if (v2 + 1 == 3) then
         GenericObject.init(3, v2)
       else
         GenericObject.init(3, 42)
     );
-    val _ = Process.println(Str.fromInt(f(2).v2)); // print 2
-    val _ = Process.println(Str.fromInt(f(3).v2)); // print 42
+    let _ = Process.println(Str.fromInt(f(2).v2)); // print 2
+    let _ = Process.println(Str.fromInt(f(3).v2)); // print 42
   }
 }
 
@@ -1791,14 +1791,14 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val a = if (true) then
+    let a = if (true) then
       (if (false) then 10000 else 3)
     else
       4
     ;
-    val b = if (false) then 4 else if (true) then 3 else 20000;
-    val _ = Process.println(Str.fromInt(a));
-    val _ = Process.println(Str.fromInt(b));
+    let b = if (false) then 4 else if (true) then 3 else 20000;
+    let _ = Process.println(Str.fromInt(a));
+    let _ = Process.println(Str.fromInt(b));
     if (a != b) then Process.panic("Not OK") else Process.println("OK")
   }
 }
@@ -1810,8 +1810,8 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val i = 2;
-    val j = 3;
+    let i = 2;
+    let j = 3;
     if (i > j) then
       Process.println("shouldn't reach here")
     else if (j < i) then
@@ -1830,8 +1830,8 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val i = 3;
-    val j = 2;
+    let i = 3;
+    let j = 2;
     if (i > j) then
       Process.println("success")
     else if (j < i) then
@@ -1855,7 +1855,7 @@ class Option<T>(Some(T), None(bool)) {
 
 class Main {
   function main(): unit = {
-    val c = Option.Some(3).map((x: int) -> "empty");
+    let c = Option.Some(3).map((x: int) -> "empty");
   }
 }
 "#,
@@ -1869,13 +1869,13 @@ class Main {
 
   function loopy(i: int): int =
     if (i >= 10) then 0 else {
-      val j: int = i * 3 + 100;
-      val _: unit = Main.printInt(j);
+      let j: int = i * 3 + 100;
+      let _: unit = Main.printInt(j);
       Main.loopy(i + 2)
     }
 
   function main(): unit = {
-    val _: int = Main.loopy(0);
+    let _: int = Main.loopy(0);
   }
 
 }
@@ -1887,16 +1887,16 @@ class Main {
         source_code: r#"
 class Option<T>(None(unit), Some(T)) {
   method <R> mapButIgnore(f: (T) -> R): unit = {
-    val _ = match (this) {
+    let _ = match (this) {
       None(_) -> Option.None<R>({}),
       Some(d) -> Option.Some(f(d)),
     };
   }
 
   function main(): unit = {
-    val none = Option.None<int>({});
-    val noneMapped = none.mapButIgnore((it) -> it);
-    val _ = Option.Some(noneMapped).mapButIgnore((it) -> it);
+    let none = Option.None<int>({});
+    let noneMapped = none.mapButIgnore((it) -> it);
+    let _ = Option.Some(noneMapped).mapButIgnore((it) -> it);
   }
 }
 
@@ -1919,9 +1919,9 @@ class Main {
   function uselessRecursion(n: int): unit = if (n == 0) then {} else Main.uselessRecursion(n - 1)
 
   function main(): unit = {
-    val _ = Process.println(Str.fromInt(Main.factorial(4)));
-    val _ = Process.println(Str.fromInt(Main.fib(10)));
-    val _ = Main.uselessRecursion(3);
+    let _ = Process.println(Str.fromInt(Main.factorial(4)));
+    let _ = Process.println(Str.fromInt(Main.fib(10)));
+    let _ = Main.uselessRecursion(3);
   }
 }
 "#,
@@ -1945,14 +1945,14 @@ class Main {
         source_code: r#"
 class Main(val a: int, val b: bool) {
   function main(): unit = {
-    val _ = 3;
-    val a = 2;
-    val c = a - 3;
-    val d = c * 7;
-    val b = true;
-    val e = c;
-    val _ = Main.init(e, b);
-    val finalValue = a + c + d + (if (b) then 0 else Process.panic("")) + e; // 2 + (-1) + (-7) + (-1) = -7;
+    let _ = 3;
+    let a = 2;
+    let c = a - 3;
+    let d = c * 7;
+    let b = true;
+    let e = c;
+    let _ = Main.init(e, b);
+    let finalValue = a + c + d + (if (b) then 0 else Process.panic("")) + e; // 2 + (-1) + (-7) + (-1) = -7;
     Process.println(Str.fromInt(finalValue))
   }
 }
@@ -1996,61 +1996,61 @@ true
         source_code: r#"
 class Main {
   function printAndReturn(b: bool, i: int): bool = {
-    val _ = Process.println(Str.fromInt(i));
+    let _ = Process.println(Str.fromInt(i));
     b
   }
 
   function printlnBool(b: bool): unit = if (b) then Process.println("true") else Process.println("false")
 
   function testAndShortCircuitInExpression(): unit = {
-    val b1 = Main.printAndReturn(true, 0) && Main.printAndReturn(false, 1); // [0] [1]
-    val _ = Main.printlnBool(b1); // false
-    val b2 = Main.printAndReturn(true, 0) && Main.printAndReturn(true, 1); // [0] [1]
-    val _ = Main.printlnBool(b2); // true
-    val b3 = Main.printAndReturn(false, 0) && Main.printAndReturn(false, 1); // [0]
-    val _ = Main.printlnBool(b3); // false
-    val b4 = Main.printAndReturn(false, 0) && Main.printAndReturn(true, 1); // [0]
-    val _ = Main.printlnBool(b4); // false
+    let b1 = Main.printAndReturn(true, 0) && Main.printAndReturn(false, 1); // [0] [1]
+    let _ = Main.printlnBool(b1); // false
+    let b2 = Main.printAndReturn(true, 0) && Main.printAndReturn(true, 1); // [0] [1]
+    let _ = Main.printlnBool(b2); // true
+    let b3 = Main.printAndReturn(false, 0) && Main.printAndReturn(false, 1); // [0]
+    let _ = Main.printlnBool(b3); // false
+    let b4 = Main.printAndReturn(false, 0) && Main.printAndReturn(true, 1); // [0]
+    let _ = Main.printlnBool(b4); // false
   }
 
   function testOrShortCircuitInExpression(): unit = {
-    val b1 = Main.printAndReturn(true, 0) || Main.printAndReturn(false, 1); // [0]
-    val _ = Main.printlnBool(b1); // true
-    val b2 = Main.printAndReturn(true, 0) || Main.printAndReturn(true, 1); // [0]
-    val _ = Main.printlnBool(b2); // true
-    val b3 = Main.printAndReturn(false, 0) || Main.printAndReturn(false, 1); // [0] [1]
-    val _ = Main.printlnBool(b3); // false
-    val b4 = Main.printAndReturn(false, 0) || Main.printAndReturn(true, 1); // [0] [1]
-    val _ = Main.printlnBool(b4); // true
+    let b1 = Main.printAndReturn(true, 0) || Main.printAndReturn(false, 1); // [0]
+    let _ = Main.printlnBool(b1); // true
+    let b2 = Main.printAndReturn(true, 0) || Main.printAndReturn(true, 1); // [0]
+    let _ = Main.printlnBool(b2); // true
+    let b3 = Main.printAndReturn(false, 0) || Main.printAndReturn(false, 1); // [0] [1]
+    let _ = Main.printlnBool(b3); // false
+    let b4 = Main.printAndReturn(false, 0) || Main.printAndReturn(true, 1); // [0] [1]
+    let _ = Main.printlnBool(b4); // true
   }
 
   function testAndShortCircuitInIf(): unit = {
     // [0] [1]
-    val _ = if (Main.printAndReturn(true, 0) && Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
+    let _ = if (Main.printAndReturn(true, 0) && Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
     // [0] [1]
-    val _ = if (Main.printAndReturn(true, 0) && Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
+    let _ = if (Main.printAndReturn(true, 0) && Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
     // [0]
-    val _ = if (Main.printAndReturn(false, 0) && Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
+    let _ = if (Main.printAndReturn(false, 0) && Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
     // [0]
-    val _ = if (Main.printAndReturn(false, 0) && Main.printAndReturn(true, 1)) then Process.panic<unit>("Ah") else {};
+    let _ = if (Main.printAndReturn(false, 0) && Main.printAndReturn(true, 1)) then Process.panic<unit>("Ah") else {};
   }
 
   function testOrShortCircuitInIf(): unit = {
     // [0]
-    val _ = if (Main.printAndReturn(true, 0) || Main.printAndReturn(false, 1)) then {} else Process.panic("Ah");
+    let _ = if (Main.printAndReturn(true, 0) || Main.printAndReturn(false, 1)) then {} else Process.panic("Ah");
     // [0]
-    val _ = if (Main.printAndReturn(true, 0) || Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
+    let _ = if (Main.printAndReturn(true, 0) || Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
     // [0] [1]
-    val _ = if (Main.printAndReturn(false, 0) || Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
+    let _ = if (Main.printAndReturn(false, 0) || Main.printAndReturn(false, 1)) then Process.panic<unit>("Ah") else {};
     // [0] [1]
-    val _ = if (Main.printAndReturn(false, 0) || Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
+    let _ = if (Main.printAndReturn(false, 0) || Main.printAndReturn(true, 1)) then {} else Process.panic("Ah");
   }
 
   function main(): unit = {
-    val _ = Main.testAndShortCircuitInExpression();
-    val _ = Main.testOrShortCircuitInExpression();
-    val _ = Main.testAndShortCircuitInIf();
-    val _ = Main.testOrShortCircuitInIf();
+    let _ = Main.testAndShortCircuitInExpression();
+    let _ = Main.testOrShortCircuitInExpression();
+    let _ = Main.testAndShortCircuitInIf();
+    let _ = Main.testOrShortCircuitInIf();
   }
 }
 "#,
@@ -2080,8 +2080,8 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
     match (this) {
       Nil(_) -> {  }
       Cons(pair) -> {
-        val [v, rest] = pair;
-        val _ = f(v);
+        let [v, rest] = pair;
+        let _ = f(v);
         rest.iter(f)
       }
     }
@@ -2092,7 +2092,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
       Cons(pair) -> match (pair.e1) {
         Nil(_) -> this,
         Cons(_) -> {
-          val [l1, l2] = this.split(List.nil<T>(), List.nil<T>());
+          let [l1, l2] = this.split(List.nil<T>(), List.nil<T>());
           l1.sort().merge(l2.sort())
         }
       }
@@ -2104,8 +2104,8 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
       Cons(pair1) -> match (other) {
         Nil(_) -> this,
         Cons(pair2) -> {
-          val [h1, t1] = pair1;
-          val [h2, t2] = pair2;
+          let [h1, t1] = pair1;
+          let [h2, t2] = pair2;
           if (h1.compare(h2) < 0) then t1.merge(other).cons(h1) else t2.merge(this).cons(h2)
         }
       }
@@ -2115,7 +2115,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
     match (this) {
       Nil(_) -> Pair.init(y, z),
       Cons(pair) -> {
-        val [x, rest] = pair;
+        let [x, rest] = pair;
         rest.split(z, y.cons(x))
       }
     }
@@ -2123,7 +2123,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
 
 class Main {
   function main(): unit = {
-    val list = List.of(BoxedInt.init(4)).cons(BoxedInt.init(2)).cons(BoxedInt.init(1)).cons(
+    let list = List.of(BoxedInt.init(4)).cons(BoxedInt.init(2)).cons(BoxedInt.init(1)).cons(
       BoxedInt.init(3)
     );
     list.sort().iter((n) -> Process.println(Str.fromInt(n.i)))
@@ -2137,8 +2137,8 @@ class Main {
         source_code: r#"
 class Main {
   function main(): unit = {
-    val a1 = "a";
-    val a2 = "a";
+    let a1 = "a";
+    let a2 = "a";
     if a1 == a2 then
       Process.println("OK")
     else {
@@ -2155,57 +2155,57 @@ class Main {
 class Main {
   function main(): unit = {
     // without constant propagation, this program will spill a lot!
-    val v0 = 0;
-    val v1 = 0;
-    val v2 = 0;
-    val v3 = 0;
-    val v4 = 0;
-    val v5 = 0;
-    val v6 = 0;
-    val v7 = 0;
-    val v8 = 0;
-    val v9 = 0;
-    val v10 = 0;
-    val v11 = 0;
-    val v12 = 0;
-    val v13 = 0;
-    val v14 = 0;
-    val v15 = 0;
-    val v16 = 0;
-    val v17 = 0;
-    val v18 = 0;
-    val v19 = 0;
-    val v20 = 0;
-    val v21 = 0;
-    val v22 = 0;
-    val v23 = 0;
-    val v24 = 0;
-    val v25 = 0;
-    val v26 = 0;
-    val v27 = 0;
-    val v28 = 0;
-    val v29 = 0;
-    val v30 = 0;
-    val v31 = 0;
-    val v32 = 0;
-    val v33 = 0;
-    val v34 = 0;
-    val v35 = 0;
-    val v36 = 0;
-    val v37 = 0;
-    val v38 = 0;
-    val v39 = 0;
-    val v40 = 0;
-    val v41 = 0;
-    val v42 = 0;
-    val v43 = 0;
-    val v44 = 0;
-    val v45 = 0;
-    val v46 = 0;
-    val v47 = 0;
-    val v48 = 0;
-    val v49 = 0;
-    val result =
+    let v0 = 0;
+    let v1 = 0;
+    let v2 = 0;
+    let v3 = 0;
+    let v4 = 0;
+    let v5 = 0;
+    let v6 = 0;
+    let v7 = 0;
+    let v8 = 0;
+    let v9 = 0;
+    let v10 = 0;
+    let v11 = 0;
+    let v12 = 0;
+    let v13 = 0;
+    let v14 = 0;
+    let v15 = 0;
+    let v16 = 0;
+    let v17 = 0;
+    let v18 = 0;
+    let v19 = 0;
+    let v20 = 0;
+    let v21 = 0;
+    let v22 = 0;
+    let v23 = 0;
+    let v24 = 0;
+    let v25 = 0;
+    let v26 = 0;
+    let v27 = 0;
+    let v28 = 0;
+    let v29 = 0;
+    let v30 = 0;
+    let v31 = 0;
+    let v32 = 0;
+    let v33 = 0;
+    let v34 = 0;
+    let v35 = 0;
+    let v36 = 0;
+    let v37 = 0;
+    let v38 = 0;
+    let v39 = 0;
+    let v40 = 0;
+    let v41 = 0;
+    let v42 = 0;
+    let v43 = 0;
+    let v44 = 0;
+    let v45 = 0;
+    let v46 = 0;
+    let v47 = 0;
+    let v48 = 0;
+    let v49 = 0;
+    let result =
     v0 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 +
     v10 + v11 + v12 + v13 + v14 + v15 + v16 + v17 + v18 + v19 +
     v20 + v21 + v22 + v23 + v24 + v25 + v26 + v27 + v28 + v29 +
@@ -2227,8 +2227,8 @@ class Clazz(val t: Pair<Triple<int, int, bool>, Str>) {
     function of(): Clazz = Clazz.init([[42, 2, false], ""])
 
     method thisTest(): int = {
-      val [[i, _, _], _] = this.t;
-      val {t as {e0 as [j, _, _], e1}} = this;
+      let [[i, _, _], _] = this.t;
+      let {t as {e0 as [j, _, _], e1}} = this;
       i + j
     }
 }
@@ -2246,7 +2246,7 @@ class Option<T>(Some(T), None) {
       Some(t) -> Option.Some(f(t)),
     }
   function test(): unit = {
-    val _ = match (Option.None<(Str) -> int>()) {
+    let _ = match (Option.None<(Str) -> int>()) {
       None -> "",
       Some(f) -> Str.fromInt(f("")),
     };
@@ -2262,20 +2262,20 @@ class List<T>(Nil, Cons(T, List<T>)) {
 
 class Main {
   function literalsAndSimpleExpressions(): unit = {
-    val _ = 42;
-    val _ = -65536;
-    val _ = true;
-    val _ = false;
-    val _ = !true;
-    val _ = !false;
-    val _ = "aaa";
-    val _ = {};
+    let _ = 42;
+    let _ = -65536;
+    let _ = true;
+    let _ = false;
+    let _ = !true;
+    let _ = !false;
+    let _ = "aaa";
+    let _ = {};
   }
 
   function variables(a: int, b: Str): unit = {
-    val c = 3 + a;
-    val d = b == b;
-    val e = c % c;
+    let c = 3 + a;
+    let d = b == b;
+    let e = c % c;
   }
 
   function methodAndFunctionReference(): int =
@@ -2284,33 +2284,33 @@ class Main {
   function panicTest(reason: Str): Clazz = Process.panic(reason)
 
   function functionsTest(): unit = {
-    val _ = Main.literalsAndSimpleExpressions();
-    val _ = Main.variables(3, "hi");
-    val _ = Main.methodAndFunctionReference();
-    val _ = Main.panicTest("Ah!").thisTest();
-    val _ = Main.binaryExpressions();
-    val _ = Main.lambdaTest(3);
+    let _ = Main.literalsAndSimpleExpressions();
+    let _ = Main.variables(3, "hi");
+    let _ = Main.methodAndFunctionReference();
+    let _ = Main.panicTest("Ah!").thisTest();
+    let _ = Main.binaryExpressions();
+    let _ = Main.lambdaTest(3);
     Main.functionsTest()
   }
 
   function binaryExpressions(): unit = {
-    val a: int = 1 * 2 + 3 / 4 % 5 - 6;
-    val b: bool = a < a && 1 > 3 || 2 <= 4 && 5 >= 6;
-    val c: bool = a == 2;
-    val d: bool = Main.panicTest("ha") != Clazz.of();
-    val e: bool = List.of(3) == List.of(a * 3);
+    let a: int = 1 * 2 + 3 / 4 % 5 - 6;
+    let b: bool = a < a && 1 > 3 || 2 <= 4 && 5 >= 6;
+    let c: bool = a == 2;
+    let d: bool = Main.panicTest("ha") != Clazz.of();
+    let e: bool = List.of(3) == List.of(a * 3);
   }
 
   function lambdaTest(a: int): Str = {
-    val b = Option.none<int>().toSome(3).map(Main.lambdaTest);
-    val c = Option.none<int>().toSome(3).map((x) -> "empty");
+    let b = Option.none<int>().toSome(3).map(Main.lambdaTest);
+    let c = Option.none<int>().toSome(3).map((x) -> "empty");
     "hello world"
   }
 
   function main(): unit = {
-    val _ = Main.literalsAndSimpleExpressions();
-    val _ = Main.variables(3, "sss");
-    val v = Main.methodAndFunctionReference(); // 42 + 42 == 84
+    let _ = Main.literalsAndSimpleExpressions();
+    let _ = Main.variables(3, "sss");
+    let v = Main.methodAndFunctionReference(); // 42 + 42 == 84
     Process.println(Str.fromInt(v))
   }
 }

--- a/crates/samlang-core/src/parser.rs
+++ b/crates/samlang-core/src/parser.rs
@@ -110,17 +110,17 @@ mod tests {
     expect_good_expr("() -> 3");
     expect_good_expr("(foo) -> 3");
     expect_good_expr("(foo: bool) -> 3");
-    expect_good_expr("{ val a = 3; }");
-    expect_good_expr("{ val a: () -> int = () -> 3; }");
-    expect_good_expr("{ val a = 3; val b = 3; }");
-    expect_good_expr("{ val a = 3; a }");
-    expect_good_expr("{ val a: int = 3; }");
-    expect_good_expr("{ val a: unit = {}; }");
-    expect_good_expr("{ val [foo, _]: Type = [1, 2]; }");
-    expect_good_expr("{ val {foo, bar as baz}: Type = 3; }");
-    expect_good_expr("{ val _: Int<bool> = 3; }");
-    expect_good_expr("{ val _: HAHAHA = 3; }");
-    expect_good_expr("{ val _: (int, bool) -> Str = 3; }");
+    expect_good_expr("{ let a = 3; }");
+    expect_good_expr("{ let a: () -> int = () -> 3; }");
+    expect_good_expr("{ let a = 3; let b = 3; }");
+    expect_good_expr("{ let a = 3; a }");
+    expect_good_expr("{ let a: int = 3; }");
+    expect_good_expr("{ let a: unit = {}; }");
+    expect_good_expr("{ let [foo, _]: Type = [1, 2]; }");
+    expect_good_expr("{ let {foo, bar as baz}: Type = 3; }");
+    expect_good_expr("{ let _: Int<bool> = 3; }");
+    expect_good_expr("{ let _: HAHAHA = 3; }");
+    expect_good_expr("{ let _: (int, bool) -> Str = 3; }");
     expect_good_expr("{ }");
   }
 
@@ -163,15 +163,15 @@ mod tests {
     expect_bad_expr("(: int) -> 3");
     expect_bad_expr("(:) -> 3");
     expect_bad_expr("(a:) -> 3");
-    expect_bad_expr("{ val a = /* empty */");
-    expect_bad_expr("{ val a = /* empty */ }");
-    expect_bad_expr("{ val  = 3 }");
-    expect_bad_expr("{ val a = int }");
-    expect_bad_expr("{ val a:  = 3; a }");
-    expect_bad_expr("{ val a: <int> = 3; a }");
-    expect_bad_expr("{ val {foo, as baz}: Type = 3; }");
-    expect_bad_expr("{ val {foo, bar as }: Type = 3; }");
-    expect_bad_expr("{ val a: () ->  = 3; a }");
+    expect_bad_expr("{ let a = /* empty */");
+    expect_bad_expr("{ let a = /* empty */ }");
+    expect_bad_expr("{ let  = 3 }");
+    expect_bad_expr("{ let a = int }");
+    expect_bad_expr("{ let a:  = 3; a }");
+    expect_bad_expr("{ let a: <int> = 3; a }");
+    expect_bad_expr("{ let {foo, as baz}: Type = 3; }");
+    expect_bad_expr("{ let {foo, bar as }: Type = 3; }");
+    expect_bad_expr("{ let a: () ->  = 3; a }");
   }
 
   #[test]
@@ -227,11 +227,11 @@ mod tests {
 
     class TypeInference {
       private function <T: Int> notAnnotated(): unit = {
-        val _ = (a, b, c) -> if a(b + 1) then b else c;
+        let _ = (a, b, c) -> if a(b + 1) then b else c;
       }
       // Read the docs to see how we do the type inference.
       function annotated(): unit = {
-        val _: ((int) -> bool, int, int) -> int =
+        let _: ((int) -> bool, int, int) -> int =
           (a: (int) -> bool, b: int, c: int) -> (
             if a(b + 1) then b else c
           );
@@ -243,8 +243,8 @@ mod tests {
       private val projects: List<Str>
     ) {
       function sam(): Developer = {
-        val l = List.of("SAMLANG").cons("...");
-        val github = "SamChou19815";
+        let l = List.of("SAMLANG").cons("...");
+        let github = "SamChou19815";
         Developer.init("Sam Zhou", github, l)
       }
     }
@@ -306,7 +306,7 @@ mod tests {
 
     class TypeInference(val : Str, val foo: ) {
       function notAnnotated(bad: ):  = {
-        val _ = (a, b, c) -> if a(b + 1) then b else c;
+        let _ = (a, b, c) -> if a(b + 1) then b else c;
       }
     }
 "#;
@@ -337,7 +337,7 @@ mod tests {
 
     class TypeInference(vafl : Str, val foo: ) {
       function notAnnotated(bad: , : int):  = {
-        val _ = (a, b, c) -> if a(b + 1) then b else c;
+        let _ = (a, b, c) -> if a(b + 1) then b else c;
       }
     }
 

--- a/crates/samlang-core/src/parser/lexer_test.rs
+++ b/crates/samlang-core/src/parser/lexer_test.rs
@@ -30,7 +30,7 @@ mod tests {
   #[test]
   fn good_test_0() {
     let expected = vec![
-      ".sam:1:1-1:4: val",
+      ".sam:1:1-1:4: let",
       ".sam:1:5-1:6: l",
       ".sam:1:7-1:8: =",
       ".sam:1:9-1:13: List",
@@ -45,7 +45,7 @@ mod tests {
       ".sam:1:33-1:38: \"...\"",
       ".sam:1:38-1:39: )",
     ];
-    assert_eq!(expected, lex(r#"val l = List.of("SAMLANG").cons("...")"#));
+    assert_eq!(expected, lex(r#"let l = List.of("SAMLANG").cons("...")"#));
   }
 
   #[test]
@@ -53,15 +53,15 @@ mod tests {
     let program = r#"
 class Main {
   function main(): unit = {
-    val i: int = 1;
-    val j: int = 2;
+    let i: int = 1;
+    let j: int = 2;
     if ((i < j && i > 0) && j > 0) then {
-      val a: int = 3;
-      val b: int = 4;
+      let a: int = 3;
+      let b: int = 4;
       if (a > b || a + b > 0 && true) then Process.println("one") else Process.println("two")
     } else {
-      val a: int = 3;
-      val b: int = 4;
+      let a: int = 3;
+      let b: int = 4;
       if (a == 2 || b == 4) then { Process.println("three") } else { Process.println("four") }
     }
   }
@@ -80,14 +80,14 @@ class Main {
       ".sam:3:20-3:24: unit",
       ".sam:3:25-3:26: =",
       ".sam:3:27-3:28: {",
-      ".sam:4:5-4:8: val",
+      ".sam:4:5-4:8: let",
       ".sam:4:9-4:10: i",
       ".sam:4:10-4:11: :",
       ".sam:4:12-4:15: int",
       ".sam:4:16-4:17: =",
       ".sam:4:18-4:19: 1",
       ".sam:4:19-4:20: ;",
-      ".sam:5:5-5:8: val",
+      ".sam:5:5-5:8: let",
       ".sam:5:9-5:10: j",
       ".sam:5:10-5:11: :",
       ".sam:5:12-5:15: int",
@@ -112,14 +112,14 @@ class Main {
       ".sam:6:34-6:35: )",
       ".sam:6:36-6:40: then",
       ".sam:6:41-6:42: {",
-      ".sam:7:7-7:10: val",
+      ".sam:7:7-7:10: let",
       ".sam:7:11-7:12: a",
       ".sam:7:12-7:13: :",
       ".sam:7:14-7:17: int",
       ".sam:7:18-7:19: =",
       ".sam:7:20-7:21: 3",
       ".sam:7:21-7:22: ;",
-      ".sam:8:7-8:10: val",
+      ".sam:8:7-8:10: let",
       ".sam:8:11-8:12: b",
       ".sam:8:12-8:13: :",
       ".sam:8:14-8:17: int",
@@ -157,14 +157,14 @@ class Main {
       ".sam:10:5-10:6: }",
       ".sam:10:7-10:11: else",
       ".sam:10:12-10:13: {",
-      ".sam:11:7-11:10: val",
+      ".sam:11:7-11:10: let",
       ".sam:11:11-11:12: a",
       ".sam:11:12-11:13: :",
       ".sam:11:14-11:17: int",
       ".sam:11:18-11:19: =",
       ".sam:11:20-11:21: 3",
       ".sam:11:21-11:22: ;",
-      ".sam:12:7-12:10: val",
+      ".sam:12:7-12:10: let",
       ".sam:12:11-12:12: b",
       ".sam:12:12-12:13: :",
       ".sam:12:14-12:17: int",
@@ -218,11 +218,11 @@ class Option<T>(None(unit), Some(T)) {
 
 class Obj(val d: int, val e: int) {
   function valExample(): int = {
-    val a: int = 1;
-    val b: int = 2;
-    val [_, c]: [Str * int] = ["dd", 3];
-    val { e as d }: Obj = { d: 5, e: 4 };
-    val _: int = 42;
+    let a: int = 1;
+    let b: int = 2;
+    let [_, c]: [Str * int] = ["dd", 3];
+    let { e as d }: Obj = { d: 5, e: 4 };
+    let _: int = 42;
     a + (b * c) / d
   }
 
@@ -232,7 +232,7 @@ class Main {
   function identity(a: int): int = a
 
   function random(): int = {
-    val a: int = 42;
+    let a: int = 42;
     a
   }
 
@@ -242,15 +242,15 @@ class Main {
     if (b == 0) then Process.panic("Division by zero is illegal!") else a / b
 
   function nestedVal(): int = {
-    val a: int = {
-      val b: int = 4;
-      val c: int = {
-        val c: int = b;
+    let a: int = {
+      let b: int = 4;
+      let c: int = {
+        let c: int = b;
         b
       };
       c
     };
-    val [e, b, _]: [int * Str * bool] = [1, "bool", true];
+    let [e, b, _]: [int * Str * bool] = [1, "bool", true];
     a + 1
   }
 
@@ -353,21 +353,21 @@ class Main {
       ".sam:10:26-10:29: int",
       ".sam:10:30-10:31: =",
       ".sam:10:32-10:33: {",
-      ".sam:11:5-11:8: val",
+      ".sam:11:5-11:8: let",
       ".sam:11:9-11:10: a",
       ".sam:11:10-11:11: :",
       ".sam:11:12-11:15: int",
       ".sam:11:16-11:17: =",
       ".sam:11:18-11:19: 1",
       ".sam:11:19-11:20: ;",
-      ".sam:12:5-12:8: val",
+      ".sam:12:5-12:8: let",
       ".sam:12:9-12:10: b",
       ".sam:12:10-12:11: :",
       ".sam:12:12-12:15: int",
       ".sam:12:16-12:17: =",
       ".sam:12:18-12:19: 2",
       ".sam:12:19-12:20: ;",
-      ".sam:13:5-13:8: val",
+      ".sam:13:5-13:8: let",
       ".sam:13:9-13:10: [",
       ".sam:13:10-13:11: _",
       ".sam:13:11-13:12: ,",
@@ -386,7 +386,7 @@ class Main {
       ".sam:13:38-13:39: 3",
       ".sam:13:39-13:40: ]",
       ".sam:13:40-13:41: ;",
-      ".sam:14:5-14:8: val",
+      ".sam:14:5-14:8: let",
       ".sam:14:9-14:10: {",
       ".sam:14:11-14:12: e",
       ".sam:14:13-14:15: as",
@@ -405,7 +405,7 @@ class Main {
       ".sam:14:38-14:39: 4",
       ".sam:14:40-14:41: }",
       ".sam:14:41-14:42: ;",
-      ".sam:15:5-15:8: val",
+      ".sam:15:5-15:8: let",
       ".sam:15:9-15:10: _",
       ".sam:15:10-15:11: :",
       ".sam:15:12-15:15: int",
@@ -445,7 +445,7 @@ class Main {
       ".sam:24:22-24:25: int",
       ".sam:24:26-24:27: =",
       ".sam:24:28-24:29: {",
-      ".sam:25:5-25:8: val",
+      ".sam:25:5-25:8: let",
       ".sam:25:9-25:10: a",
       ".sam:25:10-25:11: :",
       ".sam:25:12-25:15: int",
@@ -501,26 +501,26 @@ class Main {
       ".sam:34:25-34:28: int",
       ".sam:34:29-34:30: =",
       ".sam:34:31-34:32: {",
-      ".sam:35:5-35:8: val",
+      ".sam:35:5-35:8: let",
       ".sam:35:9-35:10: a",
       ".sam:35:10-35:11: :",
       ".sam:35:12-35:15: int",
       ".sam:35:16-35:17: =",
       ".sam:35:18-35:19: {",
-      ".sam:36:7-36:10: val",
+      ".sam:36:7-36:10: let",
       ".sam:36:11-36:12: b",
       ".sam:36:12-36:13: :",
       ".sam:36:14-36:17: int",
       ".sam:36:18-36:19: =",
       ".sam:36:20-36:21: 4",
       ".sam:36:21-36:22: ;",
-      ".sam:37:7-37:10: val",
+      ".sam:37:7-37:10: let",
       ".sam:37:11-37:12: c",
       ".sam:37:12-37:13: :",
       ".sam:37:14-37:17: int",
       ".sam:37:18-37:19: =",
       ".sam:37:20-37:21: {",
-      ".sam:38:9-38:12: val",
+      ".sam:38:9-38:12: let",
       ".sam:38:13-38:14: c",
       ".sam:38:14-38:15: :",
       ".sam:38:16-38:19: int",
@@ -533,7 +533,7 @@ class Main {
       ".sam:41:7-41:8: c",
       ".sam:42:5-42:6: }",
       ".sam:42:6-42:7: ;",
-      ".sam:43:5-43:8: val",
+      ".sam:43:5-43:8: let",
       ".sam:43:9-43:10: [",
       ".sam:43:10-43:11: e",
       ".sam:43:11-43:12: ,",
@@ -641,8 +641,8 @@ class Main {
     let program = r#"
 class Main {
   function main(): unit = {
-    val i: int = 1;
-    val j: int = 2;
+    let i: int = 1;
+    let j: int = 2;
     /* block comment lol
     ol ol
     0000l */
@@ -665,14 +665,14 @@ class Main {
       ".sam:3:20-3:24: unit",
       ".sam:3:25-3:26: =",
       ".sam:3:27-3:28: {",
-      ".sam:4:5-4:8: val",
+      ".sam:4:5-4:8: let",
       ".sam:4:9-4:10: i",
       ".sam:4:10-4:11: :",
       ".sam:4:12-4:15: int",
       ".sam:4:16-4:17: =",
       ".sam:4:18-4:19: 1",
       ".sam:4:19-4:20: ;",
-      ".sam:5:5-5:8: val",
+      ".sam:5:5-5:8: let",
       ".sam:5:9-5:10: j",
       ".sam:5:10-5:11: :",
       ".sam:5:12-5:15: int",

--- a/crates/samlang-core/src/parser/source_parser.rs
+++ b/crates/samlang-core/src/parser/source_parser.rs
@@ -1257,7 +1257,7 @@ impl<'a> SourceParser<'a> {
       self.consume();
 
       let mut statements = vec![];
-      while let Token(_, TokenContent::Keyword(Keyword::VAL)) = self.peek() {
+      while let Token(_, TokenContent::Keyword(Keyword::LET)) = self.peek() {
         statements.push(self.parse_statement());
       }
 
@@ -1308,7 +1308,7 @@ impl<'a> SourceParser<'a> {
   pub(super) fn parse_statement(&mut self) -> expr::DeclarationStatement<()> {
     let concrete_comments = self.collect_preceding_comments();
     let associated_comments = self.comments_store.create_comment_reference(concrete_comments);
-    let start_loc = self.assert_and_consume_keyword(Keyword::VAL);
+    let start_loc = self.assert_and_consume_keyword(Keyword::LET);
     let pattern = self.parse_destructuring_pattern();
     let annotation = if let Token(_, TokenContent::Operator(TokenOp::COLON)) = self.peek() {
       self.consume();

--- a/crates/samlang-core/src/parser/source_parser.rs
+++ b/crates/samlang-core/src/parser/source_parser.rs
@@ -1334,7 +1334,7 @@ impl<'a> SourceParser<'a> {
       self.consume();
       let destructured_names =
         self.parse_comma_separated_list(Some(TokenOp::RBRACKET), &mut |s: &mut Self| {
-          pattern::TuplePatternDestructuredName {
+          pattern::TuplePatternElement {
             pattern: Box::new(s.parse_destructuring_pattern()),
             type_: (),
           }
@@ -1359,7 +1359,7 @@ impl<'a> SourceParser<'a> {
             } else {
               (Box::new(pattern::DestructuringPattern::Id(field_name)), field_name.loc, true)
             };
-          pattern::ObjectPatternDestucturedName {
+          pattern::ObjectPatternElement {
             loc,
             field_name,
             field_order: 0,

--- a/crates/samlang-core/src/printer/source_printer.rs
+++ b/crates/samlang-core/src/printer/source_printer.rs
@@ -694,7 +694,7 @@ pub(super) fn statement_to_document(
     )
     .unwrap_or(Document::Nil),
   );
-  segments.push(Document::Text(rcs("val ")));
+  segments.push(Document::Text(rcs("let ")));
   segments.push(pattern_doc);
   segments.push(if let Some(annot) = &stmt.annotation {
     Document::Concat(
@@ -1207,39 +1207,39 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
       r#"
       if (b) then {
         // fff
-        val _ = println("");
-        val _ = println("");
-        val _ = println("");
+        let _ = println("");
+        let _ = println("");
+        let _ = println("");
         /* f */
-        val _ = println("");
+        let _ = println("");
       } else if (b) then {
-        val _ = println("");
-        val _ = println("");
-        val _ = println("");
-        val _ = println("");
+        let _ = println("");
+        let _ = println("");
+        let _ = println("");
+        let _ = println("");
       } else {
-        val _ = println("");
-        val _ = println("");
-        val _ = println("");
-        val _ = println("");
+        let _ = println("");
+        let _ = println("");
+        let _ = println("");
+        let _ = println("");
       }"#,
       r#"if b then {
   // fff
-  val _ = println("");
-  val _ = println("");
-  val _ = println("");
+  let _ = println("");
+  let _ = println("");
+  let _ = println("");
   /* f */
-  val _ = println("");
+  let _ = println("");
 } else if b then {
-  val _ = println("");
-  val _ = println("");
-  val _ = println("");
-  val _ = println("");
+  let _ = println("");
+  let _ = println("");
+  let _ = println("");
+  let _ = println("");
 } else {
-  val _ = println("");
-  val _ = println("");
-  val _ = println("");
-  val _ = println("");
+  let _ = println("");
+  let _ = println("");
+  let _ = println("");
+  let _ = println("");
 }"#,
     );
 
@@ -1261,36 +1261,36 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
     assert_reprint_expr("{}", "{  }");
     assert_reprint_expr("{3}", "{ 3 }");
     assert_reprint_expr(
-      "{ val _:int=0;val _=0; }",
+      "{ let _:int=0;let _=0; }",
       r#"{
-  val _: int = 0;
-  val _ = 0;
+  let _: int = 0;
+  let _ = 0;
 }"#,
     );
     assert_reprint_expr(
-      "{ val a:int=1; 3 }",
+      "{ let a:int=1; 3 }",
       r#"{
-  val a: int = 1;
+  let a: int = 1;
   3
 }"#,
     );
     assert_reprint_expr(
-      "{ val {a, b as c}: int = 3; }",
+      "{ let {a, b as c}: int = 3; }",
       r#"{
-  val { a, b as c }: int = 3;
+  let { a, b as c }: int = 3;
 }"#,
     );
 
     assert_reprint_expr(
-      "{ val [a, _]: int = [1, 4]; }",
+      "{ let [a, _]: int = [1, 4]; }",
       r#"{
-  val [a, _]: int = [1, 4];
+  let [a, _]: int = [1, 4];
 }"#,
     );
     assert_reprint_expr(
-      "{ val [aaaaa,aaaaa,aaaaa,aaaaa,_,aaaaa,aaaaa,aaaaa,aaaaa,_,aaaaa]: int = 3; }",
+      "{ let [aaaaa,aaaaa,aaaaa,aaaaa,_,aaaaa,aaaaa,aaaaa,aaaaa,_,aaaaa]: int = 3; }",
       r#"{
-  val [
+  let [
     aaaaa,
     aaaaa,
     aaaaa,
@@ -1307,23 +1307,23 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
     );
 
     assert_reprint_expr(
-      "{ val a: unit = { val b: unit = { val c: unit = { val d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong; }; }; }; }",
+      "{ let a: unit = { let b: unit = { let c: unit = { let d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong; }; }; }; }",
       r#"{
-  val a: unit = {
-    val b: unit = {
-      val c: unit = {
-        val d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong;
+  let a: unit = {
+    let b: unit = {
+      let c: unit = {
+        let d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong;
       };
     };
   };
 }"#);
     assert_reprint_expr(
-      "() -> () -> () -> { val a: unit = { val b: unit = { val c: unit = { val d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong; }; }; }; }",
+      "() -> () -> () -> { let a: unit = { let b: unit = { let c: unit = { let d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong; }; }; }; }",
       r#"() -> () -> () -> {
-  val a: unit = {
-    val b: unit = {
-      val c: unit = {
-        val d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong;
+  let a: unit = {
+    let b: unit = {
+      let c: unit = {
+        let d: unit = aVariableNameThatIsVeryVeryVeryVeryVeryLong;
       };
     };
   };
@@ -1383,14 +1383,14 @@ class Option<T>(None, Some(T)): F1,F2,F3,F4,F5,F6,/** fff */ F7, F8, F9,F10 {
   function b(): (int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int,int)->int = {}
 
   /** foo bar c */
-  function c(): Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<int>>>>>>>>>> = { val a: int = 3; }
+  function c(): Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<Foo<int>>>>>>>>>> = { let a: int = 3; }
 }
 
 class Obj(private val d: int, val e: int) {
   /** foo bar */
   function valExample(): unit = {
-    val a: int = 1;
-    val b: int = 2;
+    let a: int = 1;
+    let b: int = 2;
   }
 }
 
@@ -1472,7 +1472,7 @@ class Option<T>(None, Some(T)) :
       >
     >
   > = {
-    val a: int = 3;
+    let a: int = 3;
   }
 }
 
@@ -1482,8 +1482,8 @@ class Obj(
 ) {
   /** foo bar */
   function valExample(): unit = {
-    val a: int = 1;
-    val b: int = 2;
+    let a: int = 1;
+    let b: int = 2;
   }
 }
 

--- a/crates/samlang-core/src/services/api_tests.rs
+++ b/crates/samlang-core/src/services/api_tests.rs
@@ -238,7 +238,7 @@ class Test2(val a: int) {
         test_mod_ref,
         r#"class Test1(val a: int) {
   function test(): int = {
-    val {c, b} = 1 + 2;
+    let {c, b} = 1 + 2;
 
     a + b + c
   }
@@ -254,7 +254,7 @@ Error ---------------------------------- Test1.sam:3:10-3:11
 
 Cannot find member `c` on `int`.
 
-  3|     val {c, b} = 1 + 2;
+  3|     let {c, b} = 1 + 2;
               ^
 
 
@@ -262,7 +262,7 @@ Error ---------------------------------- Test1.sam:3:13-3:14
 
 Cannot find member `b` on `int`.
 
-  3|     val {c, b} = 1 + 2;
+  3|     let {c, b} = 1 + 2;
                  ^
 
 
@@ -298,7 +298,7 @@ Name `a` is not resolved.
       heap,
       false,
       HashMap::from([
-        (test3_mod_ref, "class ABC { function a(): unit = { val _ = 1; } }".to_string()),
+        (test3_mod_ref, "class ABC { function a(): unit = { let _ = 1; } }".to_string()),
         (test2_mod_ref, "class TTT { method test(): int = this.test() }".to_string()),
         (
           test1_mod_ref,
@@ -310,10 +310,10 @@ class Test1(val a: int) {
   function test2(): unit = ABC.a()
   function test3(): int = Test1.init(3).a
   function test4(): unit = {
-    val _ = {
-      val b = 3;
-      val _ = b + 2;
-      val _ = c;
+    let _ = {
+      let b = 3;
+      let _ = b + 2;
+      let _ = c;
     };
   }
 }
@@ -329,7 +329,7 @@ Error -------------------------------- Test1.sam:12:15-12:16
 
 Name `c` is not resolved.
 
-  12|       val _ = c;
+  12|       let _ = c;
                     ^
 "#
       .trim(),
@@ -487,8 +487,8 @@ class Developer(
   val projects: List<Str>
 ) {
   function sam(): Developer = {
-    val l = List.of("SAMLANG").cons("...")
-    val github = "SamChou19815"
+    let l = List.of("SAMLANG").cons("...")
+    let github = "SamChou19815"
     Developer.init("Sam Zhou", github, l)
   }
 }
@@ -684,7 +684,7 @@ class Test1 {
         mod_ref,
         r#"
 class Test {
-  function main(): unit = { val a = b; }
+  function main(): unit = { let a = b; }
 }
 "#
         .to_string(),
@@ -695,7 +695,7 @@ class Test {
     assert_eq!(
       r#"class Test {
   function main(): unit = {
-    val a = b;
+    let a = b;
   }
 }
 "#,
@@ -704,7 +704,7 @@ class Test {
     assert_eq!(
       r#"class Test {
   function main(): unit = {
-    val c = b;
+    let c = b;
   }
 }
 "#,
@@ -823,8 +823,8 @@ class Developer(
   val projects: List<Str>
 ) {
   function sam(): Developer = {
-    val l = List.of("SAMLANG").cons("...");
-    val github = "SamChou19815";
+    let l = List.of("SAMLANG").cons("...");
+    let github = "SamChou19815";
     Developer.init("Sam Zhou", github, l).
   }
 }
@@ -909,8 +909,8 @@ class Developer(
   val projects: List<Str>
 ) {
   function sam(): Developer = {
-    val l = List.of("SAMLANG").cons("...")
-    val github = "SamChou19815"
+    let l = List.of("SAMLANG").cons("...")
+    let github = "SamChou19815"
     Developer.init("Sam Zhou", github, l).
   }
 }
@@ -1037,9 +1037,9 @@ class Main {
         r#"
 class Main {
   function main(): unit = {
-    val foo = "";
-    val bar = 3;
-    val baz = true;
+    let foo = "";
+    let bar = 3;
+    let baz = true;
     a
   }
 }

--- a/crates/samlang-core/src/services/ast_differ.rs
+++ b/crates/samlang-core/src/services/ast_differ.rs
@@ -504,7 +504,7 @@ mod tests {
       )),
     };
     assert_eq!(
-      "val v: bool = s;",
+      "let v: bool = s;",
       Change::Replace(DiffNode::Statement(&stmt), DiffNode::Statement(&stmt))
         .to_edit(heap, &CommentStore::new())
         .1

--- a/crates/samlang-core/src/services/gc.rs
+++ b/crates/samlang-core/src/services/gc.rs
@@ -286,15 +286,15 @@ mod tests {
 
       class Obj(val d: int, val e: int) {
         function valExample(): int = {
-          val a: int = 1;
-          val b = 2;
-          val c = 3; // c = 3
-          val { d } = Obj.init(5, 4);
-          val [_, d1] = [1, 2];
-          val { e as d2 } = Obj.init(5, 4); // d = 4
-          val f = Obj.init(5, 4); // d = 4
-          val g = Obj.init(d, 4); // d = 4
-          val _ = f.d;
+          let a: int = 1;
+          let b = 2;
+          let c = 3; // c = 3
+          let { d } = Obj.init(5, 4);
+          let [_, d1] = [1, 2];
+          let { e as d2 } = Obj.init(5, 4); // d = 4
+          let f = Obj.init(5, 4); // d = 4
+          let g = Obj.init(d, 4); // d = 4
+          let _ = f.d;
           // 1 + 2 * 3 / 4 = 1 + 6/4 = 1 + 1 = 2
           a + b * c / d
         }
@@ -308,7 +308,7 @@ mod tests {
         function identity(a: int): int = a
 
         function random(): int = {
-          val a = 42; // very random
+          let a = 42; // very random
           a
         }
 
@@ -322,10 +322,10 @@ mod tests {
           )
 
         function nestedVal(): int = {
-          val a = {
-            val b = 4;
-            val c = {
-              val c = b;
+          let a = {
+            let b = 4;
+            let c = {
+              let c = b;
               b
             };
             c

--- a/crates/samlang-core/src/services/global_searcher.rs
+++ b/crates/samlang-core/src/services/global_searcher.rs
@@ -248,9 +248,9 @@ mod tests {
       function bar(): int = 3
 
       method foo(): unit = {
-        val _ = (f: Foo, b: Option<Foo>, a: (Foo)->Foo) -> this.a;
-        val {a, b} = this;
-        val [c, d] = [1, 2];
+        let _ = (f: Foo, b: Option<Foo>, a: (Foo)->Foo) -> this.a;
+        let {a, b} = this;
+        let [c, d] = [1, 2];
       }
     }
 
@@ -270,13 +270,13 @@ mod tests {
 
     class Obj(val d: int, val e: int) {
       function valExample(): int = {
-        val a: int = 1;
-        val b = 2;
-        val c = 3; // c = 3
-        val { e as d } = Obj.init(5, 4); // d = 4
-        val f = Obj.init(5, 4); // d = 4
-        val g = Obj.init(d, 4); // d = 4
-        val _ = f.d;
+        let a: int = 1;
+        let b = 2;
+        let c = 3; // c = 3
+        let { e as d } = Obj.init(5, 4); // d = 4
+        let f = Obj.init(5, 4); // d = 4
+        let g = Obj.init(d, 4); // d = 4
+        let _ = f.d;
         // 1 + 2 * 3 / 4 = 1 + 6/4 = 1 + 1 = 2
         a + b * c / d
       }
@@ -288,7 +288,7 @@ mod tests {
       function identity(a: int): int = a
 
       function random(): int = {
-        val a = 42; // very random
+        let a = 42; // very random
         a
       }
 
@@ -302,10 +302,10 @@ mod tests {
         )
 
       function nestedVal(): int = {
-        val a = {
-          val b = 4;
-          val c = {
-            val c = b;
+        let a = {
+          let b = 4;
+          let c = {
+            let c = b;
             b
           };
           c
@@ -314,7 +314,7 @@ mod tests {
       }
 
       function main(): unit = {
-        val _ = Process.println(Str.fromInt(Main.identity(
+        let _ = Process.println(Str.fromInt(Main.identity(
           Foo.bar() * Main.oof() * Obj.valExample() / Main.div(4, 2) + Main.nestedVal() - 5
         )));
         Main.main()

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -276,14 +276,14 @@ mod tests {
 
     class Obj(val d: int, val e: int) {
       function valExample(): int = {
-        val a: int = 1;
-        val b = 2;
-        val c = 3; // c = 3
-        val { e as d } = Obj.init(5, 4); // d = 4
-        val f = Obj.init(5, 4); // d = 4
-        val g = Obj.init(d, 4); // d = 4
-        val _ = f.d;
-        val [h, i] = [111, 122];
+        let a: int = 1;
+        let b = 2;
+        let c = 3; // c = 3
+        let { e as d } = Obj.init(5, 4); // d = 4
+        let f = Obj.init(5, 4); // d = 4
+        let g = Obj.init(d, 4); // d = 4
+        let _ = f.d;
+        let [h, i] = [111, 122];
         // 1 + 2 * 3 / 4 = 1 + 6/4 = 1 + 1 = 2
         a + b * c / d
       }
@@ -295,7 +295,7 @@ mod tests {
       function identity(a: int): int = a
 
       function random(): int = {
-        val a = 42; // very random
+        let a = 42; // very random
         a
       }
 
@@ -309,10 +309,10 @@ mod tests {
         )
 
       function nestedVal(): int = {
-        val a = {
-          val b = 4;
-          val c = {
-            val c = b;
+        let a = {
+          let b = 4;
+          let c = {
+            let c = b;
             b
           };
           c

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -89,15 +89,13 @@ fn apply_destructuring_pattern_renaming(
       *l,
       names
         .iter()
-        .map(|pattern::TuplePatternDestructuredName { pattern, type_ }| {
-          pattern::TuplePatternDestructuredName {
-            pattern: Box::new(apply_destructuring_pattern_renaming(
-              pattern,
-              definition_and_uses,
-              new_name,
-            )),
-            type_: *type_,
-          }
+        .map(|pattern::TuplePatternElement { pattern, type_ }| pattern::TuplePatternElement {
+          pattern: Box::new(apply_destructuring_pattern_renaming(
+            pattern,
+            definition_and_uses,
+            new_name,
+          )),
+          type_: *type_,
         })
         .collect(),
     ),
@@ -106,7 +104,7 @@ fn apply_destructuring_pattern_renaming(
       names
         .iter()
         .map(
-          |pattern::ObjectPatternDestucturedName {
+          |pattern::ObjectPatternElement {
              loc,
              field_order,
              field_name,
@@ -123,7 +121,7 @@ fn apply_destructuring_pattern_renaming(
               pattern.as_ref(),
               pattern::DestructuringPattern::Id(id) if id.name.eq(&field_name.name),
             );
-            pattern::ObjectPatternDestucturedName {
+            pattern::ObjectPatternElement {
               loc: *loc,
               field_order: *field_order,
               field_name: *field_name,

--- a/crates/samlang-core/src/services/variable_definition.rs
+++ b/crates/samlang-core/src/services/variable_definition.rs
@@ -442,12 +442,12 @@ interface Foo {}
     let source = r#"
 class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val {f, g as h} = Main.init(3, g);
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y * 3 > h then panic(f) else println(h);
+    let c = a;
+    let g = 3;
+    let {f, g as h} = Main.init(3, g);
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y * 3 > h then panic(f) else println(h);
     match lambda1(3, !h) {
       None(_) -> 1.d,
       Some(dd) -> dd,
@@ -498,7 +498,7 @@ class Main {
     let source = r#"
 class Main {
   function test(a: int, b: bool): unit = {
-    val c = a.foo;
+    let c = a.foo;
   }
 }
 
@@ -514,7 +514,7 @@ interface Foo {}
     assert_eq!(
       r#"class Main {
   function test(renAmeD: int, b: bool): unit = {
-    val c = renAmeD.foo;
+    let c = renAmeD.foo;
   }
 }
 
@@ -544,13 +544,13 @@ interface Foo
     let source = r#"
 class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val {f, g as h} = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then panic(f) else println(h);
+    let c = a;
+    let g = 3;
+    let {f, g as h} = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then panic(f) else println(h);
     match lambda1(3, !h) {
       None(_) -> 1.d,
       Some(dd) -> dd,
@@ -580,13 +580,13 @@ class Main {
       Location::from_pos(3, 8, 3, 9),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val renAmeD = a;
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
+    let renAmeD = a;
+    let g = 3;
+    let { f, g as h } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
       panic(f)
     } else {
       println(h)
@@ -605,13 +605,13 @@ class Main {
       Location::from_pos(3, 12, 3, 13),
       r#"class Main {
   function test(renAmeD: int, b: bool): unit = {
-    val c = renAmeD;
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
+    let c = renAmeD;
+    let g = 3;
+    let { f, g as h } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
       panic(f)
     } else {
       println(h)
@@ -630,13 +630,13 @@ class Main {
       Location::from_pos(5, 35, 5, 36),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val renAmeD = 3;
-    val { f, g as h } = Main.init(3, renAmeD);
-    val [i, j] = [3, renAmeD];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
+    let c = a;
+    let renAmeD = 3;
+    let { f, g as h } = Main.init(3, renAmeD);
+    let [i, j] = [3, renAmeD];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
       panic(f)
     } else {
       println(h)
@@ -655,13 +655,13 @@ class Main {
       Location::from_pos(8, 12, 8, 13),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val { f as renAmeD, g as h } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = renAmeD + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
+    let c = a;
+    let g = 3;
+    let { f as renAmeD, g as h } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = renAmeD + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
       panic(renAmeD)
     } else {
       println(h)
@@ -680,13 +680,13 @@ class Main {
       Location::from_pos(8, 16, 8, 17),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val { f, g as renAmeD } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(renAmeD);
-    val _ = f + renAmeD;
-    val lambda1 = (
+    let c = a;
+    let g = 3;
+    let { f, g as renAmeD } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(renAmeD);
+    let _ = f + renAmeD;
+    let lambda1 = (
       x,
       y
     ) -> if x + y + i + j * 3 > renAmeD then {
@@ -708,13 +708,13 @@ class Main {
       Location::from_pos(9, 22, 9, 23),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (
+    let c = a;
+    let g = 3;
+    let { f, g as h } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (
       x,
       renAmeD
     ) -> if x + renAmeD + i + j * 3 > h then {
@@ -736,13 +736,13 @@ class Main {
       Location::from_pos(9, 39, 9, 40),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val [renAmeD, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (
+    let c = a;
+    let g = 3;
+    let { f, g as h } = Main.init(3, g);
+    let [renAmeD, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (
       x,
       y
     ) -> if x + y + renAmeD + j * 3 > h then {
@@ -764,13 +764,13 @@ class Main {
       Location::from_pos(12, 18, 12, 20),
       r#"class Main {
   function test(a: int, b: bool): unit = {
-    val c = a;
-    val g = 3;
-    val { f, g as h } = Main.init(3, g);
-    val [i, j] = [3, g];
-    val _ = Obj.Tagged(h);
-    val _ = f + h;
-    val lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
+    let c = a;
+    let g = 3;
+    let { f, g as h } = Main.init(3, g);
+    let [i, j] = [3, g];
+    let _ = Obj.Tagged(h);
+    let _ = f + h;
+    let lambda1 = (x, y) -> if x + y + i + j * 3 > h then {
       panic(f)
     } else {
       println(h)

--- a/std/list.sam
+++ b/std/list.sam
@@ -20,7 +20,7 @@ class List<T>(Nil, Cons(T, List<T>)) {
     match this {
       Nil -> this,
       Cons(v, rest) -> {
-        val filteredRest = rest.filter(f);
+        let filteredRest = rest.filter(f);
         if f(v) then List.Cons(v, filteredRest) else filteredRest
       }
     }
@@ -35,7 +35,7 @@ class List<T>(Nil, Cons(T, List<T>)) {
     match this {
       Nil -> List.Nil(),
       Cons(v, rest) -> {
-        val mappedRest = rest.filterMap(f);
+        let mappedRest = rest.filterMap(f);
         match f(v) {
           None -> mappedRest,
           Some(mapped) -> List.Cons(mapped, mappedRest),
@@ -47,7 +47,7 @@ class List<T>(Nil, Cons(T, List<T>)) {
     match this {
       Nil -> {  }
       Cons(v, rest) -> {
-        val _ = f(v);
+        let _ = f(v);
         rest.iter(f)
       }
     }

--- a/std/map.sam
+++ b/std/map.sam
@@ -105,9 +105,9 @@ class Map<K: Comparable<K>, V>(Empty, Leaf(K, V), Node(int, K, V, Map<K, V>, Map
     value: V,
     right: Map<K, V>
   ): Map<K, V> = {
-    val lh = left.height();
-    val rh = right.height();
-    val h = if lh >= rh then lh + 1 else rh + 1;
+    let lh = left.height();
+    let rh = right.height();
+    let h = if lh >= rh then lh + 1 else rh + 1;
     if h == 1 then Map.singleton(key, value) else Map.Node(h, key, value, left, right)
   }
 
@@ -118,9 +118,9 @@ class Map<K: Comparable<K>, V>(Empty, Leaf(K, V), Node(int, K, V, Map<K, V>, Map
     value: V,
     right: Map<K, V>
   ): Map<K, V> = {
-    val lh = left.height();
-    val rh = right.height();
-    val h = if lh >= rh then lh + 1 else rh + 1;
+    let lh = left.height();
+    let rh = right.height();
+    let h = if lh >= rh then lh + 1 else rh + 1;
     Map.Node(h, key, value, left, right)
   }
 
@@ -135,25 +135,25 @@ class Map<K: Comparable<K>, V>(Empty, Leaf(K, V), Node(int, K, V, Map<K, V>, Map
     K,
     V
   > = {
-    val lh = l.height();
-    val rh = r.height();
+    let lh = l.height();
+    let rh = r.height();
     if lh > rh + 2 then {
-      val [lk, lv, ll, lr] = l.forcedNodeWithoutHeight();
+      let [lk, lv, ll, lr] = l.forcedNodeWithoutHeight();
       if ll.height() >= lr.height() then { Map.node(ll, lk, lv, Map.create(lr, k, v, r)) } else {
-        val [lrk, lrv, lrl, lrr] = lr.forcedNodeWithoutHeight();
+        let [lrk, lrv, lrl, lrr] = lr.forcedNodeWithoutHeight();
         Map.node(Map.create(ll, lk, lv, lrl), lrk, lrv, Map.create(lrr, k, v, r))
       }
     } else if rh > lh + 2 then {
-      val [rk, rv, rl, rr] = r.forcedNodeWithoutHeight();
+      let [rk, rv, rl, rr] = r.forcedNodeWithoutHeight();
       if rr.height() >= rl.height() then { Map.node(Map.create(l, k, v, rl), rk, rv, rr) } else {
-        val [rlk, rlv, rll, rlr] = rl.forcedNodeWithoutHeight();
+        let [rlk, rlv, rll, rlr] = rl.forcedNodeWithoutHeight();
         Map.node(Map.create(l, k, v, rll), rlk, rlv, Map.create(rlr, rk, rv, rr))
       }
     } else { Map.create(l, k, v, r) }
   }
 
   private method removeMinBindingFromNodeUnsafe(): Map<K, V> = {
-    val { e0 as k, e1 as v, e2 as l, e3 as r } = this.forcedNodeWithoutHeight();
+    let [k, v, l, r] = this.forcedNodeWithoutHeight();
     match l {
       Empty -> r,
       Leaf(_, _) -> Map.balanced(Map.empty<K, V>(), k, v, r),

--- a/tests/AllTests.sam
+++ b/tests/AllTests.sam
@@ -17,10 +17,10 @@ import { SortableListTest } from tests.SortableList;
 
 class TestCase(val name: Str, val runner: () -> unit) {
   method run(): unit = {
-    val { name, runner } = this;
-    val _ = Process.println("========================================");
-    val _ = Process.println("Test Name: " :: name);
-    val _ = runner();
+    let { name, runner } = this;
+    let _ = Process.println("========================================");
+    let _ = Process.println("Test Name: " :: name);
+    let _ = runner();
   }
 }
 
@@ -45,7 +45,7 @@ class Main {
       .reverse()
 
   function main(): unit = {
-    val _ = Main.getTests().iter((test) -> test.run());
+    let _ = Main.getTests().iter((test) -> test.run());
     Process.println("========================================")
   }
 }

--- a/tests/AndOrInsideIf.sam
+++ b/tests/AndOrInsideIf.sam
@@ -2,15 +2,15 @@ import { ForTests } from tests.StdLib;
 
 class AndOrInsideIf {
   private function test(): int = {
-    val i = 1;
-    val j = 2;
+    let i = 1;
+    let j = 2;
     if i < j /*  */ && i > 0 && /* f */ j > 0 then {
-      val a = 3;
-      val b = 4;
+      let a = 3;
+      let b = 4;
       if a > b || a + b > 0 && true then 1 else 2
     } else {
-      val a = 3;
-      val b = 4;
+      let a = 3;
+      let b = 4;
       if a == 2 || b == 4 then { 3 } else { 4 }
     }
   }

--- a/tests/Benchmark.sam
+++ b/tests/Benchmark.sam
@@ -5,9 +5,9 @@ class Benchmark {
     if n == 0 then acc else Benchmark.mathTailRec(n - 1, (acc % 10007 + n % 10007) % 10007)
 
   function run(): unit = {
-    val bigNum = 20000000;
-    val actual = Benchmark.mathTailRec(bigNum, 0);
-    val expected = (1 + bigNum) % 10007 * (bigNum % 10007 / 2) % 10007;
+    let bigNum = 20000000;
+    let actual = Benchmark.mathTailRec(bigNum, 0);
+    let expected = (1 + bigNum) % 10007 * (bigNum % 10007 / 2) % 10007;
     ForTests.assertIntEquals(expected, actual)
   }
 }

--- a/tests/BlockInIfElse.sam
+++ b/tests/BlockInIfElse.sam
@@ -1,17 +1,17 @@
 class BlockInIfElse {
   function run(): unit =
     if true then {
-      val _: int = BlockInIfElse.main2();
-      val _: unit = BlockInIfElse.main3();
-      val _: int = 3;
+      let _: int = BlockInIfElse.main2();
+      let _: unit = BlockInIfElse.main3();
+      let _: int = 3;
       {  }
     } else { {  } }
 
   private function main2(): int =
     if true then {
-      val _: int = 3;
+      let _: int = 3;
       3
     } else { 2 }
 
-  private function main3(): unit = if true then { val _: int = 3; } else {  }
+  private function main3(): unit = if true then { let _: int = 3; } else {  }
 }

--- a/tests/CSETest.sam
+++ b/tests/CSETest.sam
@@ -2,13 +2,13 @@ import { ForTests } from tests.StdLib;
 
 class CSETest {
   private function test1(a: int, b: int, c: int, d: int, e: int): unit = {
-    val _ = ForTests.assertIntEquals(c, a * b + a + (a * b + a));
-    val _ = ForTests.assertIntEquals(d, a * b);
-    val _ = ForTests.assertIntEquals(e, a * b + a);
+    let _ = ForTests.assertIntEquals(c, a * b + a + (a * b + a));
+    let _ = ForTests.assertIntEquals(d, a * b);
+    let _ = ForTests.assertIntEquals(e, a * b + a);
   }
 
   private function test2(first: bool, a: int, b: int, aTimesB: int): unit = {
-    val t = if first then a * b else a * b;
+    let t = if first then a * b else a * b;
     ForTests.assertIntEquals(aTimesB, a * b)
   }
 
@@ -35,41 +35,41 @@ class CSETest {
     if i >= 300 then acc else CSETest.test3(acc + CSETest.log(i, 2), i + 1)
 
   private function test4(totalPicograms: int, i: int): int = {
-    val maxLong = 92233720;
+    let maxLong = 92233720;
     if i >= 300 then { totalPicograms } else {
-      val megagrams = maxLong - i;
-      val kilograms = megagrams / 1000;
-      val grams = megagrams / 1000 / 1000;
-      val milligrams = megagrams / 1000 / 1000 / 1000;
+      let megagrams = maxLong - i;
+      let kilograms = megagrams / 1000;
+      let grams = megagrams / 1000 / 1000;
+      let milligrams = megagrams / 1000 / 1000 / 1000;
       CSETest.test4(kilograms + grams + milligrams, i + 1)
     }
   }
 
   private function test5(totalOddNumbers: int, i: int): int = {
     if i >= 300 then { totalOddNumbers } else {
-      val iMod64: int = i % 64;
-      val iMod32: int = i % 64 % 32;
-      val iMod16: int = i % 64 % 32 % 16;
-      val iMod8: int = i % 64 % 32 % 16 % 8;
-      val iMod4: int = i % 64 % 32 % 16 % 8 % 4;
-      val iMod2: int = i % 64 % 32 % 16 % 8 % 4 % 2;
+      let iMod64: int = i % 64;
+      let iMod32: int = i % 64 % 32;
+      let iMod16: int = i % 64 % 32 % 16;
+      let iMod8: int = i % 64 % 32 % 16 % 8;
+      let iMod4: int = i % 64 % 32 % 16 % 8 % 4;
+      let iMod2: int = i % 64 % 32 % 16 % 8 % 4 % 2;
       CSETest.test5(totalOddNumbers + iMod2, i + 1)
     }
   }
 
   private function test6(first: bool, a: int, b: int, aTimesB: int): unit = {
-    val _ = if first then { val _ = a * b; } else {  };
-    val _ = ForTests.assertIntEquals(aTimesB, a * b);
+    let _ = if first then { let _ = a * b; } else {  };
+    let _ = ForTests.assertIntEquals(aTimesB, a * b);
   }
 
   function run(): unit = {
-    val _ = CSETest.test1(3, 4, 30, 12, 15);
-    val _ = CSETest.test2(true, 3, 4, 12);
-    val _ = CSETest.test2(false, 3, 4, 12);
-    val _ = ForTests.assertIntEquals(2181, CSETest.test3(0, 0));
-    val _ = ForTests.assertIntEquals(92325, CSETest.test4(0, 0));
-    val _ = ForTests.assertIntEquals(150, CSETest.test5(0, 0));
-    val _ = CSETest.test6(true, 3, 4, 12);
-    val _ = CSETest.test6(false, 3, 4, 12);
+    let _ = CSETest.test1(3, 4, 30, 12, 15);
+    let _ = CSETest.test2(true, 3, 4, 12);
+    let _ = CSETest.test2(false, 3, 4, 12);
+    let _ = ForTests.assertIntEquals(2181, CSETest.test3(0, 0));
+    let _ = ForTests.assertIntEquals(92325, CSETest.test4(0, 0));
+    let _ = ForTests.assertIntEquals(150, CSETest.test5(0, 0));
+    let _ = CSETest.test6(true, 3, 4, 12);
+    let _ = CSETest.test6(false, 3, 4, 12);
   }
 }

--- a/tests/ConstantFoldingTest.sam
+++ b/tests/ConstantFoldingTest.sam
@@ -18,7 +18,7 @@ class ConstantFoldingTest {
 
   function test2(acc: int, i: int): int =
     if i >= 10 * 10 * 2 then { acc } else {
-      val increase: int = 1 + 2 * 3 - 4 / 5 % 10000000 / 12334 + (
+      let increase: int = 1 + 2 * 3 - 4 / 5 % 10000000 / 12334 + (
         1 + 2 * 3 - 4 / 5 % 10000000 / 12334
       ) + (1 + 2 * 3 - 4 / 5 % 10000000 / 12334) + (1 + 2 * 3 - 4 / 5 % 10000000 / 12334) + (
         1 + 2 * 3 - 4 / 5 % 10000000 / 12334
@@ -32,14 +32,14 @@ class ConstantFoldingTest {
     }
 
   function run(): unit = {
-    val _ = ForTests.assertIntEquals(
+    let _ = ForTests.assertIntEquals(
       /* expected */ 361200,
       ConstantFoldingTest /* a */
       /* b */
       // c
       .testI(0, 0)
     );
-    val _ = ForTests.assertIntEquals(7000, ConstantFoldingTest.test2(0, 0));
-    val _ = ForTests.assertIntEquals(1400, ConstantFoldingTest.test3(0, 0));
+    let _ = ForTests.assertIntEquals(7000, ConstantFoldingTest.test2(0, 0));
+    let _ = ForTests.assertIntEquals(1400, ConstantFoldingTest.test3(0, 0));
   }
 }

--- a/tests/DifferentExpressionDemo.sam
+++ b/tests/DifferentExpressionDemo.sam
@@ -8,11 +8,11 @@ class Foo(val a: int) {
 
 class Obj(val d: int, val e: int) {
   function valExample(): int = {
-    val a: int = 1;
-    val b: int = 2;
-    val c = 3;
-    val { e as d }: Obj = Obj.init(5, 4);
-    val _: int = 42;
+    let a: int = 1;
+    let b: int = 2;
+    let c = 3;
+    let { e as d }: Obj = Obj.init(5, 4);
+    let _: int = 42;
     a + b * c / d
   }
 }
@@ -21,11 +21,11 @@ class Clazz(val t: int) {
   function of(): Clazz = Clazz.init(42)
 
   method thisTest(): int = {
-    val i: int = this.t;
-    val { t as j } = this;
-    val { t as _ } = this;
-    val [_] = this;
-    val [k] = this;
+    let i: int = this.t;
+    let { t as j } = this;
+    let { t as _ } = this;
+    let [_] = this;
+    let [k] = this;
     i + j + k - k
   }
 }
@@ -34,8 +34,8 @@ class DifferentExpressionDemo {
   function identity(a: int): int = a
 
   function random(): int = {
-    val { e0, e1, e2 as [e3, _] } = [1, 2, [1, 3]];
-    val a = 42;
+    let { e0, e1, e2 as [e3, _] } = [1, 2, [1, 3]];
+    let a = 42;
     a
   }
 
@@ -45,10 +45,10 @@ class DifferentExpressionDemo {
     if b == 0 then Process.panic("Division by zero is illegal!") else a / b
 
   function nestedVal(): int = {
-    val a: int = {
-      val b: int = 4;
-      val c: int = {
-        val c: int = b;
+    let a: int = {
+      let b: int = 4;
+      let c: int = {
+        let c: int = b;
         b
       };
       c
@@ -61,16 +61,16 @@ class DifferentExpressionDemo {
   function <V, T> toSome(option: Option<V>, t: T): Option<T> = Option.Some(t)
 
   function lambdaTest(a: int): Str = {
-    val c = DifferentExpressionDemo.toSome(Option.None<int>(), 3).map((x: int) -> "empty");
+    let c = DifferentExpressionDemo.toSome(Option.None<int>(), 3).map((x: int) -> "empty");
     "hello world"
   }
 
   function run(): unit = {
-    val c = DifferentExpressionDemo.lambdaTest;
-    val _ = c(3);
-    val v = DifferentExpressionDemo.methodAndFunctionReference();
-    val _ = ForTests.assertIntEquals(84, v);
-    val _ = ForTests.assertIntEquals(
+    let c = DifferentExpressionDemo.lambdaTest;
+    let _ = c(3);
+    let v = DifferentExpressionDemo.methodAndFunctionReference();
+    let _ = ForTests.assertIntEquals(84, v);
+    let _ = ForTests.assertIntEquals(
       42,
       DifferentExpressionDemo.identity(
         Foo.bar() * DifferentExpressionDemo.oof() * Obj.valExample() / DifferentExpressionDemo.div(

--- a/tests/DifferentModulesDemo.sam
+++ b/tests/DifferentModulesDemo.sam
@@ -36,7 +36,7 @@ class FunctionExample {
 
 class Box<T>(val content: T) {
   method getContent(): T = {
-    val { content }: Box<T> = this;
+    let { content }: Box<T> = this;
     content
   }
 }
@@ -67,14 +67,14 @@ class DifferentModulesDemo {
     if !condition then {  } else Process.panic(message)
 
   function run(): unit = {
-    val _ = ForTests.assertIntEquals(Option.getSome(3).map((i: int) -> i + 1).forceValue(), 4);
-    val _ = ForTests.assertIntEquals(Box.init(42).getContent(), 42);
-    val _ = ForTests.assertIntEquals(FunctionExample.getIdentityFunction<int>()(42), 42);
-    val _ = ForTests.assertIntEquals(Student.dummyStudent().getAge(), 0);
-    val _ = ForTests.assertIntEquals(Math.plus(2, 2), 4);
-    val _ = DifferentModulesDemo.assertFalse(PrimitiveType.getUnit().isTruthy(), "Ah6");
-    val _ = DifferentModulesDemo.assertTrue(PrimitiveType.getInteger().isTruthy(), "Ah7");
-    val _ = DifferentModulesDemo.assertTrue(PrimitiveType.getString().isTruthy(), "Ah8");
-    val _ = DifferentModulesDemo.assertFalse(PrimitiveType.getBool().isTruthy(), "Ah9");
+    let _ = ForTests.assertIntEquals(Option.getSome(3).map((i: int) -> i + 1).forceValue(), 4);
+    let _ = ForTests.assertIntEquals(Box.init(42).getContent(), 42);
+    let _ = ForTests.assertIntEquals(FunctionExample.getIdentityFunction<int>()(42), 42);
+    let _ = ForTests.assertIntEquals(Student.dummyStudent().getAge(), 0);
+    let _ = ForTests.assertIntEquals(Math.plus(2, 2), 4);
+    let _ = DifferentModulesDemo.assertFalse(PrimitiveType.getUnit().isTruthy(), "Ah6");
+    let _ = DifferentModulesDemo.assertTrue(PrimitiveType.getInteger().isTruthy(), "Ah7");
+    let _ = DifferentModulesDemo.assertTrue(PrimitiveType.getString().isTruthy(), "Ah8");
+    let _ = DifferentModulesDemo.assertFalse(PrimitiveType.getBool().isTruthy(), "Ah9");
   }
 }

--- a/tests/EvaluationOrder.sam
+++ b/tests/EvaluationOrder.sam
@@ -2,21 +2,21 @@ import { ForTests } from tests.StdLib;
 
 class EvaluationOrder {
   private function intIdentity(order: int): int = {
-    val _ = ForTests.printlnInt(order);
+    let _ = ForTests.printlnInt(order);
     2
   }
 
   private function boolIdentity(item: bool, order: int): bool = {
-    val _ = ForTests.printlnInt(order);
+    let _ = ForTests.printlnInt(order);
     item
   }
 
   function run(): unit = {
-    val _ = EvaluationOrder.intIdentity(0) + EvaluationOrder.intIdentity(1);
-    val _ = EvaluationOrder.intIdentity(2) < EvaluationOrder.intIdentity(3);
-    val _ = EvaluationOrder.boolIdentity(false, 4) || EvaluationOrder.boolIdentity(false, 5);
-    val _ = EvaluationOrder.boolIdentity(true, 6) && EvaluationOrder.boolIdentity(true, 7);
-    val _ = EvaluationOrder.boolIdentity(true, 8) || EvaluationOrder.boolIdentity(false, 100);
-    val _ = EvaluationOrder.boolIdentity(false, 9) && EvaluationOrder.boolIdentity(true, 100);
+    let _ = EvaluationOrder.intIdentity(0) + EvaluationOrder.intIdentity(1);
+    let _ = EvaluationOrder.intIdentity(2) < EvaluationOrder.intIdentity(3);
+    let _ = EvaluationOrder.boolIdentity(false, 4) || EvaluationOrder.boolIdentity(false, 5);
+    let _ = EvaluationOrder.boolIdentity(true, 6) && EvaluationOrder.boolIdentity(true, 7);
+    let _ = EvaluationOrder.boolIdentity(true, 8) || EvaluationOrder.boolIdentity(false, 100);
+    let _ = EvaluationOrder.boolIdentity(false, 9) && EvaluationOrder.boolIdentity(true, 100);
   }
 }

--- a/tests/IntToString.sam
+++ b/tests/IntToString.sam
@@ -2,14 +2,14 @@ import { ForTests } from tests.StdLib;
 
 class IntToString {
   function run(): unit = {
-    val _ = ForTests.printlnInt(0);
-    val _ = ForTests.printlnInt(1);
-    val _ = ForTests.printlnInt(123);
-    val _ = ForTests.printlnInt(1234567);
-    val _ = ForTests.printlnInt(2147483647);
-    val _ = ForTests.printlnInt(-1);
-    val _ = ForTests.printlnInt(-123);
-    val _ = ForTests.printlnInt(-1234567);
-    val _ = ForTests.printlnInt(-2147483648);
+    let _ = ForTests.printlnInt(0);
+    let _ = ForTests.printlnInt(1);
+    let _ = ForTests.printlnInt(123);
+    let _ = ForTests.printlnInt(1234567);
+    let _ = ForTests.printlnInt(2147483647);
+    let _ = ForTests.printlnInt(-1);
+    let _ = ForTests.printlnInt(-123);
+    let _ = ForTests.printlnInt(-1234567);
+    let _ = ForTests.printlnInt(-2147483648);
   }
 }

--- a/tests/LoopOptimization.sam
+++ b/tests/LoopOptimization.sam
@@ -3,11 +3,11 @@ import { ForTests } from tests.StdLib;
 class LoopOptimization {
   private function loopy(i: int): int =
     if i >= 10 then { 0 } else {
-      val _ = ForTests.printlnInt(i * 3 + 100);
+      let _ = ForTests.printlnInt(i * 3 + 100);
       LoopOptimization.loopy(i + 2)
     }
 
   function run(): unit = {
-    val _ = LoopOptimization.loopy(0);
+    let _ = LoopOptimization.loopy(0);
   }
 }

--- a/tests/MathFunctions.sam
+++ b/tests/MathFunctions.sam
@@ -10,8 +10,8 @@ class MathFunctions {
     if n == 0 then {  } else MathFunctions.uselessRecursion(n - 1)
 
   function run(): unit = {
-    val _ = ForTests.assertIntEquals(24, MathFunctions.factorial(4));
-    val _ = ForTests.assertIntEquals(55, MathFunctions.fib(10));
-    val _ = MathFunctions.uselessRecursion(20);
+    let _ = ForTests.assertIntEquals(24, MathFunctions.factorial(4));
+    let _ = ForTests.assertIntEquals(55, MathFunctions.fib(10));
+    let _ = MathFunctions.uselessRecursion(20);
   }
 }

--- a/tests/PrintHelloWorld.sam
+++ b/tests/PrintHelloWorld.sam
@@ -1,18 +1,18 @@
 class PrintHelloWorld {
   private function globalConstantTest(): unit = {
-    val a1 = "a";
-    val a2 = "a";
+    let a1 = "a";
+    let a2 = "a";
     if a1 == a2 then {  } else Process.panic("")
   }
 
   private function printTest(): unit = {
-    val h = "Hello";
-    val w = " World!";
+    let h = "Hello";
+    let w = " World!";
     Process.println(h :: w)
   }
 
   function run(): unit = {
-    val _ = PrintHelloWorld.globalConstantTest();
-    val _ = PrintHelloWorld.printTest();
+    let _ = PrintHelloWorld.globalConstantTest();
+    let _ = PrintHelloWorld.printTest();
   }
 }

--- a/tests/SortableList.sam
+++ b/tests/SortableList.sam
@@ -21,8 +21,8 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
     match this {
       Nil(_) -> {  }
       Cons(pair) -> {
-        val [v, rest] = pair;
-        val _ = f(v);
+        let [v, rest] = pair;
+        let _ = f(v);
         rest.iter(f)
       }
     }
@@ -33,7 +33,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
       Cons(pair) -> match pair.e1 {
         Nil(_) -> this,
         Cons(_) -> {
-          val [l1, l2] = this.split(List.nil<T>(), List.nil<T>());
+          let [l1, l2] = this.split(List.nil<T>(), List.nil<T>());
           l1.sort().merge(l2.sort())
         }
       }
@@ -45,8 +45,8 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
       Cons(pair1) -> match other {
         Nil(_) -> this,
         Cons(pair2) -> {
-          val [h1, t1] = pair1;
-          val [h2, t2] = pair2;
+          let [h1, t1] = pair1;
+          let [h2, t2] = pair2;
           if h1.compare(h2) < 0 then t1.merge(other).cons(h1) else t2.merge(this).cons(h2)
         }
       }
@@ -56,7 +56,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
     match this {
       Nil(_) -> Pair.init(y, z),
       Cons(pair) -> {
-        val [x, rest] = pair;
+        let [x, rest] = pair;
         rest.split(z, y.cons(x))
       }
     }
@@ -64,7 +64,7 @@ class List<T: Comparable<T>>(Nil(unit), Cons(Pair<T, List<T>>)) {
 
 class SortableListTest {
   function run(): unit = {
-    val list = List.of(BoxedInt.init(4))
+    let list = List.of(BoxedInt.init(4))
       .cons(BoxedInt.init(2))
       .cons(BoxedInt.init(1))
       .cons(BoxedInt.init(3));


### PR DESCRIPTION
[syntax] Use `let` instead of `val` for local binding

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1068).
* __->__ #1068
* #1067
* #1066
* #1065