### PR TITLE
[parser] Reorganize source parser code into smaller inline mods

### DIFF
--- a/crates/samlang-ast/src/mir.rs
+++ b/crates/samlang-ast/src/mir.rs
@@ -54,6 +54,9 @@ impl TypeName {
     collector.push_str(&self.module_reference.encoded(heap));
     collector.push('_');
     collector.push_str(self.type_name.as_str(heap));
+    if !self.suffix.is_empty() {
+      collector.push('_');
+    }
     for t in &self.suffix {
       collector.push('_');
       match t {

--- a/crates/samlang-ast/src/wasm.rs
+++ b/crates/samlang-ast/src/wasm.rs
@@ -236,9 +236,13 @@ fn byte_digit_to_char(byte: u8) -> char {
 
 fn print_byte_vec(collector: &mut String, array: &[u8]) {
   for b in array {
-    collector.push('\\');
-    collector.push(byte_digit_to_char(b / 16));
-    collector.push(byte_digit_to_char(b % 16));
+    if b.is_ascii_alphanumeric() {
+      collector.push(*b as char);
+    } else {
+      collector.push('\\');
+      collector.push(byte_digit_to_char(b / 16));
+      collector.push(byte_digit_to_char(b % 16));
+    }
   }
 }
 

--- a/crates/samlang-checker/src/pattern_matching.rs
+++ b/crates/samlang-checker/src/pattern_matching.rs
@@ -216,7 +216,6 @@ fn convert_into_specialized_matrix_row(
           // Different constructors. Skip
         }
         _ => {
-          debug_assert_eq!(rs_len, rs.len());
           new_rows.push(PatternVector(rs.clone().append(p_row.rest())));
         }
       }

--- a/crates/samlang-compiler/src/hir_lowering.rs
+++ b/crates/samlang-compiler/src/hir_lowering.rs
@@ -1216,7 +1216,6 @@ fn compile_sources_with_generics_preserved(
               .iter()
               .cloned()
               .chain(lower_tparams(&member.decl.type_parameters))
-              .sorted()
               .collect_vec();
             let tparams_set: HashSet<_> = tparams.iter().cloned().collect();
             type_lowering_manager.generic_types = tparams_set;

--- a/crates/samlang-compiler/src/hir_string_manager.rs
+++ b/crates/samlang-compiler/src/hir_string_manager.rs
@@ -1,15 +1,15 @@
 use samlang_ast::hir::GlobalVariable;
 use samlang_heap::{Heap, PStr};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // TODO: move this to global variable since heap allows us to provide a better API
 pub(super) struct StringManager {
-  global_variable_reference_map: HashMap<PStr, GlobalVariable>,
+  global_variable_reference_map: BTreeMap<PStr, GlobalVariable>,
 }
 
 impl StringManager {
   pub(super) fn new() -> StringManager {
-    StringManager { global_variable_reference_map: HashMap::new() }
+    StringManager { global_variable_reference_map: BTreeMap::new() }
   }
 
   pub(super) fn all_global_variables(self) -> Vec<GlobalVariable> {

--- a/crates/samlang-compiler/src/lir_lowering.rs
+++ b/crates/samlang-compiler/src/lir_lowering.rs
@@ -487,7 +487,6 @@ fn generate_dec_ref_fn() -> lir::Function {
   let bitset = PStr::six_letter_literal(b"bitSet");
   let is_ref_bit_set = PStr::six_letter_literal(b"isRefB");
   let new_is_ref_bit_set = PStr::seven_letter_literal(b"isRefB2");
-  let header_offset = PStr::seven_letter_literal(b"hdrOfst");
   let byte_offset = PStr::seven_letter_literal(b"bytOfst");
 
   lir::Function {
@@ -605,15 +604,9 @@ fn generate_dec_ref_fn() -> lir::Function {
                         invert_condition: false,
                         statements: vec![
                           lir::Statement::binary(
-                            header_offset,
-                            hir::Operator::PLUS,
-                            lir::Expression::Variable(PStr::LOWER_I, lir::INT_TYPE),
-                            lir::ONE,
-                          ),
-                          lir::Statement::binary(
                             byte_offset,
                             hir::Operator::SHL,
-                            lir::Expression::Variable(header_offset, lir::INT_TYPE),
+                            lir::Expression::Variable(PStr::LOWER_I, lir::INT_TYPE),
                             lir::Expression::int(2),
                           ),
                           lir::Statement::binary(
@@ -1173,8 +1166,7 @@ function __$dec_ref(ptr: any): number {{
           }}
           let isRef = isRefB & 1;
           if (isRef) {{
-            let hdrOfst = i + 1;
-            let bytOfst = hdrOfst << 2;
+            let bytOfst = i << 2;
             let fPtr = ptr + bytOfst;
             __$dec_ref(fPtr);
           }}

--- a/crates/samlang-compiler/src/mir_constant_param_elimination.rs
+++ b/crates/samlang-compiler/src/mir_constant_param_elimination.rs
@@ -384,6 +384,7 @@ pub(super) fn rewrite_sources(mut sources: Sources) -> Sources {
         keep
       });
     }
+    debug_assert_eq!(f.parameters.len(), f.type_.argument_types.len());
     let state = RewriteState { all_functions: &all_functions, local_rewrite };
     rewrite_stmts(&state, &mut f.body);
     rewrite_expr(&state, &mut f.return_value);

--- a/crates/samlang-compiler/src/mir_generics_specialization.rs
+++ b/crates/samlang-compiler/src/mir_generics_specialization.rs
@@ -1397,12 +1397,12 @@ sources.mains = [_DUMMY_I$main]
       r#"
 const G1 = 'a';
 
-closure type DUMMY_CC__Str__Str = (_Str) -> _Str
-closure type DUMMY_CC_int__Str = (int) -> _Str
+closure type DUMMY_CC___Str__Str = (_Str) -> _Str
+closure type DUMMY_CC__int__Str = (int) -> _Str
 variant type _Str = []
 object type DUMMY_J = [int]
-variant type DUMMY_I_int__Str = [int, int]
-variant type DUMMY_I__Str__Str = [int, int]
+variant type DUMMY_I__int__Str = [int, int]
+variant type DUMMY_I___Str__Str = [int, int]
 variant type DUMMY_Enum = [Unboxed(DUMMY_J), int]
 variant type DUMMY_Enum3 = [Boxed(int, DUMMY_J), Boxed(int, DUMMY_J), int]
 variant type DUMMY_Enum2 = [Boxed(int, int), int]
@@ -1411,12 +1411,12 @@ function _DUMMY_I$main(): int {
   if 1 {
     if 0 {
     }
-    let a: DUMMY_I_int__Str = _DUMMY_I_int$creatorIA(0);
-    let a2: DUMMY_I_int__Str = _DUMMY_I__Str$creatorIA(G1);
-    let b: DUMMY_I_int__Str = _DUMMY_I__Str$creatorIB(G1);
-    _DUMMY_I_DUMMY_I_int__Str$functor_fun(G1);
-    _DUMMY_I_DUMMY_J$functor_fun(G1);
-    let v1: int = (a: DUMMY_I_int__Str)[0];
+    let a: DUMMY_I__int__Str = _DUMMY_I__int$creatorIA(0);
+    let a2: DUMMY_I__int__Str = _DUMMY_I___Str$creatorIA(G1);
+    let b: DUMMY_I__int__Str = _DUMMY_I___Str$creatorIB(G1);
+    _DUMMY_I__DUMMY_I__int__Str$functor_fun(G1);
+    _DUMMY_I__DUMMY_J$functor_fun(G1);
+    let v1: int = (a: DUMMY_I__int__Str)[0];
     let cast = (a: int) as int;
     let late_init: int;
     late_init = (a: int);
@@ -1426,8 +1426,8 @@ function _DUMMY_I$main(): int {
     let v1 = 0 + 0;
     let j: DUMMY_J = [0];
     let v2: int = (j: DUMMY_J)[0];
-    let c1: DUMMY_CC__Str__Str = Closure { fun: (_DUMMY_I__Str$creatorIA: (_Str) -> DUMMY_I__Str__Str), context: G1 };
-    let c2: DUMMY_CC_int__Str = Closure { fun: (_DUMMY_I__Str$creatorIA: (_Str) -> DUMMY_I__Str__Str), context: G1 };
+    let c1: DUMMY_CC___Str__Str = Closure { fun: (_DUMMY_I___Str$creatorIA: (_Str) -> DUMMY_I___Str__Str), context: G1 };
+    let c2: DUMMY_CC__int__Str = Closure { fun: (_DUMMY_I___Str$creatorIA: (_Str) -> DUMMY_I___Str__Str), context: G1 };
     finalV = (v2: int);
   }
   let b = 0 as DUMMY_Enum;
@@ -1475,27 +1475,27 @@ function _DUMMY_J$bar(a: DUMMY_J): int {
   return 0;
 }
 
-function _DUMMY_I_int$creatorIA(a: int): DUMMY_I_int__Str {
-  let v: DUMMY_I_int__Str = [0, (a: int)];
-  return (v: DUMMY_I_int__Str);
+function _DUMMY_I__int$creatorIA(a: int): DUMMY_I__int__Str {
+  let v: DUMMY_I__int__Str = [0, (a: int)];
+  return (v: DUMMY_I__int__Str);
 }
 
-function _DUMMY_I__Str$creatorIA(a: _Str): DUMMY_I__Str__Str {
-  let v: DUMMY_I__Str__Str = [0, (a: _Str)];
-  return (v: DUMMY_I__Str__Str);
+function _DUMMY_I___Str$creatorIA(a: _Str): DUMMY_I___Str__Str {
+  let v: DUMMY_I___Str__Str = [0, (a: _Str)];
+  return (v: DUMMY_I___Str__Str);
 }
 
-function _DUMMY_I__Str$creatorIB(b: _Str): DUMMY_I_int__Str {
-  let v: DUMMY_I_int__Str = [1, (b: _Str)];
-  return (v: DUMMY_I_int__Str);
+function _DUMMY_I___Str$creatorIB(b: _Str): DUMMY_I__int__Str {
+  let v: DUMMY_I__int__Str = [1, (b: _Str)];
+  return (v: DUMMY_I__int__Str);
 }
 
-function _DUMMY_I_DUMMY_I_int__Str$functor_fun(a: DUMMY_I_int__Str): int {
-  _DUMMY_I_int__Str$bar(0);
+function _DUMMY_I__DUMMY_I__int__Str$functor_fun(a: DUMMY_I__int__Str): int {
+  _DUMMY_I__int__Str$bar(0);
   return 0;
 }
 
-function _DUMMY_I_DUMMY_J$functor_fun(a: DUMMY_J): int {
+function _DUMMY_I__DUMMY_J$functor_fun(a: DUMMY_J): int {
   _DUMMY_J$bar(0);
   return 0;
 }
@@ -1623,12 +1623,12 @@ sources.mains = [_DUMMY_I$main]"#,
       },
       heap,
       r#"
-object type DUMMY_J = [DUMMY_I_int_int]
-variant type DUMMY_I_int_int = [int, int]
+object type DUMMY_J = [DUMMY_I__int_int]
+variant type DUMMY_I__int_int = [int, int]
 variant type DUMMY_StrOption = [Unboxed(DUMMY_K), int]
 variant type DUMMY_K = [Boxed(int, int), Boxed(int, int)]
 function _DUMMY_I$creatorJ(): DUMMY_J {
-  let v1: DUMMY_I_int_int = [];
+  let v1: DUMMY_I__int_int = [];
   let v2: DUMMY_J = [0, 0];
   return (v2: DUMMY_J);
 }

--- a/crates/samlang-compiler/src/wasm_lowering.rs
+++ b/crates/samlang-compiler/src/wasm_lowering.rs
@@ -247,6 +247,10 @@ pub(super) fn compile_lir_to_wasm(heap: &Heap, sources: &lir::Sources) -> wasm::
     let global_variable = wasm::GlobalData { constant_pointer: data_start, bytes };
     global_variables_to_pointer_mapping.insert(*name, data_start);
     data_start += content_str.len() + 8;
+    let pad = data_start % 8;
+    if pad != 0 {
+      data_start += 8 - pad;
+    }
     global_variables.push(global_variable);
   }
   for (i, f) in sources.functions.iter().enumerate() {
@@ -417,8 +421,8 @@ mod tests {
     let actual =
       super::compile_lir_to_wasm(heap, &sources).pretty_print(heap, &sources.symbol_table);
     let expected = r#"(type $i32_=>_i32 (func (param i32) (result i32)))
-(data (i32.const 4096) "\00\00\00\00\03\00\00\00\66\6f\6f")
-(data (i32.const 4107) "\00\00\00\00\03\00\00\00\62\61\72")
+(data (i32.const 4096) "\00\00\00\00\03\00\00\00foo")
+(data (i32.const 4112) "\00\00\00\00\03\00\00\00bar")
 (table $0 1 funcref)
 (elem $0 (i32.const 0) $__$main)
 (func $__$main (param $bar i32) (result i32)

--- a/crates/samlang-parser/src/lib.rs
+++ b/crates/samlang-parser/src/lib.rs
@@ -28,7 +28,7 @@ pub fn parse_source_module_from_text(
     module_reference,
     builtins,
   );
-  parser.parse_module()
+  source_parser::parse_module(parser)
 }
 
 pub fn parse_source_expression_from_text(
@@ -45,7 +45,7 @@ pub fn parse_source_expression_from_text(
     module_reference,
     builtins,
   );
-  parser.parse_expression_with_comment_store()
+  source_parser::parse_expression_with_comment_store(parser)
 }
 
 pub fn builtin_std_raw_sources(heap: &mut Heap) -> HashMap<ModuleReference, String> {

--- a/crates/samlang-parser/src/source_parser.rs
+++ b/crates/samlang-parser/src/source_parser.rs
@@ -1,24 +1,15 @@
 use super::lexer::{Keyword, Token, TokenContent, TokenOp};
-use itertools::Itertools;
-use samlang_ast::{
-  source::{expr::IfElseCondition, *},
-  Location, Position,
-};
+use samlang_ast::{source::*, Location, Position};
 use samlang_errors::ErrorSet;
 use samlang_heap::{Heap, ModuleReference, PStr};
 use std::{
   cmp,
   collections::{HashMap, HashSet},
-  rc::Rc,
   vec,
 };
 
 const MAX_STRUCT_SIZE: usize = 16;
 const MAX_VARIANT_SIZE: usize = 15;
-
-fn unescape_quotes(source: &str) -> String {
-  source.replace("\\\"", "\"")
-}
 
 pub(super) struct SourceParser<'a> {
   tokens: Vec<Token>,
@@ -33,7 +24,25 @@ pub(super) struct SourceParser<'a> {
 }
 
 impl<'a> SourceParser<'a> {
-  // SECTION 1: Base Methods
+  pub(super) fn new(
+    tokens: Vec<Token>,
+    heap: &'a mut Heap,
+    error_set: &'a mut ErrorSet,
+    module_reference: ModuleReference,
+    builtin_classes: HashSet<PStr>,
+  ) -> SourceParser<'a> {
+    SourceParser {
+      tokens,
+      comments_store: CommentStore::new(),
+      module_reference,
+      heap,
+      error_set,
+      builtin_classes,
+      position: 0,
+      class_source_map: HashMap::new(),
+      available_tparams: HashSet::new(),
+    }
+  }
 
   fn last_location(&self) -> Location {
     if self.position == 0 {
@@ -223,1331 +232,6 @@ impl<'a> SourceParser<'a> {
     collector
   }
 
-  // SECTION 2: Source Parser
-
-  pub(super) fn new(
-    tokens: Vec<Token>,
-    heap: &'a mut Heap,
-    error_set: &'a mut ErrorSet,
-    module_reference: ModuleReference,
-    builtin_classes: HashSet<PStr>,
-  ) -> SourceParser<'a> {
-    SourceParser {
-      tokens,
-      comments_store: CommentStore::new(),
-      module_reference,
-      heap,
-      error_set,
-      builtin_classes,
-      position: 0,
-      class_source_map: HashMap::new(),
-      available_tparams: HashSet::new(),
-    }
-  }
-
-  pub(super) fn parse_module(mut self) -> Module<()> {
-    let mut imports = vec![];
-    while let Token(import_start, TokenContent::Keyword(Keyword::IMPORT)) = self.peek() {
-      self.consume();
-      self.assert_and_consume_operator(TokenOp::LBRACE);
-      let imported_members = self.parse_comma_separated_list_with_end_token(
-        TokenOp::RBRACE,
-        &mut SourceParser::parse_upper_id,
-      );
-      self.assert_and_consume_operator(TokenOp::RBRACE);
-      self.assert_and_consume_keyword(Keyword::FROM);
-      let import_loc_start = self.peek().0;
-      let imported_module_parts = {
-        let mut collector = vec![self.assert_and_consume_identifier().1];
-        while let Token(_, TokenContent::Operator(TokenOp::DOT)) = self.peek() {
-          self.consume();
-          collector.push(self.assert_and_consume_identifier().1);
-        }
-        collector
-      };
-      let imported_module = self.heap.alloc_module_reference(imported_module_parts);
-      let imported_module_loc = import_loc_start.union(&self.last_location());
-      for variable in imported_members.iter() {
-        self.class_source_map.insert(variable.name, imported_module);
-      }
-      let loc =
-        if let Token(semicolon_loc, TokenContent::Operator(TokenOp::SEMICOLON)) = self.peek() {
-          self.consume();
-          import_start.union(&semicolon_loc)
-        } else {
-          import_start.union(&imported_module_loc)
-        };
-      imports.push(ModuleMembersImport {
-        loc,
-        imported_members,
-        imported_module,
-        imported_module_loc,
-      });
-    }
-
-    let mut toplevels = vec![];
-    'outer: loop {
-      if let TokenContent::EOF = self.peek().1 {
-        break;
-      }
-      loop {
-        match self.peek() {
-          Token(
-            _,
-            TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE),
-          ) => break,
-          Token(_, TokenContent::EOF) => break 'outer,
-          Token(loc, content) => {
-            self.consume();
-            self.report(
-              loc,
-              format!(
-                "Unexpected token among the classes and interfaces: {}",
-                content.pretty_print(self.heap)
-              ),
-            )
-          }
-        }
-      }
-      toplevels.push(self.parse_toplevel());
-    }
-    let comments = self.collect_preceding_comments();
-    let trailing_comments = self.comments_store.create_comment_reference(comments);
-
-    Module { comment_store: self.comments_store, imports, toplevels, trailing_comments }
-  }
-
-  fn parse_toplevel(&mut self) -> Toplevel<()> {
-    self.unconsume_comments();
-    let is_private = if let TokenContent::Keyword(Keyword::PRIVATE) = self.peek().1 {
-      self.consume();
-      true
-    } else {
-      false
-    };
-    let is_class = matches!(self.peek().1, TokenContent::Keyword(Keyword::CLASS));
-    if is_private {
-      self.unconsume();
-    }
-    if is_class {
-      Toplevel::Class(self.parse_class())
-    } else {
-      Toplevel::Interface(self.parse_interface())
-    }
-  }
-
-  pub(super) fn parse_class(&mut self) -> ClassDefinition<()> {
-    let associated_comments = self.collect_preceding_comments();
-    let (mut loc, private) =
-      if let Token(loc, TokenContent::Keyword(Keyword::PRIVATE)) = self.peek() {
-        self.consume();
-        self.assert_and_consume_keyword(Keyword::CLASS);
-        (loc, true)
-      } else {
-        (self.assert_and_consume_keyword(Keyword::CLASS), false)
-      };
-    let name = self.parse_upper_id();
-    loc = loc.union(&name.loc);
-    let (type_param_loc_start, type_param_loc_end, mut type_parameters) =
-      if let Token(loc_start, TokenContent::Operator(TokenOp::LT)) = self.peek() {
-        self.consume();
-        let type_params = self.parse_comma_separated_list_with_end_token(
-          TokenOp::GT,
-          &mut SourceParser::parse_type_parameter,
-        );
-        let loc_end = self.assert_and_consume_operator(TokenOp::GT);
-        (Some(loc_start), Some(loc_end), type_params)
-      } else {
-        (None, None, vec![])
-      };
-    self.available_tparams = type_parameters.iter().map(|it| it.name.name).collect();
-    self.fix_tparams_with_generic_annot(&mut type_parameters);
-    let (type_definition, extends_or_implements_nodes) = match self.peek().1 {
-      TokenContent::Operator(TokenOp::LBRACE | TokenOp::COLON)
-      | TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE) => {
-        let nodes = if let TokenContent::Operator(TokenOp::COLON) = self.peek().1 {
-          self.consume();
-          let nodes = self.parse_extends_or_implements_nodes();
-          loc = loc.union(&nodes.last().unwrap().location);
-          nodes
-        } else {
-          vec![]
-        };
-        loc = if let Some(loc_end) = type_param_loc_end { loc.union(&loc_end) } else { loc };
-        let type_def = TypeDefinition::Struct { loc: self.peek().0, fields: vec![] };
-        (type_def, nodes)
-      }
-      _ => {
-        let type_def_loc_start = self.assert_and_consume_operator(TokenOp::LPAREN);
-        let mut type_def = self.parse_type_definition_inner();
-        let type_def_loc_end = self.assert_and_consume_operator(TokenOp::RPAREN);
-        let type_def_loc =
-          type_param_loc_start.unwrap_or(type_def_loc_start).union(&type_def_loc_end);
-        match &mut type_def {
-          TypeDefinition::Struct { loc, fields: _ } => *loc = type_def_loc,
-          TypeDefinition::Enum { loc, variants: _ } => *loc = type_def_loc,
-        }
-        loc = loc.union(&type_def_loc_end);
-        let nodes = if let TokenContent::Operator(TokenOp::COLON) = self.peek().1 {
-          self.consume();
-          let nodes = self.parse_extends_or_implements_nodes();
-          loc = loc.union(&nodes.last().unwrap().location);
-          nodes
-        } else {
-          vec![]
-        };
-        (type_def, nodes)
-      }
-    };
-    let mut members = vec![];
-    if !self.peeked_class_or_interface_start() {
-      self.assert_and_consume_operator(TokenOp::LBRACE);
-      while let TokenContent::Keyword(Keyword::FUNCTION | Keyword::METHOD | Keyword::PRIVATE) =
-        self.peek().1
-      {
-        let saved_upper_type_parameters = self.available_tparams.clone();
-        members.push(self.parse_class_member_definition());
-        self.available_tparams = saved_upper_type_parameters;
-      }
-      loc = loc.union(&self.assert_and_consume_operator(TokenOp::RBRACE));
-    }
-    InterfaceDeclarationCommon {
-      loc,
-      associated_comments: self.comments_store.create_comment_reference(associated_comments),
-      private,
-      name,
-      type_parameters,
-      extends_or_implements_nodes,
-      type_definition,
-      members,
-    }
-  }
-
-  pub(super) fn parse_interface(&mut self) -> InterfaceDeclaration {
-    let associated_comments = self.collect_preceding_comments();
-    let (mut loc, private) =
-      if let Token(loc, TokenContent::Keyword(Keyword::PRIVATE)) = self.peek() {
-        self.consume();
-        self.assert_and_consume_keyword(Keyword::INTERFACE);
-        (loc, true)
-      } else {
-        (self.assert_and_consume_keyword(Keyword::INTERFACE), false)
-      };
-    let name = self.parse_upper_id();
-    let mut type_parameters = if let TokenContent::Operator(TokenOp::LT) = self.peek().1 {
-      self.consume();
-      let type_params = self.parse_comma_separated_list_with_end_token(
-        TokenOp::GT,
-        &mut SourceParser::parse_type_parameter,
-      );
-      loc = loc.union(&self.assert_and_consume_operator(TokenOp::GT));
-      type_params
-    } else {
-      vec![]
-    };
-    self.available_tparams = type_parameters.iter().map(|it| it.name.name).collect();
-    self.fix_tparams_with_generic_annot(&mut type_parameters);
-    let extends_or_implements_nodes = if let TokenContent::Operator(TokenOp::COLON) = self.peek().1
-    {
-      self.consume();
-      let nodes = self.parse_extends_or_implements_nodes();
-      loc = loc.union(&nodes.last().unwrap().location);
-      nodes
-    } else {
-      vec![]
-    };
-    let mut members = vec![];
-    if let TokenContent::Operator(TokenOp::LBRACE) = self.peek().1 {
-      self.consume();
-      while let TokenContent::Keyword(Keyword::FUNCTION | Keyword::METHOD | Keyword::PRIVATE) =
-        self.peek().1
-      {
-        let saved_upper_type_parameters = self.available_tparams.clone();
-        members.push(self.parse_class_member_declaration());
-        self.available_tparams = saved_upper_type_parameters;
-      }
-      loc = loc.union(&self.assert_and_consume_operator(TokenOp::RBRACE));
-    }
-    InterfaceDeclarationCommon {
-      loc,
-      associated_comments: self.comments_store.create_comment_reference(associated_comments),
-      private,
-      name,
-      type_parameters,
-      extends_or_implements_nodes,
-      type_definition: (),
-      members,
-    }
-  }
-
-  fn parse_extends_or_implements_nodes(&mut self) -> Vec<annotation::Id> {
-    let id = self.parse_upper_id();
-    let mut collector = vec![self.parse_identifier_annot(id)];
-    while let Token(_, TokenContent::Operator(TokenOp::COMMA)) = self.peek() {
-      self.consume();
-      let id = self.parse_upper_id();
-      collector.push(self.parse_identifier_annot(id));
-    }
-    collector
-  }
-
-  fn parse_type_definition_inner(&mut self) -> TypeDefinition {
-    if let Token(_, TokenContent::UpperId(_)) = self.peek() {
-      let mut variants = self.parse_comma_separated_list_with_end_token(
-        TokenOp::RPAREN,
-        &mut SourceParser::parse_variant_definition,
-      );
-      variants.truncate(MAX_VARIANT_SIZE);
-      // Location is later patched by the caller
-      TypeDefinition::Enum { loc: Location::dummy(), variants }
-    } else {
-      let mut fields = self.parse_comma_separated_list_with_end_token(
-        TokenOp::RPAREN,
-        &mut Self::parse_field_definition,
-      );
-      if let Some(node) = fields.get(MAX_STRUCT_SIZE) {
-        self.error_set.report_invalid_syntax_error(
-          node.name.loc,
-          format!("Maximum allowed field size is {MAX_STRUCT_SIZE}"),
-        );
-      }
-      fields.truncate(MAX_STRUCT_SIZE);
-      // Location is later patched by the caller
-      TypeDefinition::Struct { loc: Location::dummy(), fields }
-    }
-  }
-
-  fn parse_field_definition(&mut self) -> FieldDefinition {
-    let mut is_public = true;
-    if let TokenContent::Keyword(Keyword::PRIVATE) = self.peek().1 {
-      is_public = false;
-      self.consume();
-    }
-    self.assert_and_consume_keyword(Keyword::VAL);
-    let name = self.parse_lower_id();
-    self.assert_and_consume_operator(TokenOp::COLON);
-    let annotation = self.parse_annotation();
-    FieldDefinition { name, annotation, is_public }
-  }
-
-  fn parse_variant_definition(&mut self) -> VariantDefinition {
-    let name = self.parse_upper_id();
-    if let Token(_, TokenContent::Operator(TokenOp::LPAREN)) = self.peek() {
-      self.consume();
-      let associated_data_types = self.parse_comma_separated_list_with_end_token(
-        TokenOp::RPAREN,
-        &mut SourceParser::parse_annotation,
-      );
-
-      if let Some(node) = associated_data_types.get(MAX_VARIANT_SIZE) {
-        self.error_set.report_invalid_syntax_error(
-          node.location(),
-          format!("Maximum allowed field size is {MAX_VARIANT_SIZE}"),
-        );
-      }
-      self.assert_and_consume_operator(TokenOp::RPAREN);
-      VariantDefinition { name, associated_data_types }
-    } else {
-      VariantDefinition { name, associated_data_types: vec![] }
-    }
-  }
-
-  fn peeked_class_or_interface_start(&mut self) -> bool {
-    matches!(
-      self.peek().1,
-      TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE)
-    )
-  }
-
-  pub(super) fn parse_class_member_definition(&mut self) -> ClassMemberDefinition<()> {
-    let mut decl = self.parse_class_member_declaration_common(true);
-    self.assert_and_consume_operator(TokenOp::ASSIGN);
-    let body = self.parse_expression();
-    decl.loc = decl.loc.union(&body.loc());
-    ClassMemberDefinition { decl, body }
-  }
-
-  pub(super) fn parse_class_member_declaration(&mut self) -> ClassMemberDeclaration {
-    self.parse_class_member_declaration_common(false)
-  }
-
-  fn parse_class_member_declaration_common(
-    &mut self,
-    allow_private: bool,
-  ) -> ClassMemberDeclaration {
-    let associated_comments = self.collect_preceding_comments();
-    let mut is_public = true;
-    let mut is_method = true;
-    let mut peeked = self.peek();
-    if let Token(peeked_loc, TokenContent::Keyword(Keyword::PRIVATE)) = peeked {
-      if allow_private {
-        is_public = false;
-      } else {
-        self.report(peeked_loc, "Unexpected `private`".to_string());
-      }
-      self.consume();
-      peeked = self.peek();
-    }
-    let start_loc = &peeked.0;
-    if let Token(_, TokenContent::Keyword(Keyword::FUNCTION)) = &peeked {
-      is_method = false;
-      self.consume();
-    } else {
-      self.assert_and_consume_keyword(Keyword::METHOD);
-    }
-    if !is_method {
-      self.available_tparams = HashSet::new();
-    }
-    let mut type_parameters = if let TokenContent::Operator(TokenOp::LT) = self.peek().1 {
-      self.consume();
-      let type_params = self.parse_comma_separated_list_with_end_token(
-        TokenOp::GT,
-        &mut SourceParser::parse_type_parameter,
-      );
-      self.assert_and_consume_operator(TokenOp::GT);
-      type_params
-    } else {
-      vec![]
-    };
-    self.available_tparams.extend(type_parameters.iter().map(|it| it.name.name));
-    self.fix_tparams_with_generic_annot(&mut type_parameters);
-    let name = self.parse_lower_id();
-    let fun_type_loc_start = self.assert_and_consume_operator(TokenOp::LPAREN);
-    let parameters = if let TokenContent::Operator(TokenOp::RPAREN) = self.peek().1 {
-      vec![]
-    } else {
-      self.parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut Self::parse_annotated_id)
-    };
-    self.assert_and_consume_operator(TokenOp::RPAREN);
-    self.assert_and_consume_operator(TokenOp::COLON);
-    let return_type = self.parse_annotation();
-    let fun_type_loc = fun_type_loc_start.union(&return_type.location());
-    ClassMemberDeclaration {
-      loc: start_loc.union(&fun_type_loc),
-      associated_comments: self.comments_store.create_comment_reference(associated_comments),
-      is_public,
-      is_method,
-      name,
-      type_parameters: Rc::new(type_parameters),
-      type_: annotation::Function {
-        location: fun_type_loc,
-        associated_comments: NO_COMMENT_REFERENCE,
-        argument_types: parameters.iter().map(|it| it.annotation.clone()).collect_vec(),
-        return_type: Box::new(return_type),
-      },
-      parameters: Rc::new(parameters),
-    }
-  }
-
-  fn parse_type_parameter(&mut self) -> TypeParameter {
-    let name = &self.parse_upper_id();
-    let (bound, loc) = if let Token(_, TokenContent::Operator(TokenOp::COLON)) = self.peek() {
-      self.consume();
-      let id = self.parse_upper_id();
-      let bound = self.parse_identifier_annot(id);
-      let loc = name.loc.union(&bound.location);
-      (Some(bound), loc)
-    } else {
-      (None, name.loc)
-    };
-    TypeParameter { loc, name: *name, bound }
-  }
-
-  pub(super) fn parse_expression_with_comment_store(mut self) -> (CommentStore, expr::E<()>) {
-    let e = self.parse_expression();
-    (self.comments_store, e)
-  }
-
-  fn parse_expression(&mut self) -> expr::E<()> {
-    self.parse_match()
-  }
-
-  fn parse_expression_with_ending_comments(&mut self) -> expr::E<()> {
-    let mut expr = self.parse_expression();
-    let mut new_comments = self.collect_preceding_comments();
-    let common = expr.common_mut();
-    let associated_comments = self.comments_store.get_mut(common.associated_comments);
-    match associated_comments {
-      CommentsNode::NoComment => {
-        common.associated_comments = self.comments_store.create_comment_reference(new_comments);
-      }
-      CommentsNode::Comments(existing_loc, existing_comments) => {
-        let new_loc = new_comments.iter().fold(*existing_loc, |l1, c| l1.union(&c.location));
-        *existing_loc = new_loc;
-        existing_comments.append(&mut new_comments);
-      }
-    }
-    expr
-  }
-
-  fn parse_match(&mut self) -> expr::E<()> {
-    let associated_comments = self.collect_preceding_comments();
-    if let Token(peeked_loc, TokenContent::Keyword(Keyword::MATCH)) = self.peek() {
-      self.consume();
-      let match_expression = self.parse_expression_with_ending_comments();
-      self.assert_and_consume_operator(TokenOp::LBRACE);
-      let mut matching_list = vec![self.parse_pattern_to_expression()];
-      while matches!(
-        self.peek().1,
-        TokenContent::Operator(TokenOp::LBRACE | TokenOp::LPAREN | TokenOp::UNDERSCORE)
-          | TokenContent::LowerId(_)
-          | TokenContent::UpperId(_)
-      ) {
-        matching_list.push(self.parse_pattern_to_expression());
-      }
-      let loc = peeked_loc.union(&self.assert_and_consume_operator(TokenOp::RBRACE));
-      expr::E::Match(expr::Match {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(associated_comments),
-          type_: (),
-        },
-        matched: Box::new(match_expression),
-        cases: matching_list,
-      })
-    } else {
-      self.parse_if_else()
-    }
-  }
-
-  fn parse_pattern_to_expression(&mut self) -> expr::VariantPatternToExpression<()> {
-    let pattern = self.parse_matching_pattern();
-    self.assert_and_consume_operator(TokenOp::ARROW);
-    let expression = self.parse_expression();
-    let loc = if matches!(self.peek().1, TokenContent::Operator(TokenOp::RBRACE)) {
-      pattern.loc().union(&expression.loc())
-    } else {
-      pattern.loc().union(&self.assert_and_consume_operator(TokenOp::COMMA))
-    };
-    expr::VariantPatternToExpression { loc, pattern, body: Box::new(expression) }
-  }
-
-  fn parse_if_else(&mut self) -> expr::E<()> {
-    let associated_comments = self.collect_preceding_comments();
-    if let Token(peeked_loc, TokenContent::Keyword(Keyword::IF)) = self.peek() {
-      self.consume();
-      let condition =
-        if let Token(_peeked_let_loc, TokenContent::Keyword(Keyword::LET)) = self.peek() {
-          self.consume();
-          let pattern = self.parse_matching_pattern();
-          self.assert_and_consume_operator(TokenOp::ASSIGN);
-          let expr = self.parse_expression();
-          IfElseCondition::Guard(pattern, expr)
-        } else {
-          IfElseCondition::Expression(self.parse_expression())
-        };
-      self.assert_and_consume_keyword(Keyword::THEN);
-      let e1 = self.parse_expression();
-      self.assert_and_consume_keyword(Keyword::ELSE);
-      let e2 = self.parse_expression();
-      let loc = peeked_loc.union(&e2.loc());
-      return expr::E::IfElse(expr::IfElse {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(associated_comments),
-          type_: (),
-        },
-        condition: Box::new(condition),
-        e1: Box::new(e1),
-        e2: Box::new(e2),
-      });
-    }
-    self.parse_disjunction()
-  }
-
-  fn parse_disjunction(&mut self) -> expr::E<()> {
-    let mut e = self.parse_conjunction();
-    while let TokenContent::Operator(TokenOp::OR) = self.peek().1 {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      self.consume();
-      let e2 = self.parse_conjunction();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator: expr::BinaryOperator::OR,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_conjunction(&mut self) -> expr::E<()> {
-    let mut e = self.parse_comparison();
-    while let TokenContent::Operator(TokenOp::AND) = self.peek().1 {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      self.consume();
-      let e2 = self.parse_comparison();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator: expr::BinaryOperator::AND,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_comparison(&mut self) -> expr::E<()> {
-    let mut e = self.parse_term();
-    loop {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      let operator = match self.peek().1 {
-        TokenContent::Operator(TokenOp::LT) => expr::BinaryOperator::LT,
-        TokenContent::Operator(TokenOp::LE) => expr::BinaryOperator::LE,
-        TokenContent::Operator(TokenOp::GT) => expr::BinaryOperator::GT,
-        TokenContent::Operator(TokenOp::GE) => expr::BinaryOperator::GE,
-        TokenContent::Operator(TokenOp::EQ) => expr::BinaryOperator::EQ,
-        TokenContent::Operator(TokenOp::NE) => expr::BinaryOperator::NE,
-        _ => break,
-      };
-      self.consume();
-      let e2 = self.parse_term();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_term(&mut self) -> expr::E<()> {
-    let mut e = self.parse_factor();
-    loop {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      let operator = match self.peek().1 {
-        TokenContent::Operator(TokenOp::PLUS) => expr::BinaryOperator::PLUS,
-        TokenContent::Operator(TokenOp::MINUS) => expr::BinaryOperator::MINUS,
-        _ => break,
-      };
-      self.consume();
-      let e2 = self.parse_factor();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_factor(&mut self) -> expr::E<()> {
-    let mut e = self.parse_concat();
-    loop {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      let operator = match self.peek().1 {
-        TokenContent::Operator(TokenOp::MUL) => expr::BinaryOperator::MUL,
-        TokenContent::Operator(TokenOp::DIV) => expr::BinaryOperator::DIV,
-        TokenContent::Operator(TokenOp::MOD) => expr::BinaryOperator::MOD,
-        _ => break,
-      };
-      self.consume();
-      let e2 = self.parse_concat();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_concat(&mut self) -> expr::E<()> {
-    let mut e = self.parse_unary_expression();
-    while let TokenContent::Operator(TokenOp::COLONCOLON) = self.peek().1 {
-      let concrete_comments = self.collect_preceding_comments();
-      let operator_preceding_comments =
-        self.comments_store.create_comment_reference(concrete_comments);
-      self.consume();
-      let e2 = self.parse_unary_expression();
-      let loc = e.loc().union(&e2.loc());
-      e = expr::E::Binary(expr::Binary {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(vec![]),
-          type_: (),
-        },
-        operator_preceding_comments,
-        operator: expr::BinaryOperator::CONCAT,
-        e1: Box::new(e),
-        e2: Box::new(e2),
-      })
-    }
-    e
-  }
-
-  fn parse_unary_expression(&mut self) -> expr::E<()> {
-    let associated_comments = self.collect_preceding_comments();
-    let Token(peeked_loc, content) = self.peek();
-    match content {
-      TokenContent::Operator(TokenOp::NOT) => {
-        self.consume();
-        let argument = self.parse_function_call_or_field_access();
-        let loc = peeked_loc.union(&argument.loc());
-        expr::E::Unary(expr::Unary {
-          common: expr::ExpressionCommon {
-            loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          operator: expr::UnaryOperator::NOT,
-          argument: Box::new(argument),
-        })
-      }
-      TokenContent::Operator(TokenOp::MINUS) => {
-        self.consume();
-        let argument = self.parse_function_call_or_field_access();
-        let loc = peeked_loc.union(&argument.loc());
-        expr::E::Unary(expr::Unary {
-          common: expr::ExpressionCommon {
-            loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          operator: expr::UnaryOperator::NEG,
-          argument: Box::new(argument),
-        })
-      }
-      _ => self.parse_function_call_or_field_access(),
-    }
-  }
-
-  fn parse_function_call_or_field_access(&mut self) -> expr::E<()> {
-    // Treat function arguments or field name as postfix.
-    // Then use Kleene star trick to parse.
-    let mut function_expression = self.parse_base_expression();
-    loop {
-      match self.peek() {
-        Token(dot_loc, TokenContent::Operator(TokenOp::DOT)) => {
-          let mut field_preceding_comments = self.collect_preceding_comments();
-          self.consume();
-          field_preceding_comments.append(&mut self.collect_preceding_comments());
-          let (field_loc, field_name) = match self.peek() {
-            Token(l, TokenContent::LowerId(id) | TokenContent::UpperId(id)) => {
-              self.consume();
-              (l, id)
-            }
-            Token(l, t) => {
-              self.report(l, format!("Expected identifier, but get {}", t.pretty_print(self.heap)));
-              (Location { end: l.start, ..dot_loc }, PStr::MISSING)
-            }
-          };
-          let mut loc = function_expression.loc().union(&field_loc);
-          let explicit_type_arguments =
-            if let Token(_, TokenContent::Operator(TokenOp::LT)) = self.peek() {
-              field_preceding_comments.append(&mut self.collect_preceding_comments());
-              self.assert_and_consume_operator(TokenOp::LT);
-              let type_args = self.parse_comma_separated_list_with_end_token(
-                TokenOp::GT,
-                &mut SourceParser::parse_annotation,
-              );
-              loc = loc.union(&self.assert_and_consume_operator(TokenOp::GT));
-              type_args
-            } else {
-              vec![]
-            };
-          function_expression = expr::E::FieldAccess(expr::FieldAccess {
-            common: expr::ExpressionCommon {
-              loc,
-              associated_comments: self.comments_store.create_comment_reference(vec![]),
-              type_: (),
-            },
-            explicit_type_arguments,
-            inferred_type_arguments: vec![],
-            object: Box::new(function_expression),
-            field_name: Id {
-              loc: field_loc,
-              associated_comments: self
-                .comments_store
-                .create_comment_reference(field_preceding_comments),
-              name: field_name,
-            },
-            field_order: -1,
-          });
-        }
-        Token(_, TokenContent::Operator(TokenOp::LPAREN)) => {
-          self.consume();
-          let function_arguments =
-            if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = self.peek() {
-              vec![]
-            } else {
-              self.parse_comma_separated_list_with_end_token(
-                TokenOp::RPAREN,
-                &mut SourceParser::parse_expression_with_ending_comments,
-              )
-            };
-          let loc =
-            function_expression.loc().union(&self.assert_and_consume_operator(TokenOp::RPAREN));
-          function_expression = expr::E::Call(expr::Call {
-            common: expr::ExpressionCommon {
-              loc,
-              associated_comments: self.comments_store.create_comment_reference(vec![]),
-              type_: (),
-            },
-            callee: Box::new(function_expression),
-            arguments: function_arguments,
-          })
-        }
-        _ => return function_expression,
-      }
-    }
-  }
-
-  fn parse_base_expression(&mut self) -> expr::E<()> {
-    let associated_comments = self.collect_preceding_comments();
-    let peeked = self.peek();
-
-    match peeked {
-      Token(peeked_loc, TokenContent::Keyword(Keyword::TRUE)) => {
-        self.consume();
-        return expr::E::Literal(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Literal::Bool(true),
-        );
-      }
-      Token(peeked_loc, TokenContent::Keyword(Keyword::FALSE)) => {
-        self.consume();
-        return expr::E::Literal(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Literal::Bool(false),
-        );
-      }
-      Token(peeked_loc, TokenContent::IntLiteral(i)) => {
-        self.consume();
-        return expr::E::Literal(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Literal::Int(i.as_str(self.heap).parse::<i32>().unwrap_or(0)),
-        );
-      }
-      Token(peeked_loc, TokenContent::StringLiteral(s)) => {
-        self.consume();
-        let chars = s.as_str(self.heap).chars().collect_vec();
-        let str_lit = unescape_quotes(&chars[1..(chars.len() - 1)].iter().collect::<String>());
-        return expr::E::Literal(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Literal::String(self.heap.alloc_string(str_lit)),
-        );
-      }
-      Token(peeked_loc, TokenContent::Keyword(Keyword::THIS)) => {
-        self.consume();
-        return expr::E::LocalId(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Id {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(vec![]),
-            name: PStr::THIS,
-          },
-        );
-      }
-      Token(peeked_loc, TokenContent::LowerId(name)) => {
-        self.consume();
-        return expr::E::LocalId(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          Id {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(vec![]),
-            name,
-          },
-        );
-      }
-      Token(peeked_loc, TokenContent::UpperId(name)) => {
-        self.consume();
-        return expr::E::ClassId(
-          expr::ExpressionCommon {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          self.resolve_class(name),
-          Id {
-            loc: peeked_loc,
-            associated_comments: self.comments_store.create_comment_reference(vec![]),
-            name,
-          },
-        );
-      }
-      _ => {}
-    }
-
-    // Lambda or tuple or nested expression
-    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LPAREN)) = peeked {
-      self.consume();
-      // () -> ...
-      if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = self.peek() {
-        let mut comments = associated_comments;
-        self.consume();
-        comments.append(&mut self.collect_preceding_comments());
-        self.assert_and_consume_operator(TokenOp::ARROW);
-        let body = self.parse_expression();
-        let loc = peeked_loc.union(&body.loc());
-        return expr::E::Lambda(expr::Lambda {
-          common: expr::ExpressionCommon {
-            loc,
-            associated_comments: self.comments_store.create_comment_reference(comments),
-            type_: (),
-          },
-          parameters: vec![],
-          captured: HashMap::new(),
-          body: Box::new(body),
-        });
-      }
-
-      // (id ...
-      if let Token(loc_id_for_lambda, TokenContent::LowerId(id_for_lambda)) = self.peek() {
-        self.consume();
-        let next = self.peek();
-        match next.1 {
-          // (id: ... definitely a lambda
-          TokenContent::Operator(TokenOp::COLON) => {
-            self.unconsume();
-            let parameters = self.parse_comma_separated_list_with_end_token(
-              TokenOp::RPAREN,
-              &mut Self::parse_optionally_annotated_id,
-            );
-            self.assert_and_consume_operator(TokenOp::RPAREN);
-            self.assert_and_consume_operator(TokenOp::ARROW);
-            let body = self.parse_expression();
-            let loc = peeked_loc.union(&body.loc());
-            return expr::E::Lambda(expr::Lambda {
-              common: expr::ExpressionCommon {
-                loc,
-                associated_comments: self
-                  .comments_store
-                  .create_comment_reference(associated_comments),
-                type_: (),
-              },
-              parameters,
-              captured: HashMap::new(),
-              body: Box::new(body),
-            });
-          }
-          // (id, ..., might be lambda, might be tuple
-          TokenContent::Operator(TokenOp::COMMA) => {
-            self.unconsume();
-            // Advance as far as possible for a comma separated lower id.
-            // This is common for both arrow function and tuple.
-            let mut parameters_or_tuple_elements_cover = vec![self.parse_lower_id()];
-            while let Token(_, TokenContent::Operator(TokenOp::COMMA)) = self.peek() {
-              self.consume();
-              if let Token(_, TokenContent::LowerId(_)) = self.peek() {
-                self.consume();
-                match self.peek() {
-                  Token(_, TokenContent::Operator(TokenOp::COMMA))
-                  | Token(_, TokenContent::Operator(TokenOp::RPAREN)) => {
-                    self.unconsume(); // unconsume lower id
-                    parameters_or_tuple_elements_cover.push(self.parse_lower_id());
-                  }
-                  _ => {
-                    self.unconsume(); // unconsume lower id
-                    break;
-                  }
-                }
-              } else {
-                break;
-              }
-            }
-            // If we see ), it means that the cover is complete and still ambiguous.
-            if let Token(right_parenthesis_loc, TokenContent::Operator(TokenOp::RPAREN)) =
-              self.peek()
-            {
-              self.consume();
-              if let Token(_, TokenContent::Operator(TokenOp::ARROW)) = self.peek() {
-                self.consume();
-                let body = self.parse_expression();
-                let loc = peeked_loc.union(&body.loc());
-                return expr::E::Lambda(expr::Lambda {
-                  common: expr::ExpressionCommon {
-                    loc,
-                    associated_comments: self
-                      .comments_store
-                      .create_comment_reference(associated_comments),
-                    type_: (),
-                  },
-                  parameters: parameters_or_tuple_elements_cover
-                    .into_iter()
-                    .map(|name| OptionallyAnnotatedId { name, type_: (), annotation: None })
-                    .collect(),
-                  captured: HashMap::new(),
-                  body: Box::new(body),
-                });
-              } else {
-                let tuple_elements = parameters_or_tuple_elements_cover
-                  .into_iter()
-                  .map(|name| {
-                    expr::E::LocalId(
-                      expr::ExpressionCommon {
-                        loc: name.loc,
-                        associated_comments: NO_COMMENT_REFERENCE,
-                        type_: (),
-                      },
-                      name,
-                    )
-                  })
-                  .collect_vec();
-                let loc = peeked_loc.union(&right_parenthesis_loc);
-                return expr::E::Tuple(
-                  expr::ExpressionCommon {
-                    loc,
-                    associated_comments: self
-                      .comments_store
-                      .create_comment_reference(associated_comments),
-                    type_: (),
-                  },
-                  tuple_elements,
-                );
-              }
-            }
-            if let Token(_, TokenContent::LowerId(_)) = self.peek() {
-              self.consume();
-              if let Token(_, TokenContent::Operator(TokenOp::COLON)) = self.peek() {
-                self.unconsume();
-                let rest_parameters = self.parse_comma_separated_list_with_end_token(
-                  TokenOp::RPAREN,
-                  &mut Self::parse_optionally_annotated_id,
-                );
-                let parameters = parameters_or_tuple_elements_cover
-                  .into_iter()
-                  .map(|name| OptionallyAnnotatedId { name, type_: (), annotation: None })
-                  .chain(rest_parameters)
-                  .collect_vec();
-                self.assert_and_consume_operator(TokenOp::RPAREN);
-                self.assert_and_consume_operator(TokenOp::ARROW);
-                let body = self.parse_expression();
-                let loc = peeked_loc.union(&body.loc());
-                return expr::E::Lambda(expr::Lambda {
-                  common: expr::ExpressionCommon {
-                    loc,
-                    associated_comments: self
-                      .comments_store
-                      .create_comment_reference(associated_comments),
-                    type_: (),
-                  },
-                  parameters,
-                  captured: HashMap::new(),
-                  body: Box::new(body),
-                });
-              }
-              self.unconsume();
-            }
-            let rest_tuple_elements = self.parse_comma_separated_list_with_end_token(
-              TokenOp::RPAREN,
-              &mut SourceParser::parse_expression,
-            );
-            let mut tuple_elements = parameters_or_tuple_elements_cover
-              .into_iter()
-              .map(|name| {
-                expr::E::LocalId(
-                  expr::ExpressionCommon {
-                    loc: name.loc,
-                    associated_comments: NO_COMMENT_REFERENCE,
-                    type_: (),
-                  },
-                  name,
-                )
-              })
-              .chain(rest_tuple_elements)
-              .collect_vec();
-            if let Some(node) = tuple_elements.get(MAX_STRUCT_SIZE) {
-              self.error_set.report_invalid_syntax_error(
-                node.loc(),
-                format!("Maximum allowed tuple size is {MAX_STRUCT_SIZE}"),
-              );
-            }
-            tuple_elements.truncate(MAX_STRUCT_SIZE);
-            let end_loc = self.assert_and_consume_operator(TokenOp::RPAREN);
-            let loc = peeked_loc.union(&end_loc);
-            let common = expr::ExpressionCommon {
-              loc,
-              associated_comments: self
-                .comments_store
-                .create_comment_reference(associated_comments),
-              type_: (),
-            };
-            debug_assert!(tuple_elements.len() > 1);
-            return expr::E::Tuple(common, tuple_elements);
-          }
-          // (id) -> ... OR (id)
-          TokenContent::Operator(TokenOp::RPAREN) => {
-            self.consume();
-            if let Token(_, TokenContent::Operator(TokenOp::ARROW)) = self.peek() {
-              let mut comments = associated_comments;
-              comments.append(&mut self.collect_preceding_comments());
-              self.consume();
-              let body = self.parse_expression();
-              let loc = peeked_loc.union(&body.loc());
-              return expr::E::Lambda(expr::Lambda {
-                common: expr::ExpressionCommon {
-                  loc,
-                  associated_comments: self.comments_store.create_comment_reference(comments),
-                  type_: (),
-                },
-                parameters: vec![OptionallyAnnotatedId {
-                  name: Id {
-                    loc: loc_id_for_lambda,
-                    associated_comments: self.comments_store.create_comment_reference(vec![]),
-                    name: id_for_lambda,
-                  },
-                  type_: (),
-                  annotation: None,
-                }],
-                captured: HashMap::new(),
-                body: Box::new(body),
-              });
-            } else {
-              // (id)
-              self.unconsume();
-            }
-          }
-          _ => {}
-        }
-        self.unconsume();
-      }
-      let mut expressions = self.parse_comma_separated_list_with_end_token(
-        TokenOp::RPAREN,
-        &mut SourceParser::parse_expression,
-      );
-      if let Some(node) = expressions.get(MAX_STRUCT_SIZE) {
-        self.error_set.report_invalid_syntax_error(
-          node.loc(),
-          format!("Maximum allowed tuple size is {MAX_STRUCT_SIZE}"),
-        );
-      }
-      expressions.truncate(MAX_STRUCT_SIZE);
-      let end_loc = self.assert_and_consume_operator(TokenOp::RPAREN);
-      let loc = peeked_loc.union(&end_loc);
-      let common = expr::ExpressionCommon {
-        loc,
-        associated_comments: self.comments_store.create_comment_reference(associated_comments),
-        type_: (),
-      };
-      debug_assert!(!expressions.is_empty());
-      if expressions.len() == 1 {
-        return expressions.pop().unwrap();
-      }
-      return expr::E::Tuple(common, expressions);
-    }
-
-    // Statement Block: { ... }
-    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LBRACE)) = peeked {
-      self.consume();
-
-      let mut statements = vec![];
-      while let Token(_, TokenContent::Keyword(Keyword::LET)) = self.peek() {
-        statements.push(self.parse_statement());
-      }
-
-      // No final expression
-      if let Token(end_loc, TokenContent::Operator(TokenOp::RBRACE)) = self.peek() {
-        self.consume();
-        let loc = peeked_loc.union(&end_loc);
-        return expr::E::Block(expr::Block {
-          common: expr::ExpressionCommon {
-            loc,
-            associated_comments: self.comments_store.create_comment_reference(associated_comments),
-            type_: (),
-          },
-          statements,
-          expression: None,
-        });
-      }
-
-      // Has final expression
-      let expression = self.parse_expression_with_ending_comments();
-      let loc = peeked_loc.union(&self.assert_and_consume_operator(TokenOp::RBRACE));
-      return expr::E::Block(expr::Block {
-        common: expr::ExpressionCommon {
-          loc,
-          associated_comments: self.comments_store.create_comment_reference(associated_comments),
-          type_: (),
-        },
-        statements,
-        expression: Some(Box::new(expression)),
-      });
-    }
-
-    // Error case
-    self.report(
-      peeked.0,
-      format!("Expected: expression, actual: {}", peeked.1.pretty_print(self.heap)),
-    );
-    expr::E::Literal(
-      expr::ExpressionCommon {
-        loc: peeked.0,
-        associated_comments: self.comments_store.create_comment_reference(associated_comments),
-        type_: (),
-      },
-      Literal::Int(0),
-    )
-  }
-
-  pub(super) fn parse_statement(&mut self) -> expr::DeclarationStatement<()> {
-    let concrete_comments = self.collect_preceding_comments();
-    let associated_comments = self.comments_store.create_comment_reference(concrete_comments);
-    let start_loc = self.assert_and_consume_keyword(Keyword::LET);
-    let pattern = self.parse_matching_pattern();
-    let annotation = if let Token(_, TokenContent::Operator(TokenOp::COLON)) = self.peek() {
-      self.consume();
-      Some(self.parse_annotation())
-    } else {
-      None
-    };
-    self.assert_and_consume_operator(TokenOp::ASSIGN);
-    let assigned_expression = Box::new(self.parse_expression());
-    let loc = start_loc.union(&self.assert_and_consume_operator(TokenOp::SEMICOLON));
-    expr::DeclarationStatement {
-      loc,
-      associated_comments,
-      pattern,
-      annotation,
-      assigned_expression,
-    }
-  }
-
-  fn parse_matching_pattern_with_unit(&mut self) -> (pattern::MatchingPattern<()>, ()) {
-    (self.parse_matching_pattern(), ())
-  }
-
-  pub(super) fn parse_matching_pattern(&mut self) -> pattern::MatchingPattern<()> {
-    let peeked = self.peek();
-    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LPAREN)) = peeked {
-      self.consume();
-      let destructured_names =
-        self.parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut |s: &mut Self| {
-          pattern::TuplePatternElement { pattern: Box::new(s.parse_matching_pattern()), type_: () }
-        });
-      let end_location = self.assert_and_consume_operator(TokenOp::RPAREN);
-      return pattern::MatchingPattern::Tuple(peeked_loc.union(&end_location), destructured_names);
-    }
-    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LBRACE)) = peeked {
-      self.consume();
-      let destructured_names =
-        self.parse_comma_separated_list_with_end_token(TokenOp::RBRACE, &mut |s: &mut Self| {
-          let field_name = s.parse_lower_id();
-          let (pattern, loc, shorthand) =
-            if let Token(_, TokenContent::Keyword(Keyword::AS)) = s.peek() {
-              s.consume();
-              let nested = Box::new(s.parse_matching_pattern());
-              let loc = field_name.loc.union(nested.loc());
-              (nested, loc, false)
-            } else {
-              (Box::new(pattern::MatchingPattern::Id(field_name, ())), field_name.loc, true)
-            };
-          pattern::ObjectPatternElement {
-            loc,
-            field_name,
-            field_order: 0,
-            pattern,
-            shorthand,
-            type_: (),
-          }
-        });
-      let end_location = self.assert_and_consume_operator(TokenOp::RBRACE);
-      return pattern::MatchingPattern::Object(peeked_loc.union(&end_location), destructured_names);
-    }
-    if let Token(peeked_loc, TokenContent::UpperId(id)) = peeked {
-      self.consume();
-      let tag = Id { loc: peeked_loc, associated_comments: NO_COMMENT_REFERENCE, name: id };
-      let (data_variables, loc) =
-        if let Token(_, TokenContent::Operator(TokenOp::LPAREN)) = self.peek() {
-          self.consume();
-          let data_variables = self.parse_comma_separated_list_with_end_token(
-            TokenOp::RPAREN,
-            &mut Self::parse_matching_pattern_with_unit,
-          );
-          let end_loc = self.assert_and_consume_operator(TokenOp::RPAREN);
-          (data_variables, peeked_loc.union(&end_loc))
-        } else {
-          (Vec::with_capacity(0), peeked_loc)
-        };
-      return pattern::MatchingPattern::Variant(pattern::VariantPattern {
-        loc,
-        tag_order: 0,
-        tag,
-        data_variables,
-        type_: (),
-      });
-    }
-    if let Token(peeked_loc, TokenContent::Operator(TokenOp::UNDERSCORE)) = peeked {
-      self.consume();
-      return pattern::MatchingPattern::Wildcard(peeked_loc);
-    }
-    pattern::MatchingPattern::Id(
-      Id {
-        loc: peeked.0,
-        associated_comments: NO_COMMENT_REFERENCE,
-        name: self.assert_and_peek_lower_id().1,
-      },
-      (),
-    )
-  }
-
   fn parse_upper_id(&mut self) -> Id {
     let associated_comments = self.collect_preceding_comments();
     let (loc, name) = self.assert_and_peek_upper_id();
@@ -1590,62 +274,1435 @@ impl<'a> SourceParser<'a> {
     }
     comments
   }
+}
 
-  fn parse_annotated_id(&mut self) -> AnnotatedId<()> {
-    let name = self.parse_lower_id();
-    self.assert_and_consume_operator(TokenOp::COLON);
-    let annotation = self.parse_annotation();
+pub fn parse_module(mut parser: SourceParser) -> Module<()> {
+  let mut imports = vec![];
+  while let Token(import_start, TokenContent::Keyword(Keyword::IMPORT)) = parser.peek() {
+    parser.consume();
+    parser.assert_and_consume_operator(TokenOp::LBRACE);
+    let imported_members = parser.parse_comma_separated_list_with_end_token(
+      TokenOp::RBRACE,
+      &mut SourceParser::parse_upper_id,
+    );
+    parser.assert_and_consume_operator(TokenOp::RBRACE);
+    parser.assert_and_consume_keyword(Keyword::FROM);
+    let import_loc_start = parser.peek().0;
+    let imported_module_parts = {
+      let mut collector = vec![parser.assert_and_consume_identifier().1];
+      while let Token(_, TokenContent::Operator(TokenOp::DOT)) = parser.peek() {
+        parser.consume();
+        collector.push(parser.assert_and_consume_identifier().1);
+      }
+      collector
+    };
+    let imported_module = parser.heap.alloc_module_reference(imported_module_parts);
+    let imported_module_loc = import_loc_start.union(&parser.last_location());
+    for variable in imported_members.iter() {
+      parser.class_source_map.insert(variable.name, imported_module);
+    }
+    let loc =
+      if let Token(semicolon_loc, TokenContent::Operator(TokenOp::SEMICOLON)) = parser.peek() {
+        parser.consume();
+        import_start.union(&semicolon_loc)
+      } else {
+        import_start.union(&imported_module_loc)
+      };
+    imports.push(ModuleMembersImport {
+      loc,
+      imported_members,
+      imported_module,
+      imported_module_loc,
+    });
+  }
+
+  let mut toplevels = vec![];
+  'outer: loop {
+    if let TokenContent::EOF = parser.peek().1 {
+      break;
+    }
+    loop {
+      match parser.peek() {
+        Token(_, TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE)) => {
+          break
+        }
+        Token(_, TokenContent::EOF) => break 'outer,
+        Token(loc, content) => {
+          parser.consume();
+          parser.report(
+            loc,
+            format!(
+              "Unexpected token among the classes and interfaces: {}",
+              content.pretty_print(parser.heap)
+            ),
+          )
+        }
+      }
+    }
+    toplevels.push(toplevel_parser::parse_toplevel(&mut parser));
+  }
+  let comments = parser.collect_preceding_comments();
+  let trailing_comments = parser.comments_store.create_comment_reference(comments);
+
+  Module { comment_store: parser.comments_store, imports, toplevels, trailing_comments }
+}
+
+pub(super) fn parse_expression_with_comment_store(
+  mut parser: SourceParser,
+) -> (CommentStore, expr::E<()>) {
+  let e = expression_parser::parse_expression(&mut parser);
+  (parser.comments_store, e)
+}
+
+mod toplevel_parser {
+  use super::{
+    super::lexer::{Keyword, Token, TokenContent, TokenOp},
+    MAX_STRUCT_SIZE, MAX_VARIANT_SIZE,
+  };
+  use itertools::Itertools;
+  use samlang_ast::{source::*, Location};
+  use std::collections::HashSet;
+
+  pub(super) fn parse_toplevel(parser: &mut super::SourceParser) -> Toplevel<()> {
+    parser.unconsume_comments();
+    let is_private = if let TokenContent::Keyword(Keyword::PRIVATE) = parser.peek().1 {
+      parser.consume();
+      true
+    } else {
+      false
+    };
+    let is_class = matches!(parser.peek().1, TokenContent::Keyword(Keyword::CLASS));
+    if is_private {
+      parser.unconsume();
+    }
+    if is_class {
+      Toplevel::Class(parse_class(parser))
+    } else {
+      Toplevel::Interface(parse_interface(parser))
+    }
+  }
+
+  pub(super) fn parse_class(parser: &mut super::SourceParser) -> ClassDefinition<()> {
+    let associated_comments = parser.collect_preceding_comments();
+    let (mut loc, private) =
+      if let Token(loc, TokenContent::Keyword(Keyword::PRIVATE)) = parser.peek() {
+        parser.consume();
+        parser.assert_and_consume_keyword(Keyword::CLASS);
+        (loc, true)
+      } else {
+        (parser.assert_and_consume_keyword(Keyword::CLASS), false)
+      };
+    let name = parser.parse_upper_id();
+    loc = loc.union(&name.loc);
+    let (type_param_loc_start, type_param_loc_end, mut type_parameters) =
+      if let Token(loc_start, TokenContent::Operator(TokenOp::LT)) = parser.peek() {
+        parser.consume();
+        let type_params = parser.parse_comma_separated_list_with_end_token(
+          TokenOp::GT,
+          &mut super::type_parser::parse_type_parameter,
+        );
+        let loc_end = parser.assert_and_consume_operator(TokenOp::GT);
+        (Some(loc_start), Some(loc_end), type_params)
+      } else {
+        (None, None, vec![])
+      };
+    parser.available_tparams = type_parameters.iter().map(|it| it.name.name).collect();
+    super::type_parser::fix_tparams_with_generic_annot(parser, &mut type_parameters);
+    let (type_definition, extends_or_implements_nodes) = match parser.peek().1 {
+      TokenContent::Operator(TokenOp::LBRACE | TokenOp::COLON)
+      | TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE) => {
+        let nodes = if let TokenContent::Operator(TokenOp::COLON) = parser.peek().1 {
+          parser.consume();
+          let nodes = parse_extends_or_implements_nodes(parser);
+          loc = loc.union(&nodes.last().unwrap().location);
+          nodes
+        } else {
+          vec![]
+        };
+        loc = if let Some(loc_end) = type_param_loc_end { loc.union(&loc_end) } else { loc };
+        let type_def = TypeDefinition::Struct { loc: parser.peek().0, fields: vec![] };
+        (type_def, nodes)
+      }
+      _ => {
+        let type_def_loc_start = parser.assert_and_consume_operator(TokenOp::LPAREN);
+        let mut type_def = parse_type_definition_inner(parser);
+        let type_def_loc_end = parser.assert_and_consume_operator(TokenOp::RPAREN);
+        let type_def_loc =
+          type_param_loc_start.unwrap_or(type_def_loc_start).union(&type_def_loc_end);
+        match &mut type_def {
+          TypeDefinition::Struct { loc, fields: _ } => *loc = type_def_loc,
+          TypeDefinition::Enum { loc, variants: _ } => *loc = type_def_loc,
+        }
+        loc = loc.union(&type_def_loc_end);
+        let nodes = if let TokenContent::Operator(TokenOp::COLON) = parser.peek().1 {
+          parser.consume();
+          let nodes = parse_extends_or_implements_nodes(parser);
+          loc = loc.union(&nodes.last().unwrap().location);
+          nodes
+        } else {
+          vec![]
+        };
+        (type_def, nodes)
+      }
+    };
+    let mut members = vec![];
+    if !peeked_class_or_interface_start(parser) {
+      parser.assert_and_consume_operator(TokenOp::LBRACE);
+      while let TokenContent::Keyword(Keyword::FUNCTION | Keyword::METHOD | Keyword::PRIVATE) =
+        parser.peek().1
+      {
+        let saved_upper_type_parameters = parser.available_tparams.clone();
+        members.push(parse_class_member_definition(parser));
+        parser.available_tparams = saved_upper_type_parameters;
+      }
+      loc = loc.union(&parser.assert_and_consume_operator(TokenOp::RBRACE));
+    }
+    InterfaceDeclarationCommon {
+      loc,
+      associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+      private,
+      name,
+      type_parameters,
+      extends_or_implements_nodes,
+      type_definition,
+      members,
+    }
+  }
+
+  pub(super) fn parse_interface(parser: &mut super::SourceParser) -> InterfaceDeclaration {
+    let associated_comments = parser.collect_preceding_comments();
+    let (mut loc, private) =
+      if let Token(loc, TokenContent::Keyword(Keyword::PRIVATE)) = parser.peek() {
+        parser.consume();
+        parser.assert_and_consume_keyword(Keyword::INTERFACE);
+        (loc, true)
+      } else {
+        (parser.assert_and_consume_keyword(Keyword::INTERFACE), false)
+      };
+    let name = parser.parse_upper_id();
+    let mut type_parameters = if let TokenContent::Operator(TokenOp::LT) = parser.peek().1 {
+      parser.consume();
+      let type_params = parser.parse_comma_separated_list_with_end_token(
+        TokenOp::GT,
+        &mut super::type_parser::parse_type_parameter,
+      );
+      loc = loc.union(&parser.assert_and_consume_operator(TokenOp::GT));
+      type_params
+    } else {
+      vec![]
+    };
+    parser.available_tparams = type_parameters.iter().map(|it| it.name.name).collect();
+    super::type_parser::fix_tparams_with_generic_annot(parser, &mut type_parameters);
+    let extends_or_implements_nodes =
+      if let TokenContent::Operator(TokenOp::COLON) = parser.peek().1 {
+        parser.consume();
+        let nodes = parse_extends_or_implements_nodes(parser);
+        loc = loc.union(&nodes.last().unwrap().location);
+        nodes
+      } else {
+        vec![]
+      };
+    let mut members = vec![];
+    if let TokenContent::Operator(TokenOp::LBRACE) = parser.peek().1 {
+      parser.consume();
+      while let TokenContent::Keyword(Keyword::FUNCTION | Keyword::METHOD | Keyword::PRIVATE) =
+        parser.peek().1
+      {
+        let saved_upper_type_parameters = parser.available_tparams.clone();
+        members.push(parse_class_member_declaration(parser));
+        parser.available_tparams = saved_upper_type_parameters;
+      }
+      loc = loc.union(&parser.assert_and_consume_operator(TokenOp::RBRACE));
+    }
+    InterfaceDeclarationCommon {
+      loc,
+      associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+      private,
+      name,
+      type_parameters,
+      extends_or_implements_nodes,
+      type_definition: (),
+      members,
+    }
+  }
+
+  fn parse_extends_or_implements_nodes(parser: &mut super::SourceParser) -> Vec<annotation::Id> {
+    let id = parser.parse_upper_id();
+    let mut collector = vec![super::type_parser::parse_identifier_annot(parser, id)];
+    while let Token(_, TokenContent::Operator(TokenOp::COMMA)) = parser.peek() {
+      parser.consume();
+      let id = parser.parse_upper_id();
+      collector.push(super::type_parser::parse_identifier_annot(parser, id));
+    }
+    collector
+  }
+
+  fn parse_type_definition_inner(parser: &mut super::SourceParser) -> TypeDefinition {
+    if let Token(_, TokenContent::UpperId(_)) = parser.peek() {
+      let mut variants = parser
+        .parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut parse_variant_definition);
+      variants.truncate(MAX_VARIANT_SIZE);
+      // Location is later patched by the caller
+      TypeDefinition::Enum { loc: Location::dummy(), variants }
+    } else {
+      let mut fields = parser
+        .parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut parse_field_definition);
+      if let Some(node) = fields.get(MAX_STRUCT_SIZE) {
+        parser.error_set.report_invalid_syntax_error(
+          node.name.loc,
+          format!("Maximum allowed field size is {MAX_STRUCT_SIZE}"),
+        );
+      }
+      fields.truncate(MAX_STRUCT_SIZE);
+      // Location is later patched by the caller
+      TypeDefinition::Struct { loc: Location::dummy(), fields }
+    }
+  }
+
+  fn parse_field_definition(parser: &mut super::SourceParser) -> FieldDefinition {
+    let mut is_public = true;
+    if let TokenContent::Keyword(Keyword::PRIVATE) = parser.peek().1 {
+      is_public = false;
+      parser.consume();
+    }
+    parser.assert_and_consume_keyword(Keyword::VAL);
+    let name = parser.parse_lower_id();
+    parser.assert_and_consume_operator(TokenOp::COLON);
+    let annotation = super::type_parser::parse_annotation(parser);
+    FieldDefinition { name, annotation, is_public }
+  }
+
+  fn parse_variant_definition(parser: &mut super::SourceParser) -> VariantDefinition {
+    let name = parser.parse_upper_id();
+    if let Token(_, TokenContent::Operator(TokenOp::LPAREN)) = parser.peek() {
+      parser.consume();
+      let associated_data_types = parser.parse_comma_separated_list_with_end_token(
+        TokenOp::RPAREN,
+        &mut super::type_parser::parse_annotation,
+      );
+
+      if let Some(node) = associated_data_types.get(MAX_VARIANT_SIZE) {
+        parser.error_set.report_invalid_syntax_error(
+          node.location(),
+          format!("Maximum allowed field size is {MAX_VARIANT_SIZE}"),
+        );
+      }
+      parser.assert_and_consume_operator(TokenOp::RPAREN);
+      VariantDefinition { name, associated_data_types }
+    } else {
+      VariantDefinition { name, associated_data_types: vec![] }
+    }
+  }
+
+  fn peeked_class_or_interface_start(parser: &mut super::SourceParser) -> bool {
+    matches!(
+      parser.peek().1,
+      TokenContent::Keyword(Keyword::CLASS | Keyword::INTERFACE | Keyword::PRIVATE)
+    )
+  }
+
+  pub(super) fn parse_class_member_definition(
+    parser: &mut super::SourceParser,
+  ) -> ClassMemberDefinition<()> {
+    let mut decl = parse_class_member_declaration_common(parser, true);
+    parser.assert_and_consume_operator(TokenOp::ASSIGN);
+    let body = super::expression_parser::parse_expression(parser);
+    decl.loc = decl.loc.union(&body.loc());
+    ClassMemberDefinition { decl, body }
+  }
+
+  pub(super) fn parse_class_member_declaration(
+    parser: &mut super::SourceParser,
+  ) -> ClassMemberDeclaration {
+    parse_class_member_declaration_common(parser, false)
+  }
+
+  fn parse_class_member_declaration_common(
+    parser: &mut super::SourceParser,
+    allow_private: bool,
+  ) -> ClassMemberDeclaration {
+    let associated_comments = parser.collect_preceding_comments();
+    let mut is_public = true;
+    let mut is_method = true;
+    let mut peeked = parser.peek();
+    if let Token(peeked_loc, TokenContent::Keyword(Keyword::PRIVATE)) = peeked {
+      if allow_private {
+        is_public = false;
+      } else {
+        parser.report(peeked_loc, "Unexpected `private`".to_string());
+      }
+      parser.consume();
+      peeked = parser.peek();
+    }
+    let start_loc = &peeked.0;
+    if let Token(_, TokenContent::Keyword(Keyword::FUNCTION)) = &peeked {
+      is_method = false;
+      parser.consume();
+    } else {
+      parser.assert_and_consume_keyword(Keyword::METHOD);
+    }
+    if !is_method {
+      parser.available_tparams = HashSet::new();
+    }
+    let mut type_parameters = if let TokenContent::Operator(TokenOp::LT) = parser.peek().1 {
+      parser.consume();
+      let type_params = parser.parse_comma_separated_list_with_end_token(
+        TokenOp::GT,
+        &mut super::type_parser::parse_type_parameter,
+      );
+      parser.assert_and_consume_operator(TokenOp::GT);
+      type_params
+    } else {
+      vec![]
+    };
+    parser.available_tparams.extend(type_parameters.iter().map(|it| it.name.name));
+    super::type_parser::fix_tparams_with_generic_annot(parser, &mut type_parameters);
+    let name = parser.parse_lower_id();
+    let fun_type_loc_start = parser.assert_and_consume_operator(TokenOp::LPAREN);
+    let parameters = if let TokenContent::Operator(TokenOp::RPAREN) = parser.peek().1 {
+      vec![]
+    } else {
+      parser.parse_comma_separated_list_with_end_token(
+        TokenOp::RPAREN,
+        &mut super::type_parser::parse_annotated_id,
+      )
+    };
+    parser.assert_and_consume_operator(TokenOp::RPAREN);
+    parser.assert_and_consume_operator(TokenOp::COLON);
+    let return_type = super::type_parser::parse_annotation(parser);
+    let fun_type_loc = fun_type_loc_start.union(&return_type.location());
+    ClassMemberDeclaration {
+      loc: start_loc.union(&fun_type_loc),
+      associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+      is_public,
+      is_method,
+      name,
+      type_parameters: std::rc::Rc::new(type_parameters),
+      type_: annotation::Function {
+        location: fun_type_loc,
+        associated_comments: NO_COMMENT_REFERENCE,
+        argument_types: parameters.iter().map(|it| it.annotation.clone()).collect_vec(),
+        return_type: Box::new(return_type),
+      },
+      parameters: std::rc::Rc::new(parameters),
+    }
+  }
+}
+
+mod expression_parser {
+  use super::{
+    super::lexer::{Keyword, Token, TokenContent, TokenOp},
+    MAX_STRUCT_SIZE,
+  };
+  use itertools::Itertools;
+  use samlang_ast::{source::*, Location};
+  use samlang_heap::PStr;
+  use std::collections::HashMap;
+
+  pub(super) fn parse_expression(parser: &mut super::SourceParser) -> expr::E<()> {
+    parse_match(parser)
+  }
+
+  fn parse_expression_with_ending_comments(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut expr = parse_expression(parser);
+    let mut new_comments = parser.collect_preceding_comments();
+    let common = expr.common_mut();
+    let associated_comments = parser.comments_store.get_mut(common.associated_comments);
+    match associated_comments {
+      CommentsNode::NoComment => {
+        common.associated_comments = parser.comments_store.create_comment_reference(new_comments);
+      }
+      CommentsNode::Comments(existing_loc, existing_comments) => {
+        let new_loc = new_comments.iter().fold(*existing_loc, |l1, c| l1.union(&c.location));
+        *existing_loc = new_loc;
+        existing_comments.append(&mut new_comments);
+      }
+    }
+    expr
+  }
+
+  fn parse_match(parser: &mut super::SourceParser) -> expr::E<()> {
+    let associated_comments = parser.collect_preceding_comments();
+    if let Token(peeked_loc, TokenContent::Keyword(Keyword::MATCH)) = parser.peek() {
+      parser.consume();
+      let match_expression = parse_expression_with_ending_comments(parser);
+      parser.assert_and_consume_operator(TokenOp::LBRACE);
+      let mut matching_list = vec![parse_pattern_to_expression(parser)];
+      while matches!(
+        parser.peek().1,
+        TokenContent::Operator(TokenOp::LBRACE | TokenOp::LPAREN | TokenOp::UNDERSCORE)
+          | TokenContent::LowerId(_)
+          | TokenContent::UpperId(_)
+      ) {
+        matching_list.push(parse_pattern_to_expression(parser));
+      }
+      let loc = peeked_loc.union(&parser.assert_and_consume_operator(TokenOp::RBRACE));
+      expr::E::Match(expr::Match {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+          type_: (),
+        },
+        matched: Box::new(match_expression),
+        cases: matching_list,
+      })
+    } else {
+      parse_if_else(parser)
+    }
+  }
+
+  fn parse_pattern_to_expression(
+    parser: &mut super::SourceParser,
+  ) -> expr::VariantPatternToExpression<()> {
+    let pattern = super::pattern_parser::parse_matching_pattern(parser);
+    parser.assert_and_consume_operator(TokenOp::ARROW);
+    let expression = parse_expression(parser);
+    let loc = if matches!(parser.peek().1, TokenContent::Operator(TokenOp::RBRACE)) {
+      pattern.loc().union(&expression.loc())
+    } else {
+      pattern.loc().union(&parser.assert_and_consume_operator(TokenOp::COMMA))
+    };
+    expr::VariantPatternToExpression { loc, pattern, body: Box::new(expression) }
+  }
+
+  fn parse_if_else(parser: &mut super::SourceParser) -> expr::E<()> {
+    let associated_comments = parser.collect_preceding_comments();
+    if let Token(peeked_loc, TokenContent::Keyword(Keyword::IF)) = parser.peek() {
+      parser.consume();
+      let condition =
+        if let Token(_peeked_let_loc, TokenContent::Keyword(Keyword::LET)) = parser.peek() {
+          parser.consume();
+          let pattern = super::pattern_parser::parse_matching_pattern(parser);
+          parser.assert_and_consume_operator(TokenOp::ASSIGN);
+          let expr = parse_expression(parser);
+          expr::IfElseCondition::Guard(pattern, expr)
+        } else {
+          expr::IfElseCondition::Expression(parse_expression(parser))
+        };
+      parser.assert_and_consume_keyword(Keyword::THEN);
+      let e1 = parse_expression(parser);
+      parser.assert_and_consume_keyword(Keyword::ELSE);
+      let e2 = parse_expression(parser);
+      let loc = peeked_loc.union(&e2.loc());
+      return expr::E::IfElse(expr::IfElse {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+          type_: (),
+        },
+        condition: Box::new(condition),
+        e1: Box::new(e1),
+        e2: Box::new(e2),
+      });
+    }
+    parse_disjunction(parser)
+  }
+
+  fn parse_disjunction(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_conjunction(parser);
+    while let TokenContent::Operator(TokenOp::OR) = parser.peek().1 {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      parser.consume();
+      let e2 = parse_conjunction(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator: expr::BinaryOperator::OR,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_conjunction(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_comparison(parser);
+    while let TokenContent::Operator(TokenOp::AND) = parser.peek().1 {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      parser.consume();
+      let e2 = parse_comparison(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator: expr::BinaryOperator::AND,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_comparison(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_term(parser);
+    loop {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      let operator = match parser.peek().1 {
+        TokenContent::Operator(TokenOp::LT) => expr::BinaryOperator::LT,
+        TokenContent::Operator(TokenOp::LE) => expr::BinaryOperator::LE,
+        TokenContent::Operator(TokenOp::GT) => expr::BinaryOperator::GT,
+        TokenContent::Operator(TokenOp::GE) => expr::BinaryOperator::GE,
+        TokenContent::Operator(TokenOp::EQ) => expr::BinaryOperator::EQ,
+        TokenContent::Operator(TokenOp::NE) => expr::BinaryOperator::NE,
+        _ => break,
+      };
+      parser.consume();
+      let e2 = parse_term(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_term(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_factor(parser);
+    loop {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      let operator = match parser.peek().1 {
+        TokenContent::Operator(TokenOp::PLUS) => expr::BinaryOperator::PLUS,
+        TokenContent::Operator(TokenOp::MINUS) => expr::BinaryOperator::MINUS,
+        _ => break,
+      };
+      parser.consume();
+      let e2 = parse_factor(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_factor(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_concat(parser);
+    loop {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      let operator = match parser.peek().1 {
+        TokenContent::Operator(TokenOp::MUL) => expr::BinaryOperator::MUL,
+        TokenContent::Operator(TokenOp::DIV) => expr::BinaryOperator::DIV,
+        TokenContent::Operator(TokenOp::MOD) => expr::BinaryOperator::MOD,
+        _ => break,
+      };
+      parser.consume();
+      let e2 = parse_concat(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_concat(parser: &mut super::SourceParser) -> expr::E<()> {
+    let mut e = parse_unary_expression(parser);
+    while let TokenContent::Operator(TokenOp::COLONCOLON) = parser.peek().1 {
+      let concrete_comments = parser.collect_preceding_comments();
+      let operator_preceding_comments =
+        parser.comments_store.create_comment_reference(concrete_comments);
+      parser.consume();
+      let e2 = parse_unary_expression(parser);
+      let loc = e.loc().union(&e2.loc());
+      e = expr::E::Binary(expr::Binary {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(vec![]),
+          type_: (),
+        },
+        operator_preceding_comments,
+        operator: expr::BinaryOperator::CONCAT,
+        e1: Box::new(e),
+        e2: Box::new(e2),
+      })
+    }
+    e
+  }
+
+  fn parse_unary_expression(parser: &mut super::SourceParser) -> expr::E<()> {
+    let associated_comments = parser.collect_preceding_comments();
+    let Token(peeked_loc, content) = parser.peek();
+    match content {
+      TokenContent::Operator(TokenOp::NOT) => {
+        parser.consume();
+        let argument = parse_function_call_or_field_access(parser);
+        let loc = peeked_loc.union(&argument.loc());
+        expr::E::Unary(expr::Unary {
+          common: expr::ExpressionCommon {
+            loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          operator: expr::UnaryOperator::NOT,
+          argument: Box::new(argument),
+        })
+      }
+      TokenContent::Operator(TokenOp::MINUS) => {
+        parser.consume();
+        let argument = parse_function_call_or_field_access(parser);
+        let loc = peeked_loc.union(&argument.loc());
+        expr::E::Unary(expr::Unary {
+          common: expr::ExpressionCommon {
+            loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          operator: expr::UnaryOperator::NEG,
+          argument: Box::new(argument),
+        })
+      }
+      _ => parse_function_call_or_field_access(parser),
+    }
+  }
+
+  fn parse_function_call_or_field_access(parser: &mut super::SourceParser) -> expr::E<()> {
+    // Treat function arguments or field name as postfix.
+    // Then use Kleene star trick to parse.
+    let mut function_expression = parse_base_expression(parser);
+    loop {
+      match parser.peek() {
+        Token(dot_loc, TokenContent::Operator(TokenOp::DOT)) => {
+          let mut field_preceding_comments = parser.collect_preceding_comments();
+          parser.consume();
+          field_preceding_comments.append(&mut parser.collect_preceding_comments());
+          let (field_loc, field_name) = match parser.peek() {
+            Token(l, TokenContent::LowerId(id) | TokenContent::UpperId(id)) => {
+              parser.consume();
+              (l, id)
+            }
+            Token(l, t) => {
+              parser
+                .report(l, format!("Expected identifier, but get {}", t.pretty_print(parser.heap)));
+              (Location { end: l.start, ..dot_loc }, PStr::MISSING)
+            }
+          };
+          let mut loc = function_expression.loc().union(&field_loc);
+          let explicit_type_arguments =
+            if let Token(_, TokenContent::Operator(TokenOp::LT)) = parser.peek() {
+              field_preceding_comments.append(&mut parser.collect_preceding_comments());
+              parser.assert_and_consume_operator(TokenOp::LT);
+              let type_args = parser.parse_comma_separated_list_with_end_token(
+                TokenOp::GT,
+                &mut super::type_parser::parse_annotation,
+              );
+              loc = loc.union(&parser.assert_and_consume_operator(TokenOp::GT));
+              type_args
+            } else {
+              vec![]
+            };
+          function_expression = expr::E::FieldAccess(expr::FieldAccess {
+            common: expr::ExpressionCommon {
+              loc,
+              associated_comments: parser.comments_store.create_comment_reference(vec![]),
+              type_: (),
+            },
+            explicit_type_arguments,
+            inferred_type_arguments: vec![],
+            object: Box::new(function_expression),
+            field_name: Id {
+              loc: field_loc,
+              associated_comments: parser
+                .comments_store
+                .create_comment_reference(field_preceding_comments),
+              name: field_name,
+            },
+            field_order: -1,
+          });
+        }
+        Token(_, TokenContent::Operator(TokenOp::LPAREN)) => {
+          parser.consume();
+          let function_arguments =
+            if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = parser.peek() {
+              vec![]
+            } else {
+              parser.parse_comma_separated_list_with_end_token(
+                TokenOp::RPAREN,
+                &mut parse_expression_with_ending_comments,
+              )
+            };
+          let loc =
+            function_expression.loc().union(&parser.assert_and_consume_operator(TokenOp::RPAREN));
+          function_expression = expr::E::Call(expr::Call {
+            common: expr::ExpressionCommon {
+              loc,
+              associated_comments: parser.comments_store.create_comment_reference(vec![]),
+              type_: (),
+            },
+            callee: Box::new(function_expression),
+            arguments: function_arguments,
+          })
+        }
+        _ => return function_expression,
+      }
+    }
+  }
+
+  fn parse_base_expression(parser: &mut super::SourceParser) -> expr::E<()> {
+    let associated_comments = parser.collect_preceding_comments();
+    let peeked = parser.peek();
+
+    match peeked {
+      Token(peeked_loc, TokenContent::Keyword(Keyword::TRUE)) => {
+        parser.consume();
+        return expr::E::Literal(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Literal::Bool(true),
+        );
+      }
+      Token(peeked_loc, TokenContent::Keyword(Keyword::FALSE)) => {
+        parser.consume();
+        return expr::E::Literal(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Literal::Bool(false),
+        );
+      }
+      Token(peeked_loc, TokenContent::IntLiteral(i)) => {
+        parser.consume();
+        return expr::E::Literal(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Literal::Int(i.as_str(parser.heap).parse::<i32>().unwrap_or(0)),
+        );
+      }
+      Token(peeked_loc, TokenContent::StringLiteral(s)) => {
+        parser.consume();
+        let chars = s.as_str(parser.heap).chars().collect_vec();
+        let str_lit =
+          super::utils::unescape_quotes(&chars[1..(chars.len() - 1)].iter().collect::<String>());
+        return expr::E::Literal(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Literal::String(parser.heap.alloc_string(str_lit)),
+        );
+      }
+      Token(peeked_loc, TokenContent::Keyword(Keyword::THIS)) => {
+        parser.consume();
+        return expr::E::LocalId(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Id {
+            loc: peeked_loc,
+            associated_comments: parser.comments_store.create_comment_reference(vec![]),
+            name: PStr::THIS,
+          },
+        );
+      }
+      Token(peeked_loc, TokenContent::LowerId(name)) => {
+        parser.consume();
+        return expr::E::LocalId(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          Id {
+            loc: peeked_loc,
+            associated_comments: parser.comments_store.create_comment_reference(vec![]),
+            name,
+          },
+        );
+      }
+      Token(peeked_loc, TokenContent::UpperId(name)) => {
+        parser.consume();
+        return expr::E::ClassId(
+          expr::ExpressionCommon {
+            loc: peeked_loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          super::utils::resolve_class(parser, name),
+          Id {
+            loc: peeked_loc,
+            associated_comments: parser.comments_store.create_comment_reference(vec![]),
+            name,
+          },
+        );
+      }
+      _ => {}
+    }
+
+    // Lambda or tuple or nested expression
+    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LPAREN)) = peeked {
+      parser.consume();
+      // () -> ...
+      if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = parser.peek() {
+        let mut comments = associated_comments;
+        parser.consume();
+        comments.append(&mut parser.collect_preceding_comments());
+        parser.assert_and_consume_operator(TokenOp::ARROW);
+        let body = parse_expression(parser);
+        let loc = peeked_loc.union(&body.loc());
+        return expr::E::Lambda(expr::Lambda {
+          common: expr::ExpressionCommon {
+            loc,
+            associated_comments: parser.comments_store.create_comment_reference(comments),
+            type_: (),
+          },
+          parameters: vec![],
+          captured: HashMap::new(),
+          body: Box::new(body),
+        });
+      }
+
+      // (id ...
+      if let Token(loc_id_for_lambda, TokenContent::LowerId(id_for_lambda)) = parser.peek() {
+        parser.consume();
+        let next = parser.peek();
+        match next.1 {
+          // (id: ... definitely a lambda
+          TokenContent::Operator(TokenOp::COLON) => {
+            parser.unconsume();
+            let parameters = parser.parse_comma_separated_list_with_end_token(
+              TokenOp::RPAREN,
+              &mut super::type_parser::parse_optionally_annotated_id,
+            );
+            parser.assert_and_consume_operator(TokenOp::RPAREN);
+            parser.assert_and_consume_operator(TokenOp::ARROW);
+            let body = parse_expression(parser);
+            let loc = peeked_loc.union(&body.loc());
+            return expr::E::Lambda(expr::Lambda {
+              common: expr::ExpressionCommon {
+                loc,
+                associated_comments: parser
+                  .comments_store
+                  .create_comment_reference(associated_comments),
+                type_: (),
+              },
+              parameters,
+              captured: HashMap::new(),
+              body: Box::new(body),
+            });
+          }
+          // (id, ..., might be lambda, might be tuple
+          TokenContent::Operator(TokenOp::COMMA) => {
+            parser.unconsume();
+            // Advance as far as possible for a comma separated lower id.
+            // This is common for both arrow function and tuple.
+            let mut parameters_or_tuple_elements_cover = vec![parser.parse_lower_id()];
+            while let Token(_, TokenContent::Operator(TokenOp::COMMA)) = parser.peek() {
+              parser.consume();
+              if let Token(_, TokenContent::LowerId(_)) = parser.peek() {
+                parser.consume();
+                match parser.peek() {
+                  Token(_, TokenContent::Operator(TokenOp::COMMA))
+                  | Token(_, TokenContent::Operator(TokenOp::RPAREN)) => {
+                    parser.unconsume(); // unconsume lower id
+                    parameters_or_tuple_elements_cover.push(parser.parse_lower_id());
+                  }
+                  _ => {
+                    parser.unconsume(); // unconsume lower id
+                    break;
+                  }
+                }
+              } else {
+                break;
+              }
+            }
+            // If we see ), it means that the cover is complete and still ambiguous.
+            if let Token(right_parenthesis_loc, TokenContent::Operator(TokenOp::RPAREN)) =
+              parser.peek()
+            {
+              parser.consume();
+              if let Token(_, TokenContent::Operator(TokenOp::ARROW)) = parser.peek() {
+                parser.consume();
+                let body = parse_expression(parser);
+                let loc = peeked_loc.union(&body.loc());
+                return expr::E::Lambda(expr::Lambda {
+                  common: expr::ExpressionCommon {
+                    loc,
+                    associated_comments: parser
+                      .comments_store
+                      .create_comment_reference(associated_comments),
+                    type_: (),
+                  },
+                  parameters: parameters_or_tuple_elements_cover
+                    .into_iter()
+                    .map(|name| OptionallyAnnotatedId { name, type_: (), annotation: None })
+                    .collect(),
+                  captured: HashMap::new(),
+                  body: Box::new(body),
+                });
+              } else {
+                let tuple_elements = parameters_or_tuple_elements_cover
+                  .into_iter()
+                  .map(|name| {
+                    expr::E::LocalId(
+                      expr::ExpressionCommon {
+                        loc: name.loc,
+                        associated_comments: NO_COMMENT_REFERENCE,
+                        type_: (),
+                      },
+                      name,
+                    )
+                  })
+                  .collect_vec();
+                let loc = peeked_loc.union(&right_parenthesis_loc);
+                return expr::E::Tuple(
+                  expr::ExpressionCommon {
+                    loc,
+                    associated_comments: parser
+                      .comments_store
+                      .create_comment_reference(associated_comments),
+                    type_: (),
+                  },
+                  tuple_elements,
+                );
+              }
+            }
+            if let Token(_, TokenContent::LowerId(_)) = parser.peek() {
+              parser.consume();
+              if let Token(_, TokenContent::Operator(TokenOp::COLON)) = parser.peek() {
+                parser.unconsume();
+                let rest_parameters = parser.parse_comma_separated_list_with_end_token(
+                  TokenOp::RPAREN,
+                  &mut super::type_parser::parse_optionally_annotated_id,
+                );
+                let parameters = parameters_or_tuple_elements_cover
+                  .into_iter()
+                  .map(|name| OptionallyAnnotatedId { name, type_: (), annotation: None })
+                  .chain(rest_parameters)
+                  .collect_vec();
+                parser.assert_and_consume_operator(TokenOp::RPAREN);
+                parser.assert_and_consume_operator(TokenOp::ARROW);
+                let body = parse_expression(parser);
+                let loc = peeked_loc.union(&body.loc());
+                return expr::E::Lambda(expr::Lambda {
+                  common: expr::ExpressionCommon {
+                    loc,
+                    associated_comments: parser
+                      .comments_store
+                      .create_comment_reference(associated_comments),
+                    type_: (),
+                  },
+                  parameters,
+                  captured: HashMap::new(),
+                  body: Box::new(body),
+                });
+              }
+              parser.unconsume();
+            }
+            let rest_tuple_elements = parser
+              .parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut parse_expression);
+            let mut tuple_elements = parameters_or_tuple_elements_cover
+              .into_iter()
+              .map(|name| {
+                expr::E::LocalId(
+                  expr::ExpressionCommon {
+                    loc: name.loc,
+                    associated_comments: NO_COMMENT_REFERENCE,
+                    type_: (),
+                  },
+                  name,
+                )
+              })
+              .chain(rest_tuple_elements)
+              .collect_vec();
+            if let Some(node) = tuple_elements.get(MAX_STRUCT_SIZE) {
+              parser.error_set.report_invalid_syntax_error(
+                node.loc(),
+                format!("Maximum allowed tuple size is {MAX_STRUCT_SIZE}"),
+              );
+            }
+            tuple_elements.truncate(MAX_STRUCT_SIZE);
+            let end_loc = parser.assert_and_consume_operator(TokenOp::RPAREN);
+            let loc = peeked_loc.union(&end_loc);
+            let common = expr::ExpressionCommon {
+              loc,
+              associated_comments: parser
+                .comments_store
+                .create_comment_reference(associated_comments),
+              type_: (),
+            };
+            debug_assert!(tuple_elements.len() > 1);
+            return expr::E::Tuple(common, tuple_elements);
+          }
+          // (id) -> ... OR (id)
+          TokenContent::Operator(TokenOp::RPAREN) => {
+            parser.consume();
+            if let Token(_, TokenContent::Operator(TokenOp::ARROW)) = parser.peek() {
+              let mut comments = associated_comments;
+              comments.append(&mut parser.collect_preceding_comments());
+              parser.consume();
+              let body = parse_expression(parser);
+              let loc = peeked_loc.union(&body.loc());
+              return expr::E::Lambda(expr::Lambda {
+                common: expr::ExpressionCommon {
+                  loc,
+                  associated_comments: parser.comments_store.create_comment_reference(comments),
+                  type_: (),
+                },
+                parameters: vec![OptionallyAnnotatedId {
+                  name: Id {
+                    loc: loc_id_for_lambda,
+                    associated_comments: parser.comments_store.create_comment_reference(vec![]),
+                    name: id_for_lambda,
+                  },
+                  type_: (),
+                  annotation: None,
+                }],
+                captured: HashMap::new(),
+                body: Box::new(body),
+              });
+            } else {
+              // (id)
+              parser.unconsume();
+            }
+          }
+          _ => {}
+        }
+        parser.unconsume();
+      }
+      let mut expressions =
+        parser.parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut parse_expression);
+      if let Some(node) = expressions.get(MAX_STRUCT_SIZE) {
+        parser.error_set.report_invalid_syntax_error(
+          node.loc(),
+          format!("Maximum allowed tuple size is {MAX_STRUCT_SIZE}"),
+        );
+      }
+      expressions.truncate(MAX_STRUCT_SIZE);
+      let end_loc = parser.assert_and_consume_operator(TokenOp::RPAREN);
+      let loc = peeked_loc.union(&end_loc);
+      let common = expr::ExpressionCommon {
+        loc,
+        associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+        type_: (),
+      };
+      debug_assert!(!expressions.is_empty());
+      if expressions.len() == 1 {
+        return expressions.pop().unwrap();
+      }
+      return expr::E::Tuple(common, expressions);
+    }
+
+    // Statement Block: { ... }
+    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LBRACE)) = peeked {
+      parser.consume();
+
+      let mut statements = vec![];
+      while let Token(_, TokenContent::Keyword(Keyword::LET)) = parser.peek() {
+        statements.push(parse_statement(parser));
+      }
+
+      // No final expression
+      if let Token(end_loc, TokenContent::Operator(TokenOp::RBRACE)) = parser.peek() {
+        parser.consume();
+        let loc = peeked_loc.union(&end_loc);
+        return expr::E::Block(expr::Block {
+          common: expr::ExpressionCommon {
+            loc,
+            associated_comments: parser
+              .comments_store
+              .create_comment_reference(associated_comments),
+            type_: (),
+          },
+          statements,
+          expression: None,
+        });
+      }
+
+      // Has final expression
+      let expression = parse_expression_with_ending_comments(parser);
+      let loc = peeked_loc.union(&parser.assert_and_consume_operator(TokenOp::RBRACE));
+      return expr::E::Block(expr::Block {
+        common: expr::ExpressionCommon {
+          loc,
+          associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+          type_: (),
+        },
+        statements,
+        expression: Some(Box::new(expression)),
+      });
+    }
+
+    // Error case
+    parser.report(
+      peeked.0,
+      format!("Expected: expression, actual: {}", peeked.1.pretty_print(parser.heap)),
+    );
+    expr::E::Literal(
+      expr::ExpressionCommon {
+        loc: peeked.0,
+        associated_comments: parser.comments_store.create_comment_reference(associated_comments),
+        type_: (),
+      },
+      Literal::Int(0),
+    )
+  }
+
+  pub(super) fn parse_statement(
+    parser: &mut super::SourceParser,
+  ) -> expr::DeclarationStatement<()> {
+    let concrete_comments = parser.collect_preceding_comments();
+    let associated_comments = parser.comments_store.create_comment_reference(concrete_comments);
+    let start_loc = parser.assert_and_consume_keyword(Keyword::LET);
+    let pattern = super::pattern_parser::parse_matching_pattern(parser);
+    let annotation = if let Token(_, TokenContent::Operator(TokenOp::COLON)) = parser.peek() {
+      parser.consume();
+      Some(super::type_parser::parse_annotation(parser))
+    } else {
+      None
+    };
+    parser.assert_and_consume_operator(TokenOp::ASSIGN);
+    let assigned_expression = Box::new(parse_expression(parser));
+    let loc = start_loc.union(&parser.assert_and_consume_operator(TokenOp::SEMICOLON));
+    expr::DeclarationStatement {
+      loc,
+      associated_comments,
+      pattern,
+      annotation,
+      assigned_expression,
+    }
+  }
+}
+
+mod pattern_parser {
+  use super::super::lexer::{Keyword, Token, TokenContent, TokenOp};
+  use samlang_ast::source::*;
+
+  pub(super) fn parse_matching_pattern_with_unit(
+    parser: &mut super::SourceParser,
+  ) -> (pattern::MatchingPattern<()>, ()) {
+    (parse_matching_pattern(parser), ())
+  }
+
+  pub(super) fn parse_matching_pattern(
+    parser: &mut super::SourceParser,
+  ) -> pattern::MatchingPattern<()> {
+    let peeked = parser.peek();
+    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LPAREN)) = peeked {
+      parser.consume();
+      let destructured_names = parser.parse_comma_separated_list_with_end_token(
+        TokenOp::RPAREN,
+        &mut |s: &mut super::SourceParser| pattern::TuplePatternElement {
+          pattern: Box::new(parse_matching_pattern(s)),
+          type_: (),
+        },
+      );
+      let end_location = parser.assert_and_consume_operator(TokenOp::RPAREN);
+      return pattern::MatchingPattern::Tuple(peeked_loc.union(&end_location), destructured_names);
+    }
+    if let Token(peeked_loc, TokenContent::Operator(TokenOp::LBRACE)) = peeked {
+      parser.consume();
+      let destructured_names = parser.parse_comma_separated_list_with_end_token(
+        TokenOp::RBRACE,
+        &mut |s: &mut super::SourceParser| {
+          let field_name = s.parse_lower_id();
+          let (pattern, loc, shorthand) =
+            if let Token(_, TokenContent::Keyword(Keyword::AS)) = s.peek() {
+              s.consume();
+              let nested = Box::new(parse_matching_pattern(s));
+              let loc = field_name.loc.union(nested.loc());
+              (nested, loc, false)
+            } else {
+              (Box::new(pattern::MatchingPattern::Id(field_name, ())), field_name.loc, true)
+            };
+          pattern::ObjectPatternElement {
+            loc,
+            field_name,
+            field_order: 0,
+            pattern,
+            shorthand,
+            type_: (),
+          }
+        },
+      );
+      let end_location = parser.assert_and_consume_operator(TokenOp::RBRACE);
+      return pattern::MatchingPattern::Object(peeked_loc.union(&end_location), destructured_names);
+    }
+    if let Token(peeked_loc, TokenContent::UpperId(id)) = peeked {
+      parser.consume();
+      let tag = Id { loc: peeked_loc, associated_comments: NO_COMMENT_REFERENCE, name: id };
+      let (data_variables, loc) =
+        if let Token(_, TokenContent::Operator(TokenOp::LPAREN)) = parser.peek() {
+          parser.consume();
+          let data_variables = parser.parse_comma_separated_list_with_end_token(
+            TokenOp::RPAREN,
+            &mut parse_matching_pattern_with_unit,
+          );
+          let end_loc = parser.assert_and_consume_operator(TokenOp::RPAREN);
+          (data_variables, peeked_loc.union(&end_loc))
+        } else {
+          (Vec::with_capacity(0), peeked_loc)
+        };
+      return pattern::MatchingPattern::Variant(pattern::VariantPattern {
+        loc,
+        tag_order: 0,
+        tag,
+        data_variables,
+        type_: (),
+      });
+    }
+    if let Token(peeked_loc, TokenContent::Operator(TokenOp::UNDERSCORE)) = peeked {
+      parser.consume();
+      return pattern::MatchingPattern::Wildcard(peeked_loc);
+    }
+    pattern::MatchingPattern::Id(
+      Id {
+        loc: peeked.0,
+        associated_comments: NO_COMMENT_REFERENCE,
+        name: parser.assert_and_peek_lower_id().1,
+      },
+      (),
+    )
+  }
+}
+
+mod type_parser {
+  use super::super::lexer::{Keyword, Token, TokenContent, TokenOp};
+  use samlang_ast::source::*;
+
+  pub(super) fn parse_type_parameter(parser: &mut super::SourceParser) -> TypeParameter {
+    let name = &parser.parse_upper_id();
+    let (bound, loc) = if let Token(_, TokenContent::Operator(TokenOp::COLON)) = parser.peek() {
+      parser.consume();
+      let id = parser.parse_upper_id();
+      let bound = super::type_parser::parse_identifier_annot(parser, id);
+      let loc = name.loc.union(&bound.location);
+      (Some(bound), loc)
+    } else {
+      (None, name.loc)
+    };
+    TypeParameter { loc, name: *name, bound }
+  }
+
+  pub(super) fn parse_annotated_id(parser: &mut super::SourceParser) -> AnnotatedId<()> {
+    let name = parser.parse_lower_id();
+    parser.assert_and_consume_operator(TokenOp::COLON);
+    let annotation = parse_annotation(parser);
     AnnotatedId { name, type_: (), annotation }
   }
 
-  fn parse_optionally_annotated_id(&mut self) -> OptionallyAnnotatedId<()> {
-    let name = self.parse_lower_id();
-    let annotation = self.parse_optional_annotation();
+  pub(super) fn parse_optionally_annotated_id(
+    parser: &mut super::SourceParser,
+  ) -> OptionallyAnnotatedId<()> {
+    let name = parser.parse_lower_id();
+    let annotation = parse_optional_annotation(parser);
     OptionallyAnnotatedId { name, type_: (), annotation }
   }
 
-  fn parse_optional_annotation(&mut self) -> Option<annotation::T> {
-    if let Token(_, TokenContent::Operator(TokenOp::COLON)) = self.peek() {
-      self.consume();
-      Some(self.parse_annotation())
+  fn parse_optional_annotation(parser: &mut super::SourceParser) -> Option<annotation::T> {
+    if let Token(_, TokenContent::Operator(TokenOp::COLON)) = parser.peek() {
+      parser.consume();
+      Some(parse_annotation(parser))
     } else {
       None
     }
   }
 
-  pub(super) fn parse_annotation(&mut self) -> annotation::T {
-    let associated_comments = self.collect_preceding_comments();
-    let peeked = self.peek();
+  pub(super) fn parse_annotation(parser: &mut super::SourceParser) -> annotation::T {
+    let associated_comments = parser.collect_preceding_comments();
+    let peeked = parser.peek();
     match peeked.1 {
       TokenContent::Keyword(Keyword::UNIT) => {
-        self.consume();
+        parser.consume();
         annotation::T::Primitive(
           peeked.0,
-          self.comments_store.create_comment_reference(associated_comments),
+          parser.comments_store.create_comment_reference(associated_comments),
           annotation::PrimitiveTypeKind::Unit,
         )
       }
       TokenContent::Keyword(Keyword::BOOL) => {
-        self.consume();
+        parser.consume();
         annotation::T::Primitive(
           peeked.0,
-          self.comments_store.create_comment_reference(associated_comments),
+          parser.comments_store.create_comment_reference(associated_comments),
           annotation::PrimitiveTypeKind::Bool,
         )
       }
       TokenContent::Keyword(Keyword::INT) => {
-        self.consume();
+        parser.consume();
         annotation::T::Primitive(
           peeked.0,
-          self.comments_store.create_comment_reference(associated_comments),
+          parser.comments_store.create_comment_reference(associated_comments),
           annotation::PrimitiveTypeKind::Int,
         )
       }
       TokenContent::UpperId(name) => {
-        self.consume();
-        let associated_comments = self.comments_store.create_comment_reference(vec![]);
-        let id_annot = self.parse_identifier_annot(Id { loc: peeked.0, associated_comments, name });
-        if id_annot.type_arguments.is_empty() && self.available_tparams.contains(&id_annot.id.name)
+        parser.consume();
+        let associated_comments = parser.comments_store.create_comment_reference(vec![]);
+        let id_annot =
+          parse_identifier_annot(parser, Id { loc: peeked.0, associated_comments, name });
+        if id_annot.type_arguments.is_empty()
+          && parser.available_tparams.contains(&id_annot.id.name)
         {
           annotation::T::Generic(id_annot.location, id_annot.id)
         } else {
@@ -1653,98 +1710,113 @@ impl<'a> SourceParser<'a> {
         }
       }
       TokenContent::Operator(TokenOp::LPAREN) => {
-        self.consume();
-        let argument_types = if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = self.peek()
-        {
-          self.consume();
-          vec![]
-        } else {
-          let types = self.parse_comma_separated_list_with_end_token(
-            TokenOp::RPAREN,
-            &mut SourceParser::parse_annotation,
-          );
-          self.assert_and_consume_operator(TokenOp::RPAREN);
-          types
-        };
-        self.assert_and_consume_operator(TokenOp::ARROW);
-        let return_type = self.parse_annotation();
+        parser.consume();
+        let argument_types =
+          if let Token(_, TokenContent::Operator(TokenOp::RPAREN)) = parser.peek() {
+            parser.consume();
+            vec![]
+          } else {
+            let types = parser
+              .parse_comma_separated_list_with_end_token(TokenOp::RPAREN, &mut parse_annotation);
+            parser.assert_and_consume_operator(TokenOp::RPAREN);
+            types
+          };
+        parser.assert_and_consume_operator(TokenOp::ARROW);
+        let return_type = parse_annotation(parser);
         let location = peeked.0.union(&return_type.location());
         annotation::T::Fn(annotation::Function {
           location,
-          associated_comments: self.comments_store.create_comment_reference(associated_comments),
+          associated_comments: parser.comments_store.create_comment_reference(associated_comments),
           argument_types,
           return_type: Box::new(return_type),
         })
       }
       content => {
-        self.report(
+        parser.report(
           peeked.0,
-          format!("Expecting: type, actual: {}", content.pretty_print(self.heap)),
+          format!("Expecting: type, actual: {}", content.pretty_print(parser.heap)),
         );
         annotation::T::Primitive(
           peeked.0,
-          self.comments_store.create_comment_reference(associated_comments),
+          parser.comments_store.create_comment_reference(associated_comments),
           annotation::PrimitiveTypeKind::Any,
         )
       }
     }
   }
 
-  fn fix_tparams_with_generic_annot(&self, tparams: &mut [TypeParameter]) {
+  pub(super) fn fix_tparams_with_generic_annot(
+    parser: &mut super::SourceParser,
+    tparams: &mut [TypeParameter],
+  ) {
     for tparam in tparams {
       if let Some(bound) = &mut tparam.bound {
         for annot in &mut bound.type_arguments {
-          self.fix_annot_with_generic_annot(annot);
+          fix_annot_with_generic_annot(parser, annot);
         }
       }
     }
   }
 
-  fn fix_annot_with_generic_annot(&self, annot: &mut annotation::T) {
+  pub(super) fn fix_annot_with_generic_annot(
+    parser: &mut super::SourceParser,
+    annot: &mut annotation::T,
+  ) {
     match annot {
       annotation::T::Primitive(_, _, _) | annotation::T::Generic(_, _) => {}
       annotation::T::Id(id_annot) => {
-        if id_annot.type_arguments.is_empty() && self.available_tparams.contains(&id_annot.id.name)
+        if id_annot.type_arguments.is_empty()
+          && parser.available_tparams.contains(&id_annot.id.name)
         {
           *annot = annotation::T::Generic(id_annot.location, id_annot.id)
         }
       }
       annotation::T::Fn(t) => {
         for annot in &mut t.argument_types {
-          self.fix_annot_with_generic_annot(annot);
+          fix_annot_with_generic_annot(parser, annot);
         }
-        self.fix_annot_with_generic_annot(&mut t.return_type);
+        fix_annot_with_generic_annot(parser, &mut t.return_type);
       }
     }
   }
 
-  fn parse_identifier_annot(&mut self, identifier: Id) -> annotation::Id {
+  pub(super) fn parse_identifier_annot(
+    parser: &mut super::SourceParser,
+    identifier: Id,
+  ) -> annotation::Id {
     let (type_arguments, location) =
-      if let Token(_, TokenContent::Operator(TokenOp::LT)) = self.peek() {
-        self.consume();
-        let types = self.parse_comma_separated_list_with_end_token(
-          TokenOp::GT,
-          &mut SourceParser::parse_annotation,
-        );
-        let location = identifier.loc.union(&self.assert_and_consume_operator(TokenOp::GT));
+      if let Token(_, TokenContent::Operator(TokenOp::LT)) = parser.peek() {
+        parser.consume();
+        let types =
+          parser.parse_comma_separated_list_with_end_token(TokenOp::GT, &mut parse_annotation);
+        let location = identifier.loc.union(&parser.assert_and_consume_operator(TokenOp::GT));
         (types, location)
       } else {
         (vec![], identifier.loc)
       };
     annotation::Id {
       location,
-      module_reference: self.resolve_class(identifier.name),
+      module_reference: super::utils::resolve_class(parser, identifier.name),
       id: identifier,
       type_arguments,
     }
   }
+}
 
-  fn resolve_class(&mut self, class_name: PStr) -> ModuleReference {
-    if self.builtin_classes.contains(&class_name) {
-      ModuleReference::ROOT
+mod utils {
+  pub(super) fn resolve_class(
+    parser: &super::SourceParser,
+    class_name: samlang_heap::PStr,
+  ) -> samlang_heap::ModuleReference {
+    if parser.builtin_classes.contains(&class_name) {
+      samlang_heap::ModuleReference::ROOT
     } else {
-      *self.class_source_map.get(&class_name).unwrap_or(&self.module_reference)
+      *parser.class_source_map.get(&class_name).unwrap_or(&parser.module_reference)
     }
+  }
+
+  pub(super) fn unescape_quotes(source: &str) -> String {
+    source.replace("\\\"", "\"")
   }
 }
 
@@ -1801,15 +1873,15 @@ mod tests {
     let mut parser =
       SourceParser::new(tokens, heap, &mut error_set, ModuleReference::DUMMY, HashSet::new());
 
-    parser.parse_interface();
-    parser.parse_class();
-    parser.parse_class_member_definition();
-    parser.parse_class_member_declaration();
-    parser.parse_expression();
-    parser.parse_matching_pattern();
-    parser.parse_statement();
-    parser.parse_annotation();
-    parser.parse_module();
+    super::pattern_parser::parse_matching_pattern(&mut parser);
+    super::expression_parser::parse_expression(&mut parser);
+    super::expression_parser::parse_statement(&mut parser);
+    super::type_parser::parse_annotation(&mut parser);
+    super::toplevel_parser::parse_interface(&mut parser);
+    super::toplevel_parser::parse_class(&mut parser);
+    super::toplevel_parser::parse_class_member_definition(&mut parser);
+    super::toplevel_parser::parse_class_member_declaration(&mut parser);
+    super::parse_module(parser);
   }
 
   #[test]

--- a/crates/samlang-services/src/location_cover.rs
+++ b/crates/samlang-services/src/location_cover.rs
@@ -153,14 +153,21 @@ fn search_expression(
     expr::E::Lambda(e) => {
       for param in &e.parameters {
         if param.name.loc.contains_position(position) {
-          if let Some(annot) = &param.annotation {
-            return Some(LocationCoverSearchResult::TypedName(
+          return if let Some(annot) = &param.annotation {
+            Some(LocationCoverSearchResult::TypedName(
               param.name.loc,
               param.name.name,
               Type::from_annotation(annot),
               true,
-            ));
-          }
+            ))
+          } else {
+            Some(LocationCoverSearchResult::TypedName(
+              param.name.loc,
+              param.name.name,
+              param.type_.as_ref().clone(),
+              false,
+            ))
+          };
         }
       }
       search_expression(&e.body, position, stop_at_call)

--- a/packages/samlang-website/src/components/samlang-wasm-glue.js
+++ b/packages/samlang-website/src/components/samlang-wasm-glue.js
@@ -3,97 +3,95 @@ async function interpretWebAssemblyModule(emittedWasmBinary) {
   const memory = new WebAssembly.Memory({ initial: 2, maximum: 65536 });
   function pointerToString(p) {
     const mem = new Uint8Array(memory.buffer);
-    const length = mem[p + 4] | mem[p + 5] << 8 | mem[p + 6] << 16 | mem[p + 7] << 24;
+    const length = mem[p + 4] | (mem[p + 5] << 8) | (mem[p + 6] << 16) | (mem[p + 7] << 24);
     const characterCodes = Array.from(mem.subarray(p + 8, p + 8 + length).values());
     return String.fromCharCode(...characterCodes);
   }
-  let printed = "";
+  let printed = '';
   const builtins = {
     __Process$println(_, p) {
       printed += pointerToString(p);
-      printed += "\n";
+      printed += '\n';
       return 0;
     },
     __Process$panic(_, p) {
       throw new Error(pointerToString(p));
-    }
+    },
   };
   const codeModule = await WebAssembly.instantiate(emittedWasmBinary, {
     env: { memory },
-    builtins
+    builtins,
   });
   const exports = codeModule.instance.exports;
-  exports["_Demo_Main$main"]?.();
+  exports['_Demo_Main$main']?.();
   return printed;
 }
 
 // samlang-demo/samlang_wasm.js
-var getObject = function(idx) {
+var getObject = function (idx) {
   return heap[idx];
 };
-var dropObject = function(idx) {
-  if (idx < 132)
-    return;
+var dropObject = function (idx) {
+  if (idx < 132) return;
   heap[idx] = heap_next;
   heap_next = idx;
 };
-var takeObject = function(idx) {
+var takeObject = function (idx) {
   const ret = getObject(idx);
   dropObject(idx);
   return ret;
 };
-var addHeapObject = function(obj) {
-  if (heap_next === heap.length)
-    heap.push(heap.length + 1);
+var addHeapObject = function (obj) {
+  if (heap_next === heap.length) heap.push(heap.length + 1);
   const idx = heap_next;
   heap_next = heap[idx];
   heap[idx] = obj;
   return idx;
 };
-var getUint8Memory0 = function() {
+var getUint8Memory0 = function () {
   if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
     cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
   }
   return cachedUint8Memory0;
 };
-var getStringFromWasm0 = function(ptr, len) {
+var getStringFromWasm0 = function (ptr, len) {
   ptr = ptr >>> 0;
   return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
 };
-var debugString = function(val) {
+var debugString = function (val) {
   const type = typeof val;
-  if (type == "number" || type == "boolean" || val == null) {
+  if (type == 'number' || type == 'boolean' || val == null) {
     return `${val}`;
   }
-  if (type == "string") {
+  if (type == 'string') {
     return `"${val}"`;
   }
-  if (type == "symbol") {
+  if (type == 'symbol') {
     const description = val.description;
     if (description == null) {
-      return "Symbol";
+      return 'Symbol';
     } else {
       return `Symbol(${description})`;
     }
   }
-  if (type == "function") {
+  if (type == 'function') {
     const name = val.name;
-    if (typeof name == "string" && name.length > 0) {
+    if (typeof name == 'string' && name.length > 0) {
       return `Function(${name})`;
     } else {
-      return "Function";
+      return 'Function';
     }
   }
   if (Array.isArray(val)) {
     const length = val.length;
-    let debug = "[";
+    let debug = '[';
     if (length > 0) {
       debug += debugString(val[0]);
     }
-    for (let i = 1;i < length; i++) {
-      debug += ", " + debugString(val[i]);
+    for (let i = 1; i < length; i++) {
+      debug += ', ' + debugString(val[i]);
     }
-    debug += "]";
+    debug += ']';
     return debug;
   }
   const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
@@ -103,11 +101,11 @@ var debugString = function(val) {
   } else {
     return toString.call(val);
   }
-  if (className == "Object") {
+  if (className == 'Object') {
     try {
-      return "Object(" + JSON.stringify(val) + ")";
+      return 'Object(' + JSON.stringify(val) + ')';
     } catch (_) {
-      return "Object";
+      return 'Object';
     }
   }
   if (val instanceof Error) {
@@ -115,11 +113,13 @@ var debugString = function(val) {
   }
   return className;
 };
-var passStringToWasm0 = function(arg, malloc, realloc) {
+var passStringToWasm0 = function (arg, malloc, realloc) {
   if (realloc === undefined) {
     const buf = cachedTextEncoder.encode(arg);
     const ptr2 = malloc(buf.length, 1) >>> 0;
-    getUint8Memory0().subarray(ptr2, ptr2 + buf.length).set(buf);
+    getUint8Memory0()
+      .subarray(ptr2, ptr2 + buf.length)
+      .set(buf);
     WASM_VECTOR_LEN = buf.length;
     return ptr2;
   }
@@ -127,17 +127,16 @@ var passStringToWasm0 = function(arg, malloc, realloc) {
   let ptr = malloc(len, 1) >>> 0;
   const mem = getUint8Memory0();
   let offset = 0;
-  for (;offset < len; offset++) {
+  for (; offset < len; offset++) {
     const code = arg.charCodeAt(offset);
-    if (code > 127)
-      break;
+    if (code > 127) break;
     mem[ptr + offset] = code;
   }
   if (offset !== len) {
     if (offset !== 0) {
       arg = arg.slice(offset);
     }
-    ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+    ptr = realloc(ptr, len, (len = offset + arg.length * 3), 1) >>> 0;
     const view = getUint8Memory0().subarray(ptr + offset, ptr + len);
     const ret = encodeString(arg, view);
     offset += ret.written;
@@ -145,7 +144,7 @@ var passStringToWasm0 = function(arg, malloc, realloc) {
   WASM_VECTOR_LEN = offset;
   return ptr;
 };
-var getInt32Memory0 = function() {
+var getInt32Memory0 = function () {
   if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
     cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
   }
@@ -193,13 +192,16 @@ function autoComplete(source, line, column) {
   return takeObject(ret);
 }
 async function __wbg_load(module, imports) {
-  if (typeof Response === "function" && module instanceof Response) {
-    if (typeof WebAssembly.instantiateStreaming === "function") {
+  if (typeof Response === 'function' && module instanceof Response) {
+    if (typeof WebAssembly.instantiateStreaming === 'function') {
       try {
         return await WebAssembly.instantiateStreaming(module, imports);
       } catch (e) {
-        if (module.headers.get("Content-Type") != "application/wasm") {
-          console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+        if (module.headers.get('Content-Type') != 'application/wasm') {
+          console.warn(
+            '`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n',
+            e
+          );
         } else {
           throw e;
         }
@@ -216,69 +218,68 @@ async function __wbg_load(module, imports) {
     }
   }
 }
-var __wbg_get_imports = function() {
+var __wbg_get_imports = function () {
   const imports = {};
   imports.wbg = {};
-  imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
+  imports.wbg.__wbindgen_object_drop_ref = function (arg0) {
     takeObject(arg0);
   };
-  imports.wbg.__wbindgen_object_clone_ref = function(arg0) {
+  imports.wbg.__wbindgen_object_clone_ref = function (arg0) {
     const ret = getObject(arg0);
     return addHeapObject(ret);
   };
-  imports.wbg.__wbindgen_string_new = function(arg0, arg1) {
+  imports.wbg.__wbindgen_string_new = function (arg0, arg1) {
     const ret = getStringFromWasm0(arg0, arg1);
     return addHeapObject(ret);
   };
-  imports.wbg.__wbindgen_number_new = function(arg0) {
+  imports.wbg.__wbindgen_number_new = function (arg0) {
     const ret = arg0;
     return addHeapObject(ret);
   };
-  imports.wbg.__wbg_set_841ac57cff3d672b = function(arg0, arg1, arg2) {
+  imports.wbg.__wbg_set_841ac57cff3d672b = function (arg0, arg1, arg2) {
     getObject(arg0)[takeObject(arg1)] = takeObject(arg2);
   };
-  imports.wbg.__wbg_new_898a68150f225f2e = function() {
-    const ret = new Array;
+  imports.wbg.__wbg_new_898a68150f225f2e = function () {
+    const ret = new Array();
     return addHeapObject(ret);
   };
-  imports.wbg.__wbg_new_b51585de1b234aff = function() {
-    const ret = new Object;
+  imports.wbg.__wbg_new_b51585de1b234aff = function () {
+    const ret = new Object();
     return addHeapObject(ret);
   };
-  imports.wbg.__wbg_set_502d29070ea18557 = function(arg0, arg1, arg2) {
+  imports.wbg.__wbg_set_502d29070ea18557 = function (arg0, arg1, arg2) {
     getObject(arg0)[arg1 >>> 0] = takeObject(arg2);
   };
-  imports.wbg.__wbg_buffer_085ec1f694018c4f = function(arg0) {
+  imports.wbg.__wbg_buffer_085ec1f694018c4f = function (arg0) {
     const ret = getObject(arg0).buffer;
     return addHeapObject(ret);
   };
-  imports.wbg.__wbg_newwithbyteoffsetandlength_6da8e527659b86aa = function(arg0, arg1, arg2) {
+  imports.wbg.__wbg_newwithbyteoffsetandlength_6da8e527659b86aa = function (arg0, arg1, arg2) {
     const ret = new Uint8Array(getObject(arg0), arg1 >>> 0, arg2 >>> 0);
     return addHeapObject(ret);
   };
-  imports.wbg.__wbg_new_8125e318e6245eed = function(arg0) {
+  imports.wbg.__wbg_new_8125e318e6245eed = function (arg0) {
     const ret = new Uint8Array(getObject(arg0));
     return addHeapObject(ret);
   };
-  imports.wbg.__wbindgen_debug_string = function(arg0, arg1) {
+  imports.wbg.__wbindgen_debug_string = function (arg0, arg1) {
     const ret = debugString(getObject(arg1));
     const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_export_0, wasm.__wbindgen_export_1);
     const len1 = WASM_VECTOR_LEN;
     getInt32Memory0()[arg0 / 4 + 1] = len1;
     getInt32Memory0()[arg0 / 4 + 0] = ptr1;
   };
-  imports.wbg.__wbindgen_throw = function(arg0, arg1) {
+  imports.wbg.__wbindgen_throw = function (arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
   };
-  imports.wbg.__wbindgen_memory = function() {
+  imports.wbg.__wbindgen_memory = function () {
     const ret = wasm.memory;
     return addHeapObject(ret);
   };
   return imports;
 };
-var __wbg_init_memory = function(imports, maybe_memory) {
-};
-var __wbg_finalize_init = function(instance, module) {
+var __wbg_init_memory = function (imports, maybe_memory) {};
+var __wbg_finalize_init = function (instance, module) {
   wasm = instance.exports;
   __wbg_init.__wbindgen_wasm_module = module;
   cachedInt32Memory0 = null;
@@ -286,13 +287,16 @@ var __wbg_finalize_init = function(instance, module) {
   return wasm;
 };
 async function __wbg_init(input) {
-  if (wasm !== undefined)
-    return wasm;
-  if (typeof input === "undefined") {
-    input = new URL("samlang_wasm_bg.wasm", import.meta.url);
+  if (wasm !== undefined) return wasm;
+  if (typeof input === 'undefined') {
+    input = new URL('samlang_wasm_bg.wasm', import.meta.url);
   }
   const imports = __wbg_get_imports();
-  if (typeof input === "string" || typeof Request === "function" && input instanceof Request || typeof URL === "function" && input instanceof URL) {
+  if (
+    typeof input === 'string' ||
+    (typeof Request === 'function' && input instanceof Request) ||
+    (typeof URL === 'function' && input instanceof URL)
+  ) {
     input = fetch(input);
   }
   __wbg_init_memory(imports);
@@ -303,27 +307,40 @@ var wasm;
 var heap = new Array(128).fill(undefined);
 heap.push(undefined, null, true, false);
 var heap_next = heap.length;
-var cachedTextDecoder = typeof TextDecoder !== "undefined" ? new TextDecoder("utf-8", { ignoreBOM: true, fatal: true }) : { decode: () => {
-  throw Error("TextDecoder not available");
-} };
-if (typeof TextDecoder !== "undefined") {
+var cachedTextDecoder =
+  typeof TextDecoder !== 'undefined'
+    ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true })
+    : {
+        decode: () => {
+          throw Error('TextDecoder not available');
+        },
+      };
+if (typeof TextDecoder !== 'undefined') {
   cachedTextDecoder.decode();
 }
 var cachedUint8Memory0 = null;
 var WASM_VECTOR_LEN = 0;
-var cachedTextEncoder = typeof TextEncoder !== "undefined" ? new TextEncoder("utf-8") : { encode: () => {
-  throw Error("TextEncoder not available");
-} };
-var encodeString = typeof cachedTextEncoder.encodeInto === "function" ? function(arg, view) {
-  return cachedTextEncoder.encodeInto(arg, view);
-} : function(arg, view) {
-  const buf = cachedTextEncoder.encode(arg);
-  view.set(buf);
-  return {
-    read: arg.length,
-    written: buf.length
-  };
-};
+var cachedTextEncoder =
+  typeof TextEncoder !== 'undefined'
+    ? new TextEncoder('utf-8')
+    : {
+        encode: () => {
+          throw Error('TextEncoder not available');
+        },
+      };
+var encodeString =
+  typeof cachedTextEncoder.encodeInto === 'function'
+    ? function (arg, view) {
+        return cachedTextEncoder.encodeInto(arg, view);
+      }
+    : function (arg, view) {
+        const buf = cachedTextEncoder.encode(arg);
+        view.set(buf);
+        return {
+          read: arg.length,
+          written: buf.length,
+        };
+      };
 var cachedInt32Memory0 = null;
 
 class SourcesCompilationResult {
@@ -382,7 +399,7 @@ async function compile2(source) {
     const compilationResult = compile(source);
     const result = {
       tsCode: compilationResult.ts_code,
-      interpreterResult: await interpretWebAssemblyModule(compilationResult.wasm_bytes)
+      interpreterResult: await interpretWebAssemblyModule(compilationResult.wasm_bytes),
     };
     compilationResult.free();
     return result;
@@ -408,5 +425,5 @@ export {
   queryDefinitionLocation2 as queryDefinitionLocation,
   init,
   compile2 as compile,
-  autoComplete2 as autoComplete
+  autoComplete2 as autoComplete,
 };

--- a/std/set.sam
+++ b/std/set.sam
@@ -1,0 +1,458 @@
+import { Comparable } from std.interfaces;
+import { List } from std.list;
+import { Option } from std.option;
+import { Pair, Triple } from std.tuples;
+
+private class NodeEnumerationHelper<E: Comparable<E>, T>(
+  End,
+  More(E, T, NodeEnumerationHelper<E, T>)
+) {
+  function <E: Comparable<E>> cons(
+    set: Set<E>,
+    helper: NodeEnumerationHelper<E, Set<E>>
+  ): NodeEnumerationHelper<E, Set<E>> =
+    match set {
+      Empty -> helper,
+      Leaf(v) -> NodeEnumerationHelper.More(v, Set.empty<E>(), helper),
+      Node(_, v, l, r) -> NodeEnumerationHelper.cons(l, NodeEnumerationHelper.More(v, r, helper)),
+    }
+}
+
+// Adapted from https://github.com/facebook/flow/
+// See src/hack_forked/utils/collections/third-party/flow_set.ml
+class Set<V: Comparable<V>>(Empty, Leaf(V), Node(int, V, Set<V>, Set<V>)) {
+  function <V: Comparable<V>> empty(): Set<V> = Set.Empty()
+
+  function <V: Comparable<V>> singleton(value: V): Set<V> = Set.Leaf(value)
+
+  method isEmpty(): bool =
+    match this {
+      Empty -> true,
+      Leaf(_) -> false,
+      Node(_, _, _, _) -> false,
+    }
+
+  method contains(value: V): bool =
+    match this {
+      Empty -> false,
+      Leaf(v) -> v.compare(value) == 0,
+      Node(_, v, l, r) -> {
+        let c = value.compare(v);
+        c == 0 || (if c < 0 then l.contains(value) else r.contains(value))
+      },
+    }
+
+  method insert(value: V): Set<V> =
+    match this {
+      Empty -> Set.singleton(value),
+      Leaf(v) -> {
+        let c = value.compare(v);
+        if c == 0 then { this } else if c < 0 then {
+          Set.unsafeNode(Set.singleton(value), v, Set.Empty<V>())
+        } else { Set.unsafeNode(this, value, Set.Empty<V>()) }
+      },
+      Node(h, v, l, r) -> {
+        let c = value.compare(v);
+        if c == 0 then { this } else if c < 0 then {
+          let ll = l.insert(value);
+          if l == ll then this else Set.balanced(ll, v, r)
+        } else {
+          let rr = r.insert(value);
+          if r == rr then this else Set.balanced(l, v, rr)
+        }
+      },
+    }
+
+  method split(value: V): Triple<Set<V>, bool, Set<V>> =
+    match this {
+      Empty -> (Set.empty<V>(), false, Set.empty<V>()),
+      Leaf(v) -> {
+        let c = value.compare(v);
+        if c == 0 then { (Set.empty<V>(), true, Set.empty<V>()) } else if c < 0 then {
+          (Set.empty<V>(), false, this)
+        } else { (this, false, Set.empty<V>()) }
+      },
+      Node(_, v, l, r) -> {
+        let c = value.compare(v);
+        if c == 0 then { (l, true, r) } else if c < 0 then {
+          let (ll, pres, rl) = l.split(value);
+          (ll, pres, Set.join(rl, v, r))
+        } else {
+          let (lr, pres, rr) = r.split(value);
+          (Set.join(l, v, lr), pres, rr)
+        }
+      },
+    }
+
+  method union(other: Set<V>): Set<V> =
+    match (this, other) {
+      (Empty, _) -> other,
+      (_, Empty) -> this,
+      (Leaf(v), s2) -> s2.insert(v),
+      (s1, Leaf(v)) -> s1.insert(v),
+      (Node(h1, v1, l1, r1), Node(h2, v2, l2, r2)) -> {
+        if h1 >= h2 then {
+          if h2 == 1 then { this.insert(v2) } else {
+            let (ll2, _, rr2) = other.split(v1);
+            Set.join(l1.union(ll2), v1, r1.union(rr2))
+          }
+        } else if h1 == 1 then { other.insert(v1) } else {
+          let (ll1, _, rr1) = this.split(v2);
+          Set.join(ll1.union(l2), v2, rr1.union(r2))
+        }
+      },
+    }
+
+  method intersection(other: Set<V>): Set<V> =
+    match (this, other) {
+      (Empty, _) -> this,
+      (_, Empty) -> other,
+      (Leaf(v), _) -> { if other.contains(v) then this else Set.Empty() },
+      (Node(_, v1, l1, r1), _) -> {
+        let (l2, b, r2) = other.split(v1);
+        if b then { Set.join(l1.intersection(l2), v1, r1.intersection(r2)) } else {
+          Set.concat(l1.intersection(l2), r1.intersection(r2))
+        }
+      },
+    }
+
+  method disjoint(other: Set<V>): bool = this.intersection(other).isEmpty()
+
+  method diff(other: Set<V>): Set<V> =
+    match (this, other) {
+      (Empty, _) -> this,
+      (_, Empty) -> other,
+      (Leaf(v), _) -> if other.contains(v) then Set.Empty<V>() else this,
+      (Node(_, v1, l1, r1), _) -> {
+        let (l2, b, r2) = other.split(v1);
+        if b then { Set.concat(l1.diff(l2), r1.diff(r2)) } else {
+          Set.join(l1.diff(l2), v1, r1.diff(r2))
+        }
+      },
+    }
+
+  method subset(other: Set<V>): bool =
+    match (this, other) {
+      (Empty, _) -> true,
+      (_, Empty) -> false,
+      (Leaf(v1), Leaf(v2)) -> v1.compare(v2) == 0,
+      (Node(h, v1, _, _), Leaf(v2)) -> h == 1 && v1.compare(v2) == 0,
+      (Leaf(v1), Node(_, v2, l2, r2)) -> {
+        let c = v1.compare(v2);
+        if c == 0 then true else if c < 0 then this.subset(l2) else this.subset(r2)
+      },
+      (Node(_, v1, l1, r1), Node(_, v2, l2, r2)) -> {
+        let c = v1.compare(v2);
+        if c == 0 then { l1.subset(l2) && r1.subset(r2) } else if c < 0 then {
+          Set.unsafeNode(l1, v1, Set.empty<V>()).subset(l2) && r1.subset(other)
+        } else { Set.unsafeNode(Set.empty<V>(), v1, r1).subset(r2) && l1.subset(other) }
+      },
+    }
+
+  private method internalMerge(other: Set<V>): Set<V> =
+    match (this, other) {
+      (Empty, _) -> Set.empty(),
+      (_, Empty) -> Set.empty(),
+      (_, _) -> Set.balanced(this, other.min().unwrap(), other.removeMin()),
+    }
+
+  /** When failed to remove, the original map is returned */
+  method remove(value: V): Set<V> =
+    match this {
+      Empty -> this,
+      Leaf(v) -> if value.compare(v) == 0 then Set.empty() else this,
+      Node(_, v, l, r) -> {
+        let c = value.compare(v);
+        if c == 0 then { l.internalMerge(r) } else if c < 0 then {
+          let ll = l.remove(value);
+          if l == ll then this else Set.balanced(ll, v, r)
+        } else {
+          let rr = r.remove(value);
+          if r == rr then this else Set.balanced(l, v, rr)
+        }
+      },
+    }
+
+  function <V: Comparable<V>> fromList(list: List<V>): Set<V> =
+    list.fold((acc, e) -> acc.insert(e), Set.empty<V>())
+
+  method compare(other: Set<V>, f: (V, V) -> int): int =
+    Set.compareHelper(
+      f,
+      NodeEnumerationHelper.cons(this, NodeEnumerationHelper.End<V, Set<V>>()),
+      NodeEnumerationHelper.cons(other, NodeEnumerationHelper.End<V, Set<V>>())
+    )
+
+  private function <V: Comparable<V>> compareHelper(
+    f: (V, V) -> int,
+    e1: NodeEnumerationHelper<V, Set<V>>,
+    e2: NodeEnumerationHelper<V, Set<V>>
+  ): int =
+    match (e1, e2) {
+      (End, End) -> 0,
+      (End, _) -> -1,
+      (_, End) -> 1,
+      (More(v1, r1, e1Nested), More(v2, r2, e2Nested)) -> {
+        let c = v1.compare(v2);
+        if c != 0 then { c } else {
+          let c1 = f(v1, v2);
+          if c1 != 0 then { c } else {
+            Set.compareHelper(
+              f,
+              NodeEnumerationHelper.cons(r1, e1Nested),
+              NodeEnumerationHelper.cons(r2, e2Nested)
+            )
+          }
+        }
+      },
+    }
+
+  method equal(other: Set<V>, f: (V, V) -> bool): bool =
+    Set.equalHelper(
+      f,
+      NodeEnumerationHelper.cons(this, NodeEnumerationHelper.End<V, Set<V>>()),
+      NodeEnumerationHelper.cons(other, NodeEnumerationHelper.End<V, Set<V>>())
+    )
+
+  private function <V: Comparable<V>> equalHelper(
+    f: (V, V) -> bool,
+    e1: NodeEnumerationHelper<V, Set<V>>,
+    e2: NodeEnumerationHelper<V, Set<V>>
+  ): bool =
+    match (e1, e2) {
+      (End, End) -> true,
+      (End, _) -> false,
+      (_, End) -> false,
+      (More(v1, r1, e1Nested), More(v2, r2, e2Nested)) -> {
+        v1.compare(v2) == 0 && f(v1, v2) && Set.equalHelper(
+          f,
+          NodeEnumerationHelper.cons(r1, e1Nested),
+          NodeEnumerationHelper.cons(r2, e2Nested)
+        )
+      },
+    }
+
+  method iter(f: (V) -> unit): unit =
+    match this {
+      Empty -> {  },
+      Leaf(v) -> f(v),
+      Node(_, v, l, r) -> {
+        let _ = l.iter(f);
+        let _ = f(v);
+        let _ = r.iter(f);
+      },
+    }
+
+  method <A> fold(acc: A, f: (A, V) -> A): A =
+    match this {
+      Empty -> acc,
+      Leaf(v) -> f(acc, v),
+      Node(_, v, l, r) -> r.fold(f(l.fold(acc, f), v), f),
+    }
+
+  method forAll(f: (V) -> bool): bool =
+    match this {
+      Empty -> true,
+      Leaf(v) -> f(v),
+      Node(_, v, l, r) -> f(v) && l.forAll(f) && r.forAll(f),
+    }
+
+  method exists(f: (V) -> bool): bool =
+    match this {
+      Empty -> true,
+      Leaf(v) -> f(v),
+      Node(_, v, l, r) -> f(v) || l.exists(f) || r.exists(f),
+    }
+
+  method filter(f: (V) -> bool): Set<V> =
+    match this {
+      Empty -> Set.Empty(),
+      Leaf(v) -> if f(v) then this else Set.empty(),
+      Node(_, v, l, r) -> {
+        let newL = l.filter(f);
+        let keepCurrentVal = f(v);
+        let newR = r.filter(f);
+        if keepCurrentVal then {
+          if l == newL && r == newR then this else Set.join(newL, v, newR)
+        } else { Set.concat(newL, newR) }
+      },
+    }
+
+  method partition(f: (V) -> bool): Pair<Set<V>, Set<V>> =
+    match this {
+      Empty -> (Set.empty<V>(), Set.empty<V>()),
+      Leaf(v) -> if f(v) then (this, Set.empty<V>()) else (Set.empty<V>(), this),
+      Node(_, v, l, r) -> {
+        let (lt, lf) = l.partition(f);
+        let currentNodeToTrue = f(v);
+        let (rt, rf) = r.partition(f);
+        if currentNodeToTrue then { (Set.join(lt, v, rt), Set.concat(lf, rf)) } else {
+          (Set.concat(lt, rt), Set.join(lf, v, rf))
+        }
+      },
+    }
+
+  method size(): int =
+    match this {
+      Empty -> 0,
+      Leaf(_) -> 1,
+      Node(_, _, l, r) -> l.size() + 1 + r.size(),
+    }
+
+  method min(): Option<V> =
+    match this {
+      Empty -> Option.None(),
+      Leaf(v) -> Option.Some(v),
+      Node(_, v, child, _) -> if child.isEmpty() then { Option.Some(v) } else { child.min() },
+    }
+
+  method max(): Option<V> =
+    match this {
+      Empty -> Option.None(),
+      Leaf(v) -> Option.Some(v),
+      Node(_, v, _, child) -> if child.isEmpty() then { Option.Some(v) } else { child.min() },
+    }
+
+  private method removeMin(): Set<V> =
+    match this {
+      Empty -> Process.panic("Invalid state for Set.removeMin"),
+      Leaf(_) -> Set.empty(),
+      Node(_, _, Empty, r) -> r,
+      Node(_, v, l, r) -> Set.balanced(l.removeMin(), v, r),
+    }
+
+  /** Return ordered keys */
+  method elements(): List<V> = this.elementsHelper(List.nil())
+
+  private method elementsHelper(acc: List<V>): List<V> =
+    match this {
+      Empty -> acc,
+      Leaf(v) -> List.Cons(v, acc),
+      Node(_, v, l, r) -> l.elementsHelper(List.Cons(v, r.elementsHelper(acc))),
+    }
+
+  method map(f: (V) -> V): Set<V> =
+    match this {
+      Empty -> Set.Empty(),
+      Leaf(v) -> {
+        let newV = f(v);
+        if newV == v then this else Set.singleton(newV)
+      },
+      Node(_, v, l, r) -> {
+        // enforce left-to-right evaluation order
+        let newL = l.map(f);
+        let newV = f(v);
+        let newR = r.map(f);
+        if l == newL && v == newV && r == newR then this else { Set.tryJoin(newL, newV, newR) }
+      },
+    }
+
+  private method height(): int =
+    match this {
+      Empty -> 0,
+      Leaf(_) -> 1,
+      Node(h, _, _, _) -> h,
+    }
+
+  private function <V: Comparable<V>> create(left: Set<V>, value: V, right: Set<V>): Set<V> = {
+    let lh = left.height();
+    let rh = right.height();
+    let h = if lh >= rh then lh + 1 else rh + 1;
+    Set.Node(h, value, left, right)
+  }
+
+  private function <V: Comparable<V>> unsafeNode(left: Set<V>, value: V, right: Set<V>): Set<V> =
+    match (left, right) {
+      (Empty, Empty) -> Set.singleton(value),
+      (Leaf(_), Empty) -> Set.Node(2, value, left, right),
+      (Empty, Leaf(_)) -> Set.Node(2, value, left, right),
+      (Leaf(_), Leaf(_)) -> Set.Node(2, value, left, right),
+      (Node(h, _, _, _), Leaf(_)) -> Set.Node(h + 1, value, left, right),
+      (Node(h, _, _, _), Empty) -> Set.Node(h + 1, value, left, right),
+      (Leaf(_), Node(h, _, _, _)) -> Set.Node(h + 1, value, left, right),
+      (Empty, Node(h, _, _, _)) -> Set.Node(h + 1, value, left, right),
+      (Node(hl, _, _, _), Node(hr, _, _, _)) -> {
+        let h = if hl >= hr then hl + 1 else hr + 1;
+        Set.Node(h, value, left, right)
+      },
+    }
+
+  private method forcedNodeWithoutHeight(): Triple<V, Set<V>, Set<V>> =
+    match this {
+      Empty -> Process.panic("Bad tree"),
+      Leaf(_) -> Process.panic("Bad tree"),
+      Node(_, v, l, r) -> (v, l, r),
+    }
+
+  private function <V: Comparable<V>> balanced(l: Set<V>, v: V, r: Set<V>): Set<V> = {
+    let lh = l.height();
+    let rh = r.height();
+    if lh > rh + 2 then {
+      let (lv, ll, lr) = l.forcedNodeWithoutHeight();
+      if ll.height() >= lr.height() then { Set.create(ll, lv, Set.unsafeNode(lr, v, r)) } else {
+        let (lrv, lrl, lrr) = lr.forcedNodeWithoutHeight();
+        Set.create(Set.unsafeNode(ll, lv, lrl), lrv, Set.unsafeNode(lrr, v, r))
+      }
+    } else if rh > lh + 2 then {
+      let (rv, rl, rr) = r.forcedNodeWithoutHeight();
+      if rr.height() >= rl.height() then { Set.create(Set.unsafeNode(l, v, rl), rv, rr) } else {
+        let (rlv, rll, rlr) = rl.forcedNodeWithoutHeight();
+        Set.create(Set.unsafeNode(l, v, rll), rlv, Set.unsafeNode(rlr, rv, rr))
+      }
+    } else { Set.unsafeNode(l, v, r) }
+  }
+
+  /*
+   * Beware: those 2 functions assume that the added k is *strictly* smaller (or bigger) than all
+   * the present keys in the tree; it does not test for equality with the current min (or max) key.
+   * Indeed, they are only used during the "join" operation which respects this precondition.
+   */
+  private function <V: Comparable<V>> addMinElement(newV: V, tree: Set<V>): Set<V> =
+    match tree {
+      Empty -> Set.singleton(newV),
+      Leaf(v) -> Set.unsafeNode(Set.singleton(newV), v, Set.empty<V>()),
+      Node(_, v, l, r) -> Set.balanced(Set.addMinElement(newV, l), v, r),
+    }
+
+  private function <V: Comparable<V>> addMaxElement(newV: V, tree: Set<V>): Set<V> =
+    match tree {
+      Empty -> Set.singleton(newV),
+      Leaf(v) -> Set.unsafeNode(Set.empty<V>(), v, Set.singleton(newV)),
+      Node(_, v, l, r) -> Set.balanced(l, v, Set.addMaxElement(newV, r)),
+    }
+
+  // Same as create and bal, but no assumptions are made on the relative heights of l and r
+  private function <V: Comparable<V>> join(l: Set<V>, v: V, r: Set<V>): Set<V> =
+    match (l, r) {
+      (Empty, _) -> Set.addMinElement(v, r),
+      (_, Empty) -> Set.addMaxElement(v, l),
+      (Leaf(_), Leaf(_)) -> Set.unsafeNode(l, v, r),
+      (Leaf(_), Node(rh, rv, rl, rr)) -> if rh > 3 then {
+        Set.balanced(Set.join(l, v, rl), rv, rr)
+      } else { Set.create(l, v, r) },
+      (Node(lh, lv, ll, lr), Leaf(_)) -> if lh > 3 then {
+        Set.balanced(ll, lv, Set.join(lr, v, r))
+      } else { Set.create(l, v, r) },
+      (Node(lh, lv, ll, lr), Node(rh, rv, rl, rr)) -> {
+        if lh > rh + 2 then { Set.balanced(ll, lv, Set.join(lr, v, r)) } else if rh > lh + 2 then {
+          Set.balanced(Set.join(l, v, rl), rv, rr)
+        } else { Set.create(l, v, r) }
+      },
+    }
+
+  /*
+   * Merge two trees l and r into one. All elements of l must precede the elements of r. No
+   * assumption on the heights of l and r.
+   */
+  private function <V: Comparable<V>> concat(t1: Set<V>, t2: Set<V>): Set<V> =
+    match (t1, t2) {
+      (Empty, t) -> t,
+      (t, Empty) -> t,
+      (_, _) -> Set.join(t1, t2.min().unwrap(), t2.removeMin()),
+    }
+
+  private function <V: Comparable<V>> tryJoin(l: Set<V>, v: V, r: Set<V>): Set<V> =
+    if (l.isEmpty() || l.max().unwrap().compare(v) < 0) && (
+      r.isEmpty() || v.compare(r.min().unwrap()) < 0
+    ) then { Set.join(l, v, r) } else { l.union(r.insert(v)) }
+}

--- a/tests/AllTests.sam
+++ b/tests/AllTests.sam
@@ -18,6 +18,7 @@ import { LoopOptimization } from tests.LoopOptimization;
 import { MapTests } from tests.MapTests;
 import { MathFunctions } from tests.MathFunctions;
 import { PrintHelloWorld } from tests.PrintHelloWorld;
+import { SetTests } from tests.SetTests;
 import { ShortCircuitAndOr } from tests.ShortCircuitAndOr;
 import { SortableListTest } from tests.SortableList;
 import { VariousSyntaxForms } from tests.VariousSyntaxForms;
@@ -53,6 +54,7 @@ class Main {
       .cons(TestCase.init("MapTests", MapTests.run))
       .cons(TestCase.init("MathFunctions", MathFunctions.run))
       .cons(TestCase.init("PrintHelloWorld", PrintHelloWorld.run))
+      .cons(TestCase.init("SetTests", SetTests.run))
       .cons(TestCase.init("ShortCircuitAndOr", ShortCircuitAndOr.run))
       .cons(TestCase.init("SortableList", SortableListTest.run))
       .cons(TestCase.init("VariousSyntaxForms", VariousSyntaxForms.run))

--- a/tests/MapTests.sam
+++ b/tests/MapTests.sam
@@ -3,41 +3,38 @@ import { Map } from std.map;
 import { Option } from std.option;
 import { ForTests } from tests.StdLib;
 
-private class MapInsertAndGetTests {
+class MapTests {
   private function keyMirrorIntMapHelper(acc: Map<Int, int>, n: int): Map<Int, int> =
     if n == 0 then { acc } else {
       let boxedN = Int.init(n);
-      MapInsertAndGetTests.keyMirrorIntMapHelper(acc.insert(boxedN, n).insert(boxedN, n), n - 1)
+      MapTests.keyMirrorIntMapHelper(acc.insert(boxedN, n).insert(boxedN, n), n - 1)
     }
 
   private function validatekeyMirrorIntMapHelper(map: Map<Int, int>, n: int): unit =
     if n == 0 then { ForTests.assertBool(map.get(Int.init(n)).isNone(), "Should be none!") } else {
       let _ = ForTests.assertBool(map.containsKey(Int.init(n)), "Missing key");
       let _ = ForTests.assertIntEquals(map.get(Int.init(n)).unwrap(), n);
-      MapInsertAndGetTests.validatekeyMirrorIntMapHelper(map, n - 1)
+      MapTests.validatekeyMirrorIntMapHelper(map, n - 1)
     }
 
   private function validatekeyMirrorPlusOneIntMapHelper(map: Map<Int, int>, n: int): unit =
     if n == 0 then { ForTests.assertBool(map.get(Int.init(n)).isNone(), "Should be none!") } else {
       let _ = ForTests.assertBool(map.containsKey(Int.init(n)), "Missing key");
       let _ = ForTests.assertIntEquals(map.get(Int.init(n)).unwrap(), n + 1);
-      MapInsertAndGetTests.validatekeyMirrorPlusOneIntMapHelper(map, n - 1)
+      MapTests.validatekeyMirrorPlusOneIntMapHelper(map, n - 1)
     }
 
   private function assertAllZeroMap(map: Map<Int, int>, n: int): unit =
     if n == 0 then { ForTests.assertBool(map.get(Int.init(n)).isNone(), "Should be none!") } else {
       let _ = ForTests.assertIntEquals(map.get(Int.init(n)).unwrap(), 0);
-      MapInsertAndGetTests.assertAllZeroMap(map, n - 1)
+      MapTests.assertAllZeroMap(map, n - 1)
     }
 
   function run(): unit = {
-    let map = MapInsertAndGetTests.keyMirrorIntMapHelper(Map.empty(), 100);
-    let _ = MapInsertAndGetTests.validatekeyMirrorIntMapHelper(map, 100);
-    let _ = MapInsertAndGetTests.validatekeyMirrorPlusOneIntMapHelper(
-      map.map((k, v) -> v + 1),
-      100
-    );
-    let _ = MapInsertAndGetTests.assertAllZeroMap(
+    let map = MapTests.keyMirrorIntMapHelper(Map.empty(), 100);
+    let _ = MapTests.validatekeyMirrorIntMapHelper(map, 100);
+    let _ = MapTests.validatekeyMirrorPlusOneIntMapHelper(map.map((k, v) -> v + 1), 100);
+    let _ = MapTests.assertAllZeroMap(
       map.merge(map, (k, v1, v2) -> Option.Some(v1.unwrap() - v2.unwrap())),
       100
     );
@@ -53,11 +50,5 @@ private class MapInsertAndGetTests {
       map.fold(0, (acc, k, v) -> acc + k.value + v),
       (1 + 100) * 100
     );
-  }
-}
-
-class MapTests {
-  function run(): unit = {
-    let _ = MapInsertAndGetTests.run();
   }
 }

--- a/tests/SetTests.sam
+++ b/tests/SetTests.sam
@@ -1,0 +1,51 @@
+import { Int } from std.boxed;
+import { Option } from std.option;
+import { Set } from std.set;
+import { ForTests } from tests.StdLib;
+
+class SetTests {
+  private function createSetHelper(acc: Set<Int>, n: int): Set<Int> =
+    if n == 0 then { acc } else {
+      let boxedN = Int.init(n);
+      SetTests.createSetHelper(acc.insert(boxedN).insert(boxedN), n - 1)
+    }
+
+  private function validateSetHelper(set: Set<Int>, n: int): unit =
+    if n == 0 then { ForTests.assertBool(!set.contains(Int.init(n)), "Should be none!") } else {
+      let _ = ForTests.assertBool(set.contains(Int.init(n)), "Missing key");
+      SetTests.validateSetHelper(set, n - 1)
+    }
+
+  private function validatePlusOneIntSetHelper(set: Set<Int>, n: int): unit =
+    if n == 0 then { ForTests.assertBool(!set.contains(Int.init(1)), "Should be none!") } else {
+      let _ = ForTests.assertBool(set.contains(Int.init(n + 1)), "Missing key");
+      SetTests.validatePlusOneIntSetHelper(set, n - 1)
+    }
+
+  function run(): unit = {
+    let set = SetTests.createSetHelper(Set.empty(), 100);
+    let _ = SetTests.validateSetHelper(set, 100);
+    let _ = SetTests.validatePlusOneIntSetHelper(set.map((v) -> Int.init(v.value + 1)), 100);
+    let _ = ForTests.assertBool(set.diff(set).isEmpty(), "Not empty");
+    let _ = ForTests.assertBool(!set.disjoint(set), "Disjoint");
+    let union = set.union(set);
+    let inter = set.intersection(set);
+    let _ = ForTests.assertBool(
+      union.equal(set, (v1, v2) -> v1.compare(v2) == 0),
+      "Not equal with union result"
+    );
+    let _ = ForTests.assertBool(
+      inter.equal(set, (v1, v2) -> v1.compare(v2) == 0),
+      "Not equal with intersetion result"
+    );
+    let _ = ForTests.assertBool(
+      union.compare(set, (v1, v2) -> v1.compare(v2)) == 0,
+      "Compare with union != 0"
+    );
+    let _ = ForTests.assertBool(
+      inter.compare(set, (v1, v2) -> v1.compare(v2)) == 0,
+      "Compare with intersection != 0"
+    );
+    let _ = ForTests.assertIntEquals(set.fold(0, (acc, v) -> acc + v.value), (1 + 100) * 100 / 2);
+  }
+}

--- a/tests/snapshot.txt
+++ b/tests/snapshot.txt
@@ -81,6 +81,8 @@ Test Name: MathFunctions
 Test Name: PrintHelloWorld
 Hello World!
 ========================================
+Test Name: SetTests
+========================================
 Test Name: ShortCircuitAndOr
 0
 1


### PR DESCRIPTION
[parser] Reorganize source parser code into smaller inline mods

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1163).
* __->__ #1163
* #1162
* #1161
* #1160
* #1159