### PR TITLE
[compiler][mir] Do not optimize enums as unboxed

### DIFF
--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -1612,11 +1612,24 @@ class Foo(val a: int) {
   function bar(): int = 3
 }
 
-class Option<T>(None(unit), Some(T)) {
+class Option<T>(None, Some(T)) {
   function matchExample(opt: Option<int>): int =
     match (opt) {
-      None(_) -> 42,
+      None -> 42,
       Some(a) -> a,
+    }
+}
+
+class FooOrFoo(F1(Foo), F2(Foo)) {
+  function f1(): FooOrFoo = FooOrFoo.F1(Foo.init(1))
+  function f2(): FooOrFoo = FooOrFoo.F2(Foo.init(2))
+
+  function intValue(): int = FooOrFoo.f1().getInt() + FooOrFoo.f2().getInt()
+
+  method getInt(): int =
+    match (this) {
+      F1(foo) -> foo.a,
+      F2(foo) -> foo.a,
     }
 }
 
@@ -1650,8 +1663,20 @@ class Main {
     )
 
   function nestedVal(): int = {
+    let veryOpt = Option.Some(Option.Some(Option.Some(Foo.init(1))));
+    let opt = match veryOpt {
+      None -> 0,
+      Some(v1) -> match v1 {
+        None -> 1,
+        Some(v2) -> match v2 {
+          None -> 2,
+          Some(v3) -> 3, // <- get this
+        }
+      },
+    };
+    let _ = Option.Some(FooOrFoo.f1());
     let a = {
-      let b = 4;
+      let b = 1 + opt;
       let c = {
         let c = b;
         b
@@ -1663,6 +1688,7 @@ class Main {
 
   function main(): unit = Process.println(Str.fromInt(Main.identity(
     Foo.bar() * Main.oof() * Obj.valExample() / Main.div(4, 2) + Main.nestedVal() - 5
+    + FooOrFoo.intValue() - FooOrFoo.intValue()
   )))
 }
 "#,

--- a/crates/samlang-core/src/interpreter.rs
+++ b/crates/samlang-core/src/interpreter.rs
@@ -287,7 +287,7 @@ pub(super) fn run(heap: &mut Heap, sources: &Sources, main_function: FunctionNam
   let mut id_to_functions = HashMap::new();
   let mut global_str_names_to_address = HashMap::new();
   let mut global_fn_names_to_address = HashMap::new();
-  let mut global_name_id = 0;
+  let mut global_name_id = 1024;
 
   for (string_id, v) in sources.global_variables.iter().enumerate() {
     let string_id = i32::try_from(string_id).unwrap();
@@ -796,7 +796,7 @@ mod tests {
               return_collector: None,
             },
             Statement::Call {
-              callee: Expression::int(16), // calling function _
+              callee: Expression::int(16 + 1024), // calling function _
               arguments: vec![Expression::Variable(heap.alloc_str_for_test("hw_string"), INT_TYPE)],
               return_type: INT_TYPE,
               return_collector: None,

--- a/crates/samlang-core/src/printer/source_printer.rs
+++ b/crates/samlang-core/src/printer/source_printer.rs
@@ -714,12 +714,18 @@ fn matching_pattern_to_document(heap: &Heap, pattern: &pattern::MatchingPattern<
       tag,
       data_variables,
       type_: (),
-    }) => Document::concat(vec![
-      Document::Text(rc_pstr(heap, tag.name)),
-      parenthesis_surrounded_doc(comma_sep_list(data_variables, |(p, _)| {
-        matching_pattern_to_document(heap, p)
-      })),
-    ]),
+    }) => {
+      if data_variables.is_empty() {
+        Document::Text(rc_pstr(heap, tag.name))
+      } else {
+        Document::concat(vec![
+          Document::Text(rc_pstr(heap, tag.name)),
+          parenthesis_surrounded_doc(comma_sep_list(data_variables, |(p, _)| {
+            matching_pattern_to_document(heap, p)
+          })),
+        ])
+      }
+    }
     pattern::MatchingPattern::Id(id, _) => Document::Text(rc_pstr(heap, id.name)),
     pattern::MatchingPattern::Wildcard(_) => Document::Text(rcs("_")),
   }
@@ -1358,7 +1364,7 @@ Test /* b */ /* c */.VariantName<T>(42)"#,
       r#"{
   let _ = if let {
     foo as {
-      bar as [Fizz(baz), Buzz(), _],
+      bar as [Fizz(baz), Buzz, _],
       boo
     }
   } = true then {


### PR DESCRIPTION
[compiler][mir] Do not optimize enums as unboxed

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1108).
* __->__ #1108
* #1107