### PR TITLE
[ide] Do not return hover type results for arbitrary expressions

### DIFF
--- a/crates/samlang-core/src/services/api_tests.rs
+++ b/crates/samlang-core/src/services/api_tests.rs
@@ -182,15 +182,7 @@ class Test2(val a: int) {
     // At b in this.b
     assert!(query::hover(&state, &test2_mod_ref, Position(3, 28)).is_none());
     // At the () of call
-    assert_eq!(
-      "any [lang=samlang]",
-      query::hover(&state, &test2_mod_ref, Position(4, 42))
-        .unwrap()
-        .contents
-        .iter()
-        .map(query::TypeQueryContent::to_string)
-        .join("\n")
-    );
+    assert!(query::hover(&state, &test2_mod_ref, Position(4, 42)).is_none());
     // Non-existent
     assert!(query::all_references(&state, &ModuleReference::DUMMY, Position(4, 100)).is_empty());
     assert!(query::all_references(&state, &test2_mod_ref, Position(4, 100)).is_empty());


### PR DESCRIPTION
[ide] Do not return hover type results for arbitrary expressions

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1121).
* #1125
* #1124
* #1123
* #1122
* __->__ #1121