### PR TITLE
[printer] Always print `{}` even if the toplevel members are empty

### DIFF
--- a/crates/samlang-printer/src/source_printer.rs
+++ b/crates/samlang-printer/src/source_printer.rs
@@ -868,10 +868,6 @@ fn interface_to_doc(
     extends_or_implements_node_to_doc(heap, comment_store, &interface.extends_or_implements_nodes),
   ];
 
-  if interface.members.is_empty() {
-    return documents;
-  }
-
   documents.push(Document::Text(rcs(" {")));
   for member in &interface.members {
     documents.push(Document::Nest(
@@ -941,10 +937,6 @@ fn class_to_doc(
     },
     extends_or_implements_node_to_doc(heap, comment_store, &class.extends_or_implements_nodes),
   ];
-
-  if class.members.is_empty() {
-    return documents;
-  }
 
   documents.push(Document::Text(rcs(" {")));
   for member in &class.members {
@@ -1419,9 +1411,9 @@ class Empty2 : Foo
 class Main { function main(): unit = {} }
 "#,
       r#"
-interface Foo
+interface Foo {}
 
-interface Foo2 : Foo
+interface Foo2 : Foo {}
 
 private interface Bar<
   /* comment */
@@ -1431,9 +1423,9 @@ private interface Bar<
   function baz(): int
 }
 
-class Empty
+class Empty {}
 
-class Empty2 : Foo
+class Empty2 : Foo {}
 
 class Main {
   function main(): unit = {  }
@@ -1562,7 +1554,7 @@ class Obj(
 }
 
 /** short line */
-private class A(val a: int)
+private class A(val a: int) {}
 
 /**
  * some very very very very very very
@@ -1570,7 +1562,7 @@ private class A(val a: int)
  * very very very very very long
  * document string
  */
-class Main"#,
+class Main {}"#,
     );
   }
 }

--- a/crates/samlang-services/src/ast_differ.rs
+++ b/crates/samlang-services/src/ast_differ.rs
@@ -536,7 +536,7 @@ mod tests {
       members: vec![],
     });
     assert_eq!(
-      "interface A",
+      "interface A {}",
       Change::Replace(DiffNode::Toplevel(&toplevel), DiffNode::Toplevel(&toplevel))
         .to_edit(heap, &CommentStore::new())
         .1
@@ -577,7 +577,7 @@ mod tests {
     assert_eq!(
       vec![(
         Location::full_document(ModuleReference::DUMMY).pretty_print_without_file(),
-        "/* B */\nclass A\n".to_string()
+        "/* B */\nclass A {}\n".to_string()
       )],
       produce_module_diff("/* A */ class A {}", "/* B */ class A {}")
     );
@@ -600,27 +600,27 @@ mod tests {
       produce_module_diff("import {Foo} from Bar", "import {Foo} from Bar\nimport {Foo} from Bar")
     );
     assert_eq!(
-      vec![("1:1-1:1".to_string(), "class A".to_string())],
+      vec![("1:1-1:1".to_string(), "class A {}".to_string())],
       produce_module_diff("", "class A {}")
     );
     assert_eq!(
-      vec![("1:22-1:22".to_string(), "class A".to_string())],
+      vec![("1:22-1:22".to_string(), "class A {}".to_string())],
       produce_module_diff("import {Foo} from Bar", "import {Foo} from Bar\nclass A {}")
     );
     assert_eq!(
-      vec![("1:1-1:11".to_string(), "class B".to_string())],
+      vec![("1:1-1:11".to_string(), "class B {}".to_string())],
       produce_module_diff("class A {}", "class B {}")
     );
     assert_eq!(
-      vec![("1:1-1:11".to_string(), "interface A".to_string())],
+      vec![("1:1-1:11".to_string(), "interface A {}".to_string())],
       produce_module_diff("class A {}", "interface A {}")
     );
     assert_eq!(
-      vec![("1:11-1:11".to_string(), "class B".to_string())],
+      vec![("1:11-1:11".to_string(), "class B {}".to_string())],
       produce_module_diff("class A {}", "class A {}\nclass B {}")
     );
     assert_eq!(
-      vec![("2:1-2:1".to_string(), "class A".to_string())],
+      vec![("2:1-2:1".to_string(), "class A {}".to_string())],
       produce_module_diff(
         "          \nclass B {}\nclass C {}\nclass D {}",
         "class A {}\nclass B {}\nclass C {}\nclass D {}"

--- a/crates/samlang-services/src/variable_definition.rs
+++ b/crates/samlang-services/src/variable_definition.rs
@@ -528,7 +528,7 @@ interface Foo {}
   }
 }
 
-interface Foo
+interface Foo {}
 "#,
       samlang_printer::pretty_print_source_module(&heap, 60, &renamed)
     );

--- a/tests/SortableList.sam
+++ b/tests/SortableList.sam
@@ -1,6 +1,6 @@
 import { Pair } from std.tuples;
 
-interface Useless
+interface Useless {}
 
 interface Comparable<T> : Useless {
   method compare(other: T): int


### PR DESCRIPTION
[printer] Always print `{}` even if the toplevel members are empty
