### PR TITLE
[refactor][errors] Expose less structs from errors

### DIFF
--- a/crates/samlang-core/src/checker/checker_tests.rs
+++ b/crates/samlang-core/src/checker/checker_tests.rs
@@ -543,7 +543,7 @@ mod tests {
 
     let (_, parsed) =
       parse_source_expression_from_text(source, ModuleReference::DUMMY, heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
 
     let mut temp_ssa_error_set = ErrorSet::new();
     let global_cx = sandbox_global_cx(heap, include_std);

--- a/crates/samlang-core/src/checker/global_signature.rs
+++ b/crates/samlang-core/src/checker/global_signature.rs
@@ -432,7 +432,7 @@ interface Hiya {}
 "#;
     let module =
       parse_source_module_from_text(source_code, ModuleReference::DUMMY, heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     let builtin_cx = create_builtin_module_signature();
     let global_cx =
       super::build_global_signature(&HashMap::from([(ModuleReference::DUMMY, module)]), builtin_cx);
@@ -498,7 +498,7 @@ interface UsingConflictingExtends : ConflictExtends1, ConflictExtends2 {}
 "#;
     let module =
       parse_source_module_from_text(source_code, ModuleReference::DUMMY, heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     let builtin_cx = create_builtin_module_signature();
     super::build_global_signature(&HashMap::from([(ModuleReference::DUMMY, module)]), builtin_cx)
   }

--- a/crates/samlang-core/src/checker/main_checker.rs
+++ b/crates/samlang-core/src/checker/main_checker.rs
@@ -9,7 +9,7 @@ use super::{
   type_system,
   typing_context::{LocalTypingContext, TypingContext},
 };
-use crate::errors::{ErrorSet, StackableError, TypeIncompatibilityNode};
+use crate::errors::{ErrorSet, StackableError};
 use itertools::Itertools;
 use samlang_ast::{
   source::{
@@ -1446,12 +1446,12 @@ fn check_class_member_conformance_with_signature(
     let actual_fn_type = FunctionType::from_annotation(&actual.type_);
     if !expected.type_.is_the_same_type(&actual_fn_type) {
       let mut error = StackableError::new();
-      error.add_type_error(TypeIncompatibilityNode {
-        lower_reason: actual_fn_type.reason,
-        lower_description: actual_fn_type.to_description(),
-        upper_reason: expected.type_.reason,
-        upper_description: expected.type_.to_description(),
-      });
+      error.add_type_incompatibility_error(
+        actual_fn_type.reason,
+        actual_fn_type.to_description(),
+        expected.type_.reason,
+        expected.type_.to_description(),
+      );
       error_set.report_stackable_error(actual.type_.location, error);
     }
   }

--- a/crates/samlang-core/src/checker/type_system.rs
+++ b/crates/samlang-core/src/checker/type_system.rs
@@ -1,5 +1,5 @@
 use super::type_::{FunctionType, ISourceType, NominalType, Type, TypeParameterSignature};
-use crate::errors::{ErrorSet, StackableError, TypeIncompatibilityNode};
+use crate::errors::{ErrorSet, StackableError};
 use samlang_ast::Reason;
 use samlang_heap::PStr;
 use std::{
@@ -63,12 +63,12 @@ fn assignability_check_visit(lower: &Type, upper: &Type, error_stack: &mut Stack
     }
     (_, _) => {}
   }
-  error_stack.add_type_error(TypeIncompatibilityNode {
-    lower_reason: *lower.get_reason(),
-    lower_description: lower.to_description(),
-    upper_reason: *upper.get_reason(),
-    upper_description: upper.to_description(),
-  });
+  error_stack.add_type_incompatibility_error(
+    *lower.get_reason(),
+    lower.to_description(),
+    *upper.get_reason(),
+    upper.to_description(),
+  );
   false
 }
 
@@ -158,12 +158,12 @@ fn type_meet_visit(lower: &Type, upper: &Type, error_stack: &mut StackableError)
     }
     (_, _) => {}
   }
-  error_stack.add_type_error(TypeIncompatibilityNode {
-    lower_reason: *lower.get_reason(),
-    lower_description: lower.to_description(),
-    upper_reason: *upper.get_reason(),
-    upper_description: upper.to_description(),
-  });
+  error_stack.add_type_incompatibility_error(
+    *lower.get_reason(),
+    lower.to_description(),
+    *upper.get_reason(),
+    upper.to_description(),
+  );
   None
 }
 
@@ -367,8 +367,14 @@ mod tests {
     let mut error_set_2 = ErrorSet::new();
     error_set_2
       .report_stackable_error(Location::dummy(), super::type_meet(lower, upper).err().unwrap());
-    assert_eq!(expected.trim(), error_set_2.pretty_print_error_messages_no_frame(heap).trim());
-    assert_eq!(expected.trim(), error_set.pretty_print_error_messages_no_frame(heap).trim());
+    assert_eq!(
+      expected.trim(),
+      error_set_2.pretty_print_error_messages_no_frame_for_test(heap).trim()
+    );
+    assert_eq!(
+      expected.trim(),
+      error_set.pretty_print_error_messages_no_frame_for_test(heap).trim()
+    );
   }
 
   #[test]

--- a/crates/samlang-core/src/checker/typing_context_tests.rs
+++ b/crates/samlang-core/src/checker/typing_context_tests.rs
@@ -275,7 +275,7 @@ Found 3 errors.
 "#;
     assert_eq!(
       expected_errors.trim(),
-      cx.error_set.pretty_print_error_messages_no_frame(&heap).trim()
+      cx.error_set.pretty_print_error_messages_no_frame_for_test(&heap).trim()
     );
   }
 

