### PR TITLE
[compiler] Fix invalid type parameter list

### DIFF
--- a/crates/samlang-ast/src/mir.rs
+++ b/crates/samlang-ast/src/mir.rs
@@ -54,6 +54,9 @@ impl TypeName {
     collector.push_str(&self.module_reference.encoded(heap));
     collector.push('_');
     collector.push_str(self.type_name.as_str(heap));
+    if !self.suffix.is_empty() {
+      collector.push('_');
+    }
     for t in &self.suffix {
       collector.push('_');
       match t {

--- a/crates/samlang-ast/src/wasm.rs
+++ b/crates/samlang-ast/src/wasm.rs
@@ -236,9 +236,13 @@ fn byte_digit_to_char(byte: u8) -> char {
 
 fn print_byte_vec(collector: &mut String, array: &[u8]) {
   for b in array {
-    collector.push('\\');
-    collector.push(byte_digit_to_char(b / 16));
-    collector.push(byte_digit_to_char(b % 16));
+    if b.is_ascii_alphanumeric() {
+      collector.push(*b as char);
+    } else {
+      collector.push('\\');
+      collector.push(byte_digit_to_char(b / 16));
+      collector.push(byte_digit_to_char(b % 16));
+    }
   }
 }
 

--- a/crates/samlang-compiler/src/hir_lowering.rs
+++ b/crates/samlang-compiler/src/hir_lowering.rs
@@ -1216,7 +1216,6 @@ fn compile_sources_with_generics_preserved(
               .iter()
               .cloned()
               .chain(lower_tparams(&member.decl.type_parameters))
-              .sorted()
               .collect_vec();
             let tparams_set: HashSet<_> = tparams.iter().cloned().collect();
             type_lowering_manager.generic_types = tparams_set;

--- a/crates/samlang-compiler/src/hir_string_manager.rs
+++ b/crates/samlang-compiler/src/hir_string_manager.rs
@@ -1,15 +1,15 @@
 use samlang_ast::hir::GlobalVariable;
 use samlang_heap::{Heap, PStr};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // TODO: move this to global variable since heap allows us to provide a better API
 pub(super) struct StringManager {
-  global_variable_reference_map: HashMap<PStr, GlobalVariable>,
+  global_variable_reference_map: BTreeMap<PStr, GlobalVariable>,
 }
 
 impl StringManager {
   pub(super) fn new() -> StringManager {
-    StringManager { global_variable_reference_map: HashMap::new() }
+    StringManager { global_variable_reference_map: BTreeMap::new() }
   }
 
   pub(super) fn all_global_variables(self) -> Vec<GlobalVariable> {

--- a/crates/samlang-compiler/src/lir_lowering.rs
+++ b/crates/samlang-compiler/src/lir_lowering.rs
@@ -487,7 +487,6 @@ fn generate_dec_ref_fn() -> lir::Function {
   let bitset = PStr::six_letter_literal(b"bitSet");
   let is_ref_bit_set = PStr::six_letter_literal(b"isRefB");
   let new_is_ref_bit_set = PStr::seven_letter_literal(b"isRefB2");
-  let header_offset = PStr::seven_letter_literal(b"hdrOfst");
   let byte_offset = PStr::seven_letter_literal(b"bytOfst");
 
   lir::Function {
@@ -605,15 +604,9 @@ fn generate_dec_ref_fn() -> lir::Function {
                         invert_condition: false,
                         statements: vec![
                           lir::Statement::binary(
-                            header_offset,
-                            hir::Operator::PLUS,
-                            lir::Expression::Variable(PStr::LOWER_I, lir::INT_TYPE),
-                            lir::ONE,
-                          ),
-                          lir::Statement::binary(
                             byte_offset,
                             hir::Operator::SHL,
-                            lir::Expression::Variable(header_offset, lir::INT_TYPE),
+                            lir::Expression::Variable(PStr::LOWER_I, lir::INT_TYPE),
                             lir::Expression::int(2),
                           ),
                           lir::Statement::binary(
@@ -1173,8 +1166,7 @@ function __$dec_ref(ptr: any): number {{
           }}
           let isRef = isRefB & 1;
           if (isRef) {{
-            let hdrOfst = i + 1;
-            let bytOfst = hdrOfst << 2;
+            let bytOfst = i << 2;
             let fPtr = ptr + bytOfst;
             __$dec_ref(fPtr);
           }}

--- a/crates/samlang-compiler/src/mir_constant_param_elimination.rs
+++ b/crates/samlang-compiler/src/mir_constant_param_elimination.rs
@@ -384,6 +384,7 @@ pub(super) fn rewrite_sources(mut sources: Sources) -> Sources {
         keep
       });
     }
+    debug_assert_eq!(f.parameters.len(), f.type_.argument_types.len());
     let state = RewriteState { all_functions: &all_functions, local_rewrite };
     rewrite_stmts(&state, &mut f.body);
     rewrite_expr(&state, &mut f.return_value);

--- a/crates/samlang-compiler/src/mir_generics_specialization.rs
+++ b/crates/samlang-compiler/src/mir_generics_specialization.rs
@@ -1397,12 +1397,12 @@ sources.mains = [_DUMMY_I$main]
       r#"
 const G1 = 'a';
 
-closure type DUMMY_CC__Str__Str = (_Str) -> _Str
-closure type DUMMY_CC_int__Str = (int) -> _Str
+closure type DUMMY_CC___Str__Str = (_Str) -> _Str
+closure type DUMMY_CC__int__Str = (int) -> _Str
 variant type _Str = []
 object type DUMMY_J = [int]
-variant type DUMMY_I_int__Str = [int, int]
-variant type DUMMY_I__Str__Str = [int, int]
+variant type DUMMY_I__int__Str = [int, int]
+variant type DUMMY_I___Str__Str = [int, int]
 variant type DUMMY_Enum = [Unboxed(DUMMY_J), int]
 variant type DUMMY_Enum3 = [Boxed(int, DUMMY_J), Boxed(int, DUMMY_J), int]
 variant type DUMMY_Enum2 = [Boxed(int, int), int]
@@ -1411,12 +1411,12 @@ function _DUMMY_I$main(): int {
   if 1 {
     if 0 {
     }
-    let a: DUMMY_I_int__Str = _DUMMY_I_int$creatorIA(0);
-    let a2: DUMMY_I_int__Str = _DUMMY_I__Str$creatorIA(G1);
-    let b: DUMMY_I_int__Str = _DUMMY_I__Str$creatorIB(G1);
-    _DUMMY_I_DUMMY_I_int__Str$functor_fun(G1);
-    _DUMMY_I_DUMMY_J$functor_fun(G1);
-    let v1: int = (a: DUMMY_I_int__Str)[0];
+    let a: DUMMY_I__int__Str = _DUMMY_I__int$creatorIA(0);
+    let a2: DUMMY_I__int__Str = _DUMMY_I___Str$creatorIA(G1);
+    let b: DUMMY_I__int__Str = _DUMMY_I___Str$creatorIB(G1);
+    _DUMMY_I__DUMMY_I__int__Str$functor_fun(G1);
+    _DUMMY_I__DUMMY_J$functor_fun(G1);
+    let v1: int = (a: DUMMY_I__int__Str)[0];
     let cast = (a: int) as int;
     let late_init: int;
     late_init = (a: int);
@@ -1426,8 +1426,8 @@ function _DUMMY_I$main(): int {
     let v1 = 0 + 0;
     let j: DUMMY_J = [0];
     let v2: int = (j: DUMMY_J)[0];
-    let c1: DUMMY_CC__Str__Str = Closure { fun: (_DUMMY_I__Str$creatorIA: (_Str) -> DUMMY_I__Str__Str), context: G1 };
-    let c2: DUMMY_CC_int__Str = Closure { fun: (_DUMMY_I__Str$creatorIA: (_Str) -> DUMMY_I__Str__Str), context: G1 };
+    let c1: DUMMY_CC___Str__Str = Closure { fun: (_DUMMY_I___Str$creatorIA: (_Str) -> DUMMY_I___Str__Str), context: G1 };
+    let c2: DUMMY_CC__int__Str = Closure { fun: (_DUMMY_I___Str$creatorIA: (_Str) -> DUMMY_I___Str__Str), context: G1 };
     finalV = (v2: int);
   }
   let b = 0 as DUMMY_Enum;
@@ -1475,27 +1475,27 @@ function _DUMMY_J$bar(a: DUMMY_J): int {
   return 0;
 }
 
-function _DUMMY_I_int$creatorIA(a: int): DUMMY_I_int__Str {
-  let v: DUMMY_I_int__Str = [0, (a: int)];
-  return (v: DUMMY_I_int__Str);
+function _DUMMY_I__int$creatorIA(a: int): DUMMY_I__int__Str {
+  let v: DUMMY_I__int__Str = [0, (a: int)];
+  return (v: DUMMY_I__int__Str);
 }
 
-function _DUMMY_I__Str$creatorIA(a: _Str): DUMMY_I__Str__Str {
-  let v: DUMMY_I__Str__Str = [0, (a: _Str)];
-  return (v: DUMMY_I__Str__Str);
+function _DUMMY_I___Str$creatorIA(a: _Str): DUMMY_I___Str__Str {
+  let v: DUMMY_I___Str__Str = [0, (a: _Str)];
+  return (v: DUMMY_I___Str__Str);
 }
 
-function _DUMMY_I__Str$creatorIB(b: _Str): DUMMY_I_int__Str {
-  let v: DUMMY_I_int__Str = [1, (b: _Str)];
-  return (v: DUMMY_I_int__Str);
+function _DUMMY_I___Str$creatorIB(b: _Str): DUMMY_I__int__Str {
+  let v: DUMMY_I__int__Str = [1, (b: _Str)];
+  return (v: DUMMY_I__int__Str);
 }
 
-function _DUMMY_I_DUMMY_I_int__Str$functor_fun(a: DUMMY_I_int__Str): int {
-  _DUMMY_I_int__Str$bar(0);
+function _DUMMY_I__DUMMY_I__int__Str$functor_fun(a: DUMMY_I__int__Str): int {
+  _DUMMY_I__int__Str$bar(0);
   return 0;
 }
 
-function _DUMMY_I_DUMMY_J$functor_fun(a: DUMMY_J): int {
+function _DUMMY_I__DUMMY_J$functor_fun(a: DUMMY_J): int {
   _DUMMY_J$bar(0);
   return 0;
 }
@@ -1623,12 +1623,12 @@ sources.mains = [_DUMMY_I$main]"#,
       },
       heap,
       r#"
-object type DUMMY_J = [DUMMY_I_int_int]
-variant type DUMMY_I_int_int = [int, int]
+object type DUMMY_J = [DUMMY_I__int_int]
+variant type DUMMY_I__int_int = [int, int]
 variant type DUMMY_StrOption = [Unboxed(DUMMY_K), int]
 variant type DUMMY_K = [Boxed(int, int), Boxed(int, int)]
 function _DUMMY_I$creatorJ(): DUMMY_J {
-  let v1: DUMMY_I_int_int = [];
+  let v1: DUMMY_I__int_int = [];
   let v2: DUMMY_J = [0, 0];
   return (v2: DUMMY_J);
 }

--- a/crates/samlang-compiler/src/wasm_lowering.rs
+++ b/crates/samlang-compiler/src/wasm_lowering.rs
@@ -247,6 +247,10 @@ pub(super) fn compile_lir_to_wasm(heap: &Heap, sources: &lir::Sources) -> wasm::
     let global_variable = wasm::GlobalData { constant_pointer: data_start, bytes };
     global_variables_to_pointer_mapping.insert(*name, data_start);
     data_start += content_str.len() + 8;
+    let pad = data_start % 8;
+    if pad != 0 {
+      data_start += 8 - pad;
+    }
     global_variables.push(global_variable);
   }
   for (i, f) in sources.functions.iter().enumerate() {
@@ -417,8 +421,8 @@ mod tests {
     let actual =
       super::compile_lir_to_wasm(heap, &sources).pretty_print(heap, &sources.symbol_table);
     let expected = r#"(type $i32_=>_i32 (func (param i32) (result i32)))
-(data (i32.const 4096) "\00\00\00\00\03\00\00\00\66\6f\6f")
-(data (i32.const 4107) "\00\00\00\00\03\00\00\00\62\61\72")
+(data (i32.const 4096) "\00\00\00\00\03\00\00\00foo")
+(data (i32.const 4112) "\00\00\00\00\03\00\00\00bar")
 (table $0 1 funcref)
 (elem $0 (i32.const 0) $__$main)
 (func $__$main (param $bar i32) (result i32)


### PR DESCRIPTION
[compiler] Fix invalid type parameter list

We should not sort parameter list, but instead always following the order of class tparams + function tparams. Otherwise, we will get inconsistent types and mess up GC.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1159).
* #1163
* #1162
* #1161
* #1160
* __->__ #1159