### PR TITLE
[parser][printer] Consistent comment attachment and printing for toplevels

### DIFF
--- a/crates/samlang-ast/src/source.rs
+++ b/crates/samlang-ast/src/source.rs
@@ -873,6 +873,7 @@ impl<T: Clone> Toplevel<T> {
 #[derive(Clone, PartialEq, Eq)]
 pub struct ModuleMembersImport {
   pub loc: Location,
+  pub associated_comments: CommentReference,
   pub imported_members: Vec<Id>,
   pub imported_module: ModuleReference,
   pub imported_module_loc: Location,

--- a/crates/samlang-ast/src/source_tests.rs
+++ b/crates/samlang-ast/src/source_tests.rs
@@ -608,6 +608,7 @@ mod tests {
     .is_none());
     assert!(ModuleMembersImport {
       loc: Location::dummy(),
+      associated_comments: NO_COMMENT_REFERENCE,
       imported_members: vec![],
       imported_module: ModuleReference::DUMMY,
       imported_module_loc: Location::dummy(),
@@ -772,6 +773,7 @@ mod tests {
 
     let one_import = ModuleMembersImport {
       loc: Location::dummy(),
+      associated_comments: NO_COMMENT_REFERENCE,
       imported_members: vec![],
       imported_module: ModuleReference::DUMMY,
       imported_module_loc: Location::dummy(),

--- a/crates/samlang-printer/src/lib.rs
+++ b/crates/samlang-printer/src/lib.rs
@@ -48,6 +48,7 @@ pub fn pretty_print_import(
     source_printer::import_to_document(
       heap,
       comment_store,
+      vec![import.associated_comments],
       import.imported_module,
       &import.imported_members,
     ),

--- a/crates/samlang-services/src/ast_differ.rs
+++ b/crates/samlang-services/src/ast_differ.rs
@@ -516,6 +516,7 @@ mod tests {
 
     let import = ModuleMembersImport {
       loc: Location::dummy(),
+      associated_comments: NO_COMMENT_REFERENCE,
       imported_members: vec![Id::from(PStr::UPPER_A)],
       imported_module: ModuleReference::DUMMY,
       imported_module_loc: Location::dummy(),

--- a/crates/samlang-services/src/lib.rs
+++ b/crates/samlang-services/src/lib.rs
@@ -562,6 +562,7 @@ pub mod rewrite {
     let mut changed_ast = ast.clone();
     changed_ast.imports.push(ModuleMembersImport {
       loc: dummy_location,
+      associated_comments: NO_COMMENT_REFERENCE,
       imported_members: vec![Id {
         loc: dummy_location,
         associated_comments: NO_COMMENT_REFERENCE,


### PR DESCRIPTION
[parser][printer] Consistent comment attachment and printing for toplevels

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1169).
* #1170
* __->__ #1169