--- a/crates/samlang-core/src/integration_tests.rs
+++ b/crates/samlang-core/src/integration_tests.rs
@@ -2375,11 +2375,11 @@ class Main {
       let raw = printer::pretty_print_source_module(heap, 100, &module);
       let mut error_set = ErrorSet::new();
       sources.insert(mod_ref, parse_source_module_from_text(&raw, mod_ref, heap, &mut error_set));
-      assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+      assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     }
     let mut error_set = ErrorSet::new();
     let (checked_sources, _) = type_check_sources(&sources, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     assert!(checked_sources.len() == expected_sources_size);
   }
 
@@ -2401,7 +2401,7 @@ class Main {
       sources.insert(mod_ref, parsed);
     }
     let (checked_sources, _) = type_check_sources(&sources, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     let unoptimized_mir_sources = compiler::compile_sources_to_mir(heap, &checked_sources);
     let optimized_mir_sources = optimization::optimize_sources(
       heap,

--- a/crates/samlang-core/src/parser.rs
+++ b/crates/samlang-core/src/parser.rs
@@ -55,7 +55,7 @@ mod tests {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
     parse_source_expression_from_text(text, ModuleReference::DUMMY, &mut heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(&heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(&heap));
   }
 
   #[test]
@@ -133,7 +133,7 @@ mod tests {
     let mut heap = Heap::new();
     let mut error_set = ErrorSet::new();
     parse_source_expression_from_text(text, ModuleReference::DUMMY, &mut heap, &mut error_set);
-    assert_ne!("", error_set.pretty_print_error_messages_no_frame(&heap));
+    assert_ne!("", error_set.pretty_print_error_messages_no_frame_for_test(&heap));
   }
 
   #[test]
@@ -257,7 +257,7 @@ mod tests {
 "#;
     let parsed =
       &parse_source_module_from_text(text, ModuleReference::DUMMY, &mut heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(&heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(&heap));
     assert_eq!(1, parsed.imports.len());
     assert_eq!(
       vec![
@@ -456,7 +456,7 @@ Found 6 errors.
 "#;
     assert_eq!(
       expected_errors.trim(),
-      error_set.pretty_print_error_messages_no_frame(&heap).trim()
+      error_set.pretty_print_error_messages_no_frame_for_test(&heap).trim()
     );
   }
 }

--- a/crates/samlang-core/src/printer/source_printer.rs
+++ b/crates/samlang-core/src/printer/source_printer.rs
@@ -1055,7 +1055,7 @@ mod tests {
     let mut error_set = ErrorSet::new();
     let (comment_store, e) =
       parse_source_expression_from_text(source, ModuleReference::DUMMY, &mut heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(&heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(&heap));
     assert_eq!(
       expected,
       prettier::pretty_print(40, create_doc(&heap, &comment_store, &e)).trim_end()
@@ -1067,7 +1067,7 @@ mod tests {
     let mut error_set = ErrorSet::new();
     let m =
       parse_source_module_from_text(source, ModuleReference::DUMMY, &mut heap, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(&heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(&heap));
     assert_eq!(expected, format!("\n{}", pretty_print_source_module(&heap, 40, &m).trim_end()));
   }
 

--- a/crates/samlang-core/src/services/location_cover.rs
+++ b/crates/samlang-core/src/services/location_cover.rs
@@ -376,7 +376,7 @@ mod tests {
     let mut sources = builtin_parsed_std_sources(heap);
     sources.insert(mod_ref, parsed);
     let (checked_sources, _) = type_check_sources(&sources, &mut error_set);
-    assert_eq!("", error_set.pretty_print_error_messages_no_frame(heap));
+    assert_eq!("", error_set.pretty_print_error_messages_no_frame_for_test(heap));
     for m in checked_sources.values() {
       for (i, line) in source_code.lines().enumerate() {
         let i = i as i32;

--- a/crates/samlang-core/src/services/server_state.rs
+++ b/crates/samlang-core/src/services/server_state.rs
@@ -107,7 +107,7 @@ impl ServerState {
 
   #[cfg(test)]
   pub(super) fn get_error_dump(&self) -> String {
-    ErrorSet::pretty_print_from_grouped_error_messages(
+    ErrorSet::pretty_print_from_grouped_error_messages_for_tests(
       &self.heap,
       &self.string_sources,
       &self.errors,


### PR DESCRIPTION
[refactor][errors] Expose less structs from errors

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1131).
* #1132
* __->__ #1131