### PR TITLE
[ast][cleanup][EZ] Do not make pattern polymorphic over base

### DIFF
--- a/crates/samlang-core/src/ast/loc.rs
+++ b/crates/samlang-core/src/ast/loc.rs
@@ -1,12 +1,9 @@
 use samlang_heap::{Heap, ModuleReference};
-use std::collections::HashMap;
 
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Position(pub i32, pub i32);
 
 pub(crate) const DUMMY_POSITION: Position = Position(-1, -1);
-
-type Sources<M> = HashMap<ModuleReference, M>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Location {

--- a/crates/samlang-core/src/ast/source.rs
+++ b/crates/samlang-core/src/ast/source.rs
@@ -202,17 +202,17 @@ pub(crate) mod pattern {
   use std::collections::BTreeMap;
 
   #[derive(Clone, PartialEq, Eq)]
-  pub(crate) struct TuplePatternElement<Base: Clone, T: Clone> {
-    pub(crate) pattern: Box<Base>,
+  pub(crate) struct TuplePatternElement<T: Clone> {
+    pub(crate) pattern: Box<MatchingPattern<T>>,
     pub(crate) type_: T,
   }
 
   #[derive(Clone, PartialEq, Eq)]
-  pub(crate) struct ObjectPatternElement<Base: Clone, T: Clone> {
+  pub(crate) struct ObjectPatternElement<T: Clone> {
     pub(crate) loc: Location,
     pub(crate) field_order: usize,
     pub(crate) field_name: Id,
-    pub(crate) pattern: Box<Base>,
+    pub(crate) pattern: Box<MatchingPattern<T>>,
     pub(crate) shorthand: bool,
     pub(crate) type_: T,
   }
@@ -228,8 +228,8 @@ pub(crate) mod pattern {
 
   #[derive(Clone, PartialEq, Eq)]
   pub(crate) enum MatchingPattern<T: Clone> {
-    Tuple(Location, Vec<TuplePatternElement<MatchingPattern<T>, T>>),
-    Object(Location, Vec<ObjectPatternElement<MatchingPattern<T>, T>>),
+    Tuple(Location, Vec<TuplePatternElement<T>>),
+    Object(Location, Vec<ObjectPatternElement<T>>),
     Variant(VariantPattern<T>),
     Id(Id, T),
     Wildcard(Location),


### PR DESCRIPTION
[ast][cleanup][EZ] Do not make pattern polymorphic over base

This is a sharing strategy added when we have both destructuring and matching pattern. Now we only have matching pattern, so this kind of extra indirection is no longer necessary.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1129).
* __->__ #1129
* #1128