### PR TITLE
[compiler][mir] Handle SingleIf in generics specialization

### DIFF
--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -267,6 +267,29 @@ pub(crate) mod pattern {
       }
     }
 
+    pub(crate) fn always_matching(&self) -> bool {
+      match self {
+        Self::Tuple(_, elements) => {
+          for e in elements {
+            if !e.pattern.always_matching() {
+              return false;
+            }
+          }
+          true
+        }
+        Self::Object(_, elements) => {
+          for e in elements {
+            if !e.pattern.always_matching() {
+              return false;
+            }
+          }
+          true
+        }
+        Self::Variant(_) => false,
+        Self::Id(_, _) | Self::Wildcard(_) => true,
+      }
+    }
+
     pub(crate) fn bindings(&self) -> HashSet<PStr> {
       let mut set = HashSet::new();
       self.collect_bindings(&mut set);

--- a/crates/samlang-core/src/ast/source_tests.rs
+++ b/crates/samlang-core/src/ast/source_tests.rs
@@ -50,59 +50,6 @@ mod tests {
     destructuring_pattern = pattern::DestructuringPattern::Wildcard(Location::dummy());
     assert_eq!(*destructuring_pattern.loc(), Location::dummy());
 
-    let mut matching_pattern: pattern::MatchingPattern<()> = pattern::MatchingPattern::Object(
-      Location::dummy(),
-      vec![pattern::ObjectPatternElement {
-        loc: Location::dummy(),
-        field_order: 0,
-        field_name: Id::from(PStr::UPPER_A),
-        pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
-        shorthand: false,
-        type_: (),
-      }],
-    );
-    matching_pattern.bindings();
-    assert_eq!(*matching_pattern.loc(), Location::dummy());
-    matching_pattern = pattern::MatchingPattern::Tuple(
-      Location::dummy(),
-      vec![pattern::TuplePatternElement {
-        pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
-        type_: (),
-      }],
-    );
-    matching_pattern.bindings();
-    assert_eq!(*matching_pattern.loc(), Location::dummy());
-    matching_pattern = pattern::MatchingPattern::Variant(pattern::VariantPattern {
-      loc: Location::dummy(),
-      tag_order: 0,
-      tag: Id::from(PStr::UPPER_A),
-      data_variables: vec![(pattern::MatchingPattern::Wildcard(Location::dummy()), ())],
-      type_: (),
-    });
-    matching_pattern.bindings();
-    assert_eq!(*matching_pattern.clone().loc(), Location::dummy());
-    matching_pattern = pattern::MatchingPattern::Id(Id::from(PStr::LOWER_A), ());
-    matching_pattern.bindings();
-    assert_eq!(*matching_pattern.loc(), Location::dummy());
-    matching_pattern = pattern::MatchingPattern::Wildcard(Location::dummy());
-    matching_pattern.bindings();
-    assert_eq!(*matching_pattern.loc(), Location::dummy());
-    assert!(
-      pattern::MatchingPattern::Variant(pattern::VariantPattern {
-        loc: Location::dummy(),
-        tag_order: 0,
-        tag: Id::from(PStr::UPPER_A),
-        data_variables: vec![],
-        type_: (),
-      }) == pattern::MatchingPattern::Variant(pattern::VariantPattern {
-        loc: Location::dummy(),
-        tag_order: 0,
-        tag: Id::from(PStr::UPPER_A),
-        data_variables: vec![],
-        type_: (),
-      })
-    );
-
     let list = [
       expr::BinaryOperator::MUL,
       expr::BinaryOperator::DIV,
@@ -127,6 +74,140 @@ mod tests {
       assert!(p <= new_p);
       p = new_p;
     }
+  }
+
+  #[test]
+  fn pattern_matching_and_bindings_tests() {
+    let mut matching_pattern: pattern::MatchingPattern<()> = pattern::MatchingPattern::Object(
+      Location::dummy(),
+      vec![pattern::ObjectPatternElement {
+        loc: Location::dummy(),
+        field_order: 0,
+        field_name: Id::from(PStr::UPPER_A),
+        pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
+        shorthand: false,
+        type_: (),
+      }],
+    );
+    matching_pattern.bindings();
+    assert!(matching_pattern.always_matching());
+    matching_pattern = pattern::MatchingPattern::Object(
+      Location::dummy(),
+      vec![
+        pattern::ObjectPatternElement {
+          loc: Location::dummy(),
+          field_order: 0,
+          field_name: Id::from(PStr::UPPER_A),
+          pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
+          shorthand: false,
+          type_: (),
+        },
+        pattern::ObjectPatternElement {
+          loc: Location::dummy(),
+          field_order: 0,
+          field_name: Id::from(PStr::UPPER_A),
+          pattern: Box::new(pattern::MatchingPattern::Variant(pattern::VariantPattern {
+            loc: Location::dummy(),
+            tag_order: 0,
+            tag: Id::from(PStr::UPPER_A),
+            data_variables: vec![(pattern::MatchingPattern::Wildcard(Location::dummy()), ())],
+            type_: (),
+          })),
+          shorthand: false,
+          type_: (),
+        },
+      ],
+    );
+    matching_pattern.bindings();
+    assert!(!matching_pattern.always_matching());
+    matching_pattern = pattern::MatchingPattern::Object(
+      Location::dummy(),
+      vec![
+        pattern::ObjectPatternElement {
+          loc: Location::dummy(),
+          field_order: 0,
+          field_name: Id::from(PStr::UPPER_A),
+          pattern: Box::new(pattern::MatchingPattern::Variant(pattern::VariantPattern {
+            loc: Location::dummy(),
+            tag_order: 0,
+            tag: Id::from(PStr::UPPER_A),
+            data_variables: vec![(pattern::MatchingPattern::Wildcard(Location::dummy()), ())],
+            type_: (),
+          })),
+          shorthand: false,
+          type_: (),
+        },
+        pattern::ObjectPatternElement {
+          loc: Location::dummy(),
+          field_order: 0,
+          field_name: Id::from(PStr::UPPER_A),
+          pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
+          shorthand: false,
+          type_: (),
+        },
+      ],
+    );
+    matching_pattern.bindings();
+    assert!(!matching_pattern.always_matching());
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Tuple(
+      Location::dummy(),
+      vec![pattern::TuplePatternElement {
+        pattern: Box::new(pattern::MatchingPattern::Wildcard(Location::dummy())),
+        type_: (),
+      }],
+    );
+    matching_pattern.bindings();
+    assert!(matching_pattern.always_matching());
+    matching_pattern = pattern::MatchingPattern::Tuple(
+      Location::dummy(),
+      vec![pattern::TuplePatternElement {
+        pattern: Box::new(pattern::MatchingPattern::Variant(pattern::VariantPattern {
+          loc: Location::dummy(),
+          tag_order: 0,
+          tag: Id::from(PStr::UPPER_A),
+          data_variables: vec![(pattern::MatchingPattern::Wildcard(Location::dummy()), ())],
+          type_: (),
+        })),
+        type_: (),
+      }],
+    );
+    matching_pattern.bindings();
+    assert!(!matching_pattern.always_matching());
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Variant(pattern::VariantPattern {
+      loc: Location::dummy(),
+      tag_order: 0,
+      tag: Id::from(PStr::UPPER_A),
+      data_variables: vec![(pattern::MatchingPattern::Wildcard(Location::dummy()), ())],
+      type_: (),
+    });
+    matching_pattern.bindings();
+    assert!(!matching_pattern.always_matching());
+    assert_eq!(*matching_pattern.clone().loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Id(Id::from(PStr::LOWER_A), ());
+    matching_pattern.bindings();
+    assert!(matching_pattern.always_matching());
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    matching_pattern = pattern::MatchingPattern::Wildcard(Location::dummy());
+    matching_pattern.bindings();
+    assert!(matching_pattern.always_matching());
+    assert_eq!(*matching_pattern.loc(), Location::dummy());
+    assert!(
+      pattern::MatchingPattern::Variant(pattern::VariantPattern {
+        loc: Location::dummy(),
+        tag_order: 0,
+        tag: Id::from(PStr::UPPER_A),
+        data_variables: vec![],
+        type_: (),
+      }) == pattern::MatchingPattern::Variant(pattern::VariantPattern {
+        loc: Location::dummy(),
+        tag_order: 0,
+        tag: Id::from(PStr::UPPER_A),
+        data_variables: vec![],
+        type_: (),
+      })
+    );
   }
 
   #[test]


### PR DESCRIPTION
[compiler][mir] Handle SingleIf in generics specialization


It might be a possible instruction to encounter once we add if let compilation support.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1112).
* __->__ #1112
* #1111