### PR TITLE
[ast][ir] Introduce AnyPointer IR type

### DIFF
--- a/crates/samlang-ast/src/lir.rs
+++ b/crates/samlang-ast/src/lir.rs
@@ -6,23 +6,6 @@ use enum_as_inner::EnumAsInner;
 use samlang_heap::{Heap, PStr};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PrimitiveType {
-  Int32,
-  Int31,
-  Any,
-}
-
-impl PrimitiveType {
-  fn as_str(&self) -> &'static str {
-    match self {
-      PrimitiveType::Int32 => "number",
-      PrimitiveType::Int31 => "i31",
-      PrimitiveType::Any => "any",
-    }
-  }
-}
-
 #[derive(Debug, Clone)]
 pub struct FunctionType {
   pub argument_types: Vec<Type>,
@@ -50,7 +33,9 @@ impl FunctionType {
 
 #[derive(Debug, Clone, EnumAsInner)]
 pub enum Type {
-  Primitive(PrimitiveType),
+  Int32,
+  Int31,
+  AnyPointer,
   Id(TypeNameId),
   Fn(FunctionType),
 }
@@ -66,7 +51,9 @@ impl Type {
 
   fn pretty_print(&self, collector: &mut String, heap: &Heap, table: &SymbolTable) {
     match self {
-      Type::Primitive(t) => collector.push_str(t.as_str()),
+      Type::Int32 => collector.push_str("number"),
+      Type::Int31 => collector.push_str("i31"),
+      Type::AnyPointer => collector.push_str("any"),
       Type::Id(id) => id.write_encoded(collector, heap, table),
       Type::Fn(function) => function.pretty_print(collector, heap, table),
     }
@@ -74,7 +61,9 @@ impl Type {
 
   pub fn is_the_same_type(&self, other: &Type) -> bool {
     match (self, other) {
-      (Type::Primitive(k1), Type::Primitive(k2)) => k1 == k2,
+      (Type::Int32, Type::Int32)
+      | (Type::Int31, Type::Int31)
+      | (Type::AnyPointer, Type::AnyPointer) => true,
       (Type::Id(n1), Type::Id(n2)) => n1 == n2,
       (Type::Fn(f1), Type::Fn(f2)) => {
         f1.return_type.is_the_same_type(&f2.return_type)
@@ -90,9 +79,9 @@ impl Type {
   }
 }
 
-pub const INT_32_TYPE: Type = Type::Primitive(PrimitiveType::Int32);
-pub const INT_31_TYPE: Type = Type::Primitive(PrimitiveType::Int31);
-pub const ANY_TYPE: Type = Type::Primitive(PrimitiveType::Any);
+pub const INT_32_TYPE: Type = Type::Int32;
+pub const INT_31_TYPE: Type = Type::Int31;
+pub const ANY_POINTER_TYPE: Type = Type::AnyPointer;
 
 #[derive(Debug, Clone, EnumAsInner)]
 pub enum Expression {

--- a/crates/samlang-ast/src/lir_tests.rs
+++ b/crates/samlang-ast/src/lir_tests.rs
@@ -10,8 +10,6 @@ mod tests {
 
   #[test]
   fn boilterplate() {
-    assert!(PrimitiveType::Int32.eq(&PrimitiveType::Int32));
-    assert!(PrimitiveType::Int31.eq(&PrimitiveType::Int31));
     assert!(INT_32_TYPE.as_fn().is_none());
     assert!(ZERO.as_fn_name().is_none());
 

--- a/crates/samlang-ast/src/mir.rs
+++ b/crates/samlang-ast/src/mir.rs
@@ -63,6 +63,7 @@ impl TypeName {
         Type::Int32 => collector.push_str("int"),
         Type::Int31 => collector.push_str("i31"),
         Type::Id(id) => id.write_encoded(collector, heap, table),
+        Type::AnyPointer => collector.push_str("any"),
       }
     }
     if let Some(t) = self.sub_type_tag {
@@ -197,6 +198,7 @@ pub enum Type {
   Int32,
   Int31,
   Id(TypeNameId),
+  AnyPointer,
 }
 
 impl Type {
@@ -209,12 +211,14 @@ impl Type {
       Type::Int32 => "int".to_string(),
       Type::Int31 => "i31".to_string(),
       Type::Id(id) => id.encoded_for_test(heap, table),
+      Type::AnyPointer => "any".to_string(),
     }
   }
 }
 
 pub const INT_32_TYPE: Type = Type::Int32;
 pub const INT_31_TYPE: Type = Type::Int31;
+pub const ANY_POINTER_TYPE: Type = Type::AnyPointer;
 
 #[derive(Debug, Clone)]
 pub struct ClosureTypeDefinition {

--- a/crates/samlang-ast/src/mir_tests.rs
+++ b/crates/samlang-ast/src/mir_tests.rs
@@ -42,8 +42,8 @@ mod tests {
       VariableName::new(heap.alloc_str_for_test("s"), INT_32_TYPE).debug_print(heap, table)
     );
     assert_eq!(
-      "(s: i31)",
-      VariableName::new(heap.alloc_str_for_test("s"), INT_31_TYPE).debug_print(heap, table)
+      "(s: any)",
+      VariableName::new(heap.alloc_str_for_test("s"), ANY_POINTER_TYPE).debug_print(heap, table)
     );
     GenenalLoopVariable {
       name: PStr::LOWER_A,
@@ -107,7 +107,7 @@ mod tests {
     type_name_id = table.create_type_name_with_suffix(
       ModuleReference::ROOT,
       PStr::UPPER_A,
-      vec![INT_31_TYPE, INT_32_TYPE],
+      vec![INT_31_TYPE, INT_32_TYPE, ANY_POINTER_TYPE],
     );
     assert_eq!(false, type_name_id.encoded_for_test(heap, &table).is_empty());
     type_name_id = table.create_simple_type_name(ModuleReference::ROOT, PStr::UPPER_A);
@@ -123,6 +123,7 @@ mod tests {
 
     assert_eq!("int", INT_32_TYPE.pretty_print(heap, table));
     assert_eq!("i31", INT_31_TYPE.pretty_print(heap, table));
+    assert_eq!("any", ANY_POINTER_TYPE.pretty_print(heap, table));
     assert_eq!("0", ZERO.clone().debug_print(heap, table));
     assert_eq!(
       "(a: int)",

--- a/crates/samlang-compiler/src/mir_generics_specialization.rs
+++ b/crates/samlang-compiler/src/mir_generics_specialization.rs
@@ -583,7 +583,7 @@ impl Rewriter {
   fn type_permit_enum_boxed_optimization(&self, type_: &mir::Type) -> bool {
     match type_ {
       // We cannot distinguish unboxed int from tags
-      mir::Type::Int32 | mir::Type::Int31 => false,
+      mir::Type::Int32 | mir::Type::Int31 | mir::Type::AnyPointer => false,
       mir::Type::Id(type_id) => {
         match &self.specialized_type_definitions.get(type_id).unwrap().mappings {
           // Structs are always pointers.


### PR DESCRIPTION
[ast][ir] Introduce AnyPointer IR type

This is intended to mirror the any type in the WASM GC spec.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1207).
* #1208
* __->__ #1207