### PR TITLE
[compiler] Rename some functions with incorrect AST phase names

### DIFF
--- a/crates/samlang-compiler/src/lib.rs
+++ b/crates/samlang-compiler/src/lib.rs
@@ -21,7 +21,7 @@ pub fn compile_lir_to_wasm(
   let whole_module_string = format!(
     "(module\n{}\n{}\n)\n",
     include_str!("libsam.wat"),
-    wasm_lowering::compile_mir_to_wasm(heap, sources).pretty_print(heap, &sources.symbol_table)
+    wasm_lowering::compile_lir_to_wasm(heap, sources).pretty_print(heap, &sources.symbol_table)
   );
   let wat = wat::parse_str(&whole_module_string).unwrap();
   (whole_module_string, wat)

--- a/crates/samlang-compiler/src/lir_lowering.rs
+++ b/crates/samlang-compiler/src/lir_lowering.rs
@@ -732,7 +732,7 @@ pub fn compile_mir_to_lir(heap: &mut Heap, sources: mir::Sources) -> lir::Source
     .collect_vec();
   functions.push(generate_inc_ref_fn());
   functions.push(generate_dec_ref_fn());
-  lir_unused_name_elimination::optimize_mir_sources_by_eliminating_unused_ones(lir::Sources {
+  lir_unused_name_elimination::optimize_lir_sources_by_eliminating_unused_ones(lir::Sources {
     symbol_table,
     global_variables,
     type_definitions: type_defs,

--- a/crates/samlang-compiler/src/lir_unused_name_elimination.rs
+++ b/crates/samlang-compiler/src/lir_unused_name_elimination.rs
@@ -184,7 +184,7 @@ fn analyze_used_function_names_and_type_names(
   (used_str_names, used_fn_names, used_types)
 }
 
-pub(super) fn optimize_mir_sources_by_eliminating_unused_ones(
+pub(super) fn optimize_lir_sources_by_eliminating_unused_ones(
   Sources { symbol_table,global_variables, type_definitions, main_function_names, functions }: Sources,
 ) -> Sources {
   let (used_str_names, used_fn_names, used_types) =
@@ -223,7 +223,7 @@ mod tests {
     let heap = &mut Heap::new();
     let mut table = SymbolTable::new();
 
-    let optimized = super::optimize_mir_sources_by_eliminating_unused_ones(Sources {
+    let optimized = super::optimize_lir_sources_by_eliminating_unused_ones(Sources {
       global_variables: vec![
         hir::GlobalVariable {
           name: heap.alloc_str_for_test("bar"),

--- a/crates/samlang-compiler/src/wasm_lowering.rs
+++ b/crates/samlang-compiler/src/wasm_lowering.rs
@@ -207,12 +207,12 @@ impl<'a> LoweringManager<'a> {
       lir::Expression::IntLiteral(v) => wasm::InlineInstruction::Const(*v),
       lir::Expression::Variable(n, _) => self.get(n),
       lir::Expression::StringName(n) => {
-        let index = self.global_variables_to_pointer_mapping.get(n);
-        wasm::InlineInstruction::Const(i32::try_from(*(index.unwrap())).unwrap())
+        let index = self.global_variables_to_pointer_mapping.get(n).unwrap();
+        wasm::InlineInstruction::Const(i32::try_from(*index).unwrap())
       }
       lir::Expression::FnName(n, _) => {
-        let index = self.function_index_mapping.get(n);
-        wasm::InlineInstruction::Const(i32::try_from(*(index.unwrap())).unwrap())
+        let index = self.function_index_mapping.get(n).unwrap();
+        wasm::InlineInstruction::Const(i32::try_from(*index).unwrap())
       }
     }
   }
@@ -234,7 +234,7 @@ impl<'a> LoweringManager<'a> {
   }
 }
 
-pub(super) fn compile_mir_to_wasm(heap: &Heap, sources: &lir::Sources) -> wasm::Module {
+pub(super) fn compile_lir_to_wasm(heap: &Heap, sources: &lir::Sources) -> wasm::Module {
   let mut data_start: usize = 4096;
   let mut global_variables_to_pointer_mapping = HashMap::new();
   let mut function_index_mapping = HashMap::new();
@@ -415,7 +415,7 @@ mod tests {
       }],
     };
     let actual =
-      super::compile_mir_to_wasm(heap, &sources).pretty_print(heap, &sources.symbol_table);
+      super::compile_lir_to_wasm(heap, &sources).pretty_print(heap, &sources.symbol_table);
     let expected = r#"(type $i32_=>_i32 (func (param i32) (result i32)))
 (data (i32.const 4096) "\00\00\00\00\03\00\00\00\66\6f\6f")
 (data (i32.const 4107) "\00\00\00\00\03\00\00\00\62\61\72")


### PR DESCRIPTION
[compiler] Rename some functions with incorrect AST phase names
