### PR TITLE
[checker] Add missing substitution during conformance check

### DIFF
--- a/crates/samlang-checker/src/typing_context.rs
+++ b/crates/samlang-checker/src/typing_context.rs
@@ -206,9 +206,15 @@ impl<'a> TypingContext<'a> {
         self.error_set.report_stackable_error(nominal_type.reason.use_loc, error);
         return;
       }
+      let subst_mapping = interface_type_parameters
+        .iter()
+        .zip(&nominal_type.type_arguments)
+        .map(|(tparam, targ)| (tparam.name, targ.clone()))
+        .collect::<HashMap<_, _>>();
       for (tparam, targ) in interface_type_parameters.into_iter().zip(&nominal_type.type_arguments)
       {
         if let Some(bound) = tparam.bound {
+          let bound = type_system::subst_nominal_type(&bound, &subst_mapping);
           if !self.is_subtype_with_id_upper(targ, &bound) {
             self.error_set.report_incompatible_subtype_error(
               targ.get_reason().use_loc,

--- a/crates/samlang-checker/src/typing_context.rs
+++ b/crates/samlang-checker/src/typing_context.rs
@@ -246,7 +246,7 @@ impl<'a> TypingContext<'a> {
       nominal_type.module_reference,
       nominal_type.id,
     )
-    .filter(|it| !it.private)?;
+    .filter(|it| !it.private || nominal_type.module_reference == self.current_module_reference)?;
     if nominal_type.is_class_statics {
       let resolved = global_signature::resolve_function_signature(
         self.global_signature,


### PR DESCRIPTION
[checker] Add missing substitution during conformance check

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1143).
* __->__ #1143
* #1142