### PR TITLE
[compiler] Make use of i31 literals

### DIFF
--- a/crates/samlang-ast/src/lir.rs
+++ b/crates/samlang-ast/src/lir.rs
@@ -6,23 +6,6 @@ use enum_as_inner::EnumAsInner;
 use samlang_heap::{Heap, PStr};
 use std::collections::HashMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PrimitiveType {
-  Int32,
-  Int31,
-  Any,
-}
-
-impl PrimitiveType {
-  fn as_str(&self) -> &'static str {
-    match self {
-      PrimitiveType::Int32 => "number",
-      PrimitiveType::Int31 => "i31",
-      PrimitiveType::Any => "any",
-    }
-  }
-}
-
 #[derive(Debug, Clone)]
 pub struct FunctionType {
   pub argument_types: Vec<Type>,
@@ -50,7 +33,9 @@ impl FunctionType {
 
 #[derive(Debug, Clone, EnumAsInner)]
 pub enum Type {
-  Primitive(PrimitiveType),
+  Int32,
+  Int31,
+  AnyPointer,
   Id(TypeNameId),
   Fn(FunctionType),
 }
@@ -66,7 +51,9 @@ impl Type {
 
   fn pretty_print(&self, collector: &mut String, heap: &Heap, table: &SymbolTable) {
     match self {
-      Type::Primitive(t) => collector.push_str(t.as_str()),
+      Type::Int32 => collector.push_str("number"),
+      Type::Int31 => collector.push_str("i31"),
+      Type::AnyPointer => collector.push_str("any"),
       Type::Id(id) => id.write_encoded(collector, heap, table),
       Type::Fn(function) => function.pretty_print(collector, heap, table),
     }
@@ -74,7 +61,9 @@ impl Type {
 
   pub fn is_the_same_type(&self, other: &Type) -> bool {
     match (self, other) {
-      (Type::Primitive(k1), Type::Primitive(k2)) => k1 == k2,
+      (Type::Int32, Type::Int32)
+      | (Type::Int31, Type::Int31)
+      | (Type::AnyPointer, Type::AnyPointer) => true,
       (Type::Id(n1), Type::Id(n2)) => n1 == n2,
       (Type::Fn(f1), Type::Fn(f2)) => {
         f1.return_type.is_the_same_type(&f2.return_type)
@@ -90,9 +79,9 @@ impl Type {
   }
 }
 
-pub const INT_32_TYPE: Type = Type::Primitive(PrimitiveType::Int32);
-pub const INT_31_TYPE: Type = Type::Primitive(PrimitiveType::Int31);
-pub const ANY_TYPE: Type = Type::Primitive(PrimitiveType::Any);
+pub const INT_32_TYPE: Type = Type::Int32;
+pub const INT_31_TYPE: Type = Type::Int31;
+pub const ANY_POINTER_TYPE: Type = Type::AnyPointer;
 
 #[derive(Debug, Clone, EnumAsInner)]
 pub enum Expression {

--- a/crates/samlang-ast/src/lir.rs
+++ b/crates/samlang-ast/src/lir.rs
@@ -113,8 +113,10 @@ impl Expression {
     str_table: &HashMap<PStr, usize>,
   ) {
     match self {
-      Expression::Int32Literal(i) | Expression::Int31Literal(i) => {
-        collector.push_str(&i.to_string())
+      Expression::Int32Literal(i) => collector.push_str(&i.to_string()),
+      Expression::Int31Literal(i) => {
+        let i32_form = i * 2 + 1;
+        collector.push_str(&i32_form.to_string())
       }
       Expression::Variable(n, _) => collector.push_str(n.as_str(heap)),
       Expression::StringName(n) => {
@@ -574,6 +576,7 @@ pub fn ts_prolog() -> String {
   let table = &SymbolTable::new();
   let mut collector = String::new();
 
+  collector.push_str("type i31 = number;\n");
   collector.push_str("const ");
   FunctionName::STR_CONCAT.write_encoded(&mut collector, heap, table);
   collector.push_str(" = ([, a]: _Str, [, b]: _Str): _Str => [1, a + b];\n");

--- a/crates/samlang-ast/src/lir_tests.rs
+++ b/crates/samlang-ast/src/lir_tests.rs
@@ -161,7 +161,7 @@ mod tests {
                 heap.alloc_str_for_test("dd"),
                 BinaryOperator::MINUS,
                 ZERO,
-                Expression::Int31Literal(-2147483648),
+                Expression::Int31Literal(-21478),
               ),
               Statement::binary(heap.alloc_str_for_test("dd"), BinaryOperator::MUL, ZERO, ZERO),
               Statement::binary(heap.alloc_str_for_test("dd"), BinaryOperator::DIV, ZERO, ZERO),
@@ -291,7 +291,7 @@ function __$f(v1: (t0: number) => number): number {{
     let dd = typeof 0 === 'object';
     let dd = 0 + 0;
     let dd = 0 + 0;
-    let dd = 0 - -2147483648;
+    let dd = 0 - -42955;
     let dd = 0 * 0;
     let dd = Math.floor(0 / 0);
     let dd = 0 % 0;

--- a/crates/samlang-ast/src/lir_tests.rs
+++ b/crates/samlang-ast/src/lir_tests.rs
@@ -10,8 +10,6 @@ mod tests {
 
   #[test]
   fn boilterplate() {
-    assert!(PrimitiveType::Int32.eq(&PrimitiveType::Int32));
-    assert!(PrimitiveType::Int31.eq(&PrimitiveType::Int31));
     assert!(INT_32_TYPE.as_fn().is_none());
     assert!(ZERO.as_fn_name().is_none());
 

--- a/crates/samlang-ast/src/mir.rs
+++ b/crates/samlang-ast/src/mir.rs
@@ -63,6 +63,7 @@ impl TypeName {
         Type::Int32 => collector.push_str("int"),
         Type::Int31 => collector.push_str("i31"),
         Type::Id(id) => id.write_encoded(collector, heap, table),
+        Type::AnyPointer => collector.push_str("any"),
       }
     }
     if let Some(t) = self.sub_type_tag {
@@ -197,6 +198,7 @@ pub enum Type {
   Int32,
   Int31,
   Id(TypeNameId),
+  AnyPointer,
 }
 
 impl Type {
@@ -209,12 +211,14 @@ impl Type {
       Type::Int32 => "int".to_string(),
       Type::Int31 => "i31".to_string(),
       Type::Id(id) => id.encoded_for_test(heap, table),
+      Type::AnyPointer => "any".to_string(),
     }
   }
 }
 
 pub const INT_32_TYPE: Type = Type::Int32;
 pub const INT_31_TYPE: Type = Type::Int31;
+pub const ANY_POINTER_TYPE: Type = Type::AnyPointer;
 
 #[derive(Debug, Clone)]
 pub struct ClosureTypeDefinition {

--- a/crates/samlang-ast/src/mir.rs
+++ b/crates/samlang-ast/src/mir.rs
@@ -240,7 +240,7 @@ impl ClosureTypeDefinition {
 pub enum EnumTypeDefinition {
   Boxed(Vec<Type>),
   Unboxed(TypeNameId),
-  Int,
+  Int31,
 }
 
 impl EnumTypeDefinition {
@@ -250,7 +250,7 @@ impl EnumTypeDefinition {
         format!("Boxed({})", types.iter().map(|it| it.pretty_print(heap, table)).join(", "))
       }
       EnumTypeDefinition::Unboxed(t) => format!("Unboxed({})", t.encoded_for_test(heap, table)),
-      EnumTypeDefinition::Int => "int".to_string(),
+      EnumTypeDefinition::Int31 => "i31".to_string(),
     }
   }
 }
@@ -423,7 +423,8 @@ impl Expression {
 
   pub fn debug_print(&self, heap: &Heap, table: &SymbolTable) -> String {
     match self {
-      Expression::Int32Literal(i) | Expression::Int31Literal(i) => i.to_string(),
+      Expression::Int32Literal(i) => i.to_string(),
+      Expression::Int31Literal(i) => format!("{} as i31", i),
       Expression::StringName(n) => format!("\"{}\"", n.as_str(heap)),
       Expression::Variable(v) => v.debug_print(heap, table),
     }

--- a/crates/samlang-ast/src/mir_tests.rs
+++ b/crates/samlang-ast/src/mir_tests.rs
@@ -148,7 +148,7 @@ mod tests {
     };
     let ed1 = EnumTypeDefinition::Unboxed(table.create_type_name_for_test(PStr::UPPER_D));
     let ed2 = EnumTypeDefinition::Boxed(vec![INT_32_TYPE, INT_32_TYPE]);
-    let ed3 = EnumTypeDefinition::Int;
+    let ed3 = EnumTypeDefinition::Int31;
     assert!(ed1.eq(&ed1));
     assert!(ed2.eq(&ed2));
     assert!(ed3.eq(&ed3));
@@ -158,7 +158,7 @@ mod tests {
     };
     assert_eq!("object type _A = [int, int]", d1.pretty_print(heap, table));
     assert_eq!(
-      "variant type _B = [Unboxed(_D), Boxed(int, int), int]",
+      "variant type _B = [Unboxed(_D), Boxed(int, int), i31]",
       d2.pretty_print(heap, table)
     );
     format!("{d1:?} {d2:?}");
@@ -335,7 +335,7 @@ if 0 {
   let dd = 0 is _Str;
   let dd = 0 + 0;
   let dd = 0 + 0;
-  let dd = 0 - -2147483648;
+  let dd = 0 - -2147483648 as i31;
   let dd = 0 * 0;
   let dd = 0 / 0;
   let dd = 0 % 0;

--- a/crates/samlang-ast/src/mir_tests.rs
+++ b/crates/samlang-ast/src/mir_tests.rs
@@ -42,8 +42,8 @@ mod tests {
       VariableName::new(heap.alloc_str_for_test("s"), INT_32_TYPE).debug_print(heap, table)
     );
     assert_eq!(
-      "(s: i31)",
-      VariableName::new(heap.alloc_str_for_test("s"), INT_31_TYPE).debug_print(heap, table)
+      "(s: any)",
+      VariableName::new(heap.alloc_str_for_test("s"), ANY_POINTER_TYPE).debug_print(heap, table)
     );
     GenenalLoopVariable {
       name: PStr::LOWER_A,
@@ -107,7 +107,7 @@ mod tests {
     type_name_id = table.create_type_name_with_suffix(
       ModuleReference::ROOT,
       PStr::UPPER_A,
-      vec![INT_31_TYPE, INT_32_TYPE],
+      vec![INT_31_TYPE, INT_32_TYPE, ANY_POINTER_TYPE],
     );
     assert_eq!(false, type_name_id.encoded_for_test(heap, &table).is_empty());
     type_name_id = table.create_simple_type_name(ModuleReference::ROOT, PStr::UPPER_A);
@@ -123,6 +123,7 @@ mod tests {
 
     assert_eq!("int", INT_32_TYPE.pretty_print(heap, table));
     assert_eq!("i31", INT_31_TYPE.pretty_print(heap, table));
+    assert_eq!("any", ANY_POINTER_TYPE.pretty_print(heap, table));
     assert_eq!("0", ZERO.clone().debug_print(heap, table));
     assert_eq!(
       "(a: int)",

--- a/crates/samlang-compiler/src/lir_lowering.rs
+++ b/crates/samlang-compiler/src/lir_lowering.rs
@@ -435,7 +435,7 @@ fn generate_inc_ref_fn() -> lir::Function {
             is_zero,
             hir::BinaryOperator::EQ,
             lir::Expression::Variable(old_ref_count, lir::INT_32_TYPE),
-            lir::Expression::Int31Literal(0),
+            lir::Expression::Int32Literal(0),
           ),
           lir::Statement::SingleIf {
             condition: lir::Expression::Variable(is_zero, lir::INT_32_TYPE),
@@ -711,7 +711,7 @@ pub fn compile_mir_to_lir(heap: &mut Heap, sources: mir::Sources) -> lir::Source
       mir::TypeDefinitionMappings::Enum(variants) => {
         for (i, variant) in variants.iter().enumerate() {
           match variant {
-            mir::EnumTypeDefinition::Unboxed(_) | mir::EnumTypeDefinition::Int => {}
+            mir::EnumTypeDefinition::Unboxed(_) | mir::EnumTypeDefinition::Int31 => {}
             mir::EnumTypeDefinition::Boxed(types) => {
               let name = symbol_table.derived_type_name_with_subtype_tag(type_def.name, i as u32);
               let mut mappings = Vec::with_capacity(types.len() + 1);
@@ -816,7 +816,7 @@ mod tests {
         TypeDefinition {
           name: table.create_type_name_for_test(heap.alloc_str_for_test("Variant")),
           mappings: TypeDefinitionMappings::Enum(vec![
-            EnumTypeDefinition::Int,
+            EnumTypeDefinition::Int31,
             EnumTypeDefinition::Unboxed(TypeNameId::STR),
             EnumTypeDefinition::Boxed(vec![INT_32_TYPE, INT_31_TYPE]),
           ]),
@@ -1068,7 +1068,7 @@ type _Variant = [number, number];
 function __$cc(): i31 {{
   let _t1: (t0: any, t1: number) => number = cc[1];
   let _t2: any = cc[2];
-  _t1(_t2, 0);
+  _t1(_t2, 1);
   let v1: number = a[1];
   let v2: number = b[1];
   let v3: number = b[2];

--- a/crates/samlang-compiler/src/mir_constant_param_elimination.rs
+++ b/crates/samlang-compiler/src/mir_constant_param_elimination.rs
@@ -660,7 +660,7 @@ function __$str_const(): int {
 function __$func_with_consts(c: _C, e: _E): int {
   let _ = !0;
   let _ = 0 + (c: int);
-  let _ = 0 + 0;
+  let _ = 0 + 0 as i31;
   let _: int = 0[0];
   let _: __ = Closure { fun: (__$otherwise_optimizable: () -> int), context: 0 };
   (_: int)(0);

--- a/crates/samlang-compiler/src/mir_generics_specialization.rs
+++ b/crates/samlang-compiler/src/mir_generics_specialization.rs
@@ -583,7 +583,7 @@ impl Rewriter {
   fn type_permit_enum_boxed_optimization(&self, type_: &mir::Type) -> bool {
     match type_ {
       // We cannot distinguish unboxed int from tags
-      mir::Type::Int32 | mir::Type::Int31 => false,
+      mir::Type::Int32 | mir::Type::Int31 | mir::Type::AnyPointer => false,
       mir::Type::Id(type_id) => {
         match &self.specialized_type_definitions.get(type_id).unwrap().mappings {
           // Structs are always pointers.

--- a/crates/samlang-compiler/src/mir_type_deduplication.rs
+++ b/crates/samlang-compiler/src/mir_type_deduplication.rs
@@ -229,7 +229,7 @@ pub(super) fn deduplicate(
                 EnumTypeDefinition::Unboxed(t) => {
                   EnumTypeDefinition::Unboxed(rewrite_id_type_name(&state, t))
                 }
-                EnumTypeDefinition::Int => EnumTypeDefinition::Int,
+                EnumTypeDefinition::Int31 => EnumTypeDefinition::Int31,
               })
               .collect(),
           ),
@@ -344,7 +344,7 @@ mod tests {
           mappings: TypeDefinitionMappings::Enum(vec![
             EnumTypeDefinition::Boxed(vec![INT_32_TYPE]),
             EnumTypeDefinition::Unboxed(TypeNameId::STR),
-            EnumTypeDefinition::Int,
+            EnumTypeDefinition::Int31,
           ]),
         },
       ],
@@ -417,7 +417,7 @@ mod tests {
       r#"closure type _A = () -> int
 closure type _C = () -> _C
 object type _C = [int, _Str]
-variant type _E = [Boxed(int), Unboxed(_Str), int]
+variant type _E = [Boxed(int), Unboxed(_Str), i31]
 function __$main(): int {
   let _: int;
   if 1 {

--- a/crates/samlang-compiler/src/wasm_lowering.rs
+++ b/crates/samlang-compiler/src/wasm_lowering.rs
@@ -243,9 +243,8 @@ impl<'a> LoweringManager<'a> {
 
   fn lower_expr(&mut self, e: &lir::Expression) -> wasm::InlineInstruction {
     match e {
-      lir::Expression::Int32Literal(v) | lir::Expression::Int31Literal(v) => {
-        wasm::InlineInstruction::Const(*v)
-      }
+      lir::Expression::Int32Literal(v) => wasm::InlineInstruction::Const(*v),
+      lir::Expression::Int31Literal(v) => wasm::InlineInstruction::Const(*v * 2 + 1),
       lir::Expression::Variable(n, _) => self.get(n),
       lir::Expression::StringName(n) => {
         let index = self.global_variables_to_pointer_mapping.get(n).unwrap();

--- a/crates/samlang-optimization/src/unused_name_elimination.rs
+++ b/crates/samlang-optimization/src/unused_name_elimination.rs
@@ -186,7 +186,7 @@ fn analyze_all_used_names(
             EnumTypeDefinition::Unboxed(t) => {
               type_set.insert(*t);
             }
-            EnumTypeDefinition::Int => {}
+            EnumTypeDefinition::Int31 => {}
           }
         }
       }
@@ -308,7 +308,7 @@ mod tests {
         TypeDefinition {
           name: table.create_type_name_for_test(heap.alloc_str_for_test("Baz")),
           mappings: TypeDefinitionMappings::Enum(vec![
-            EnumTypeDefinition::Int,
+            EnumTypeDefinition::Int31,
             EnumTypeDefinition::Unboxed(TypeNameId::STR),
             EnumTypeDefinition::Boxed(vec![INT_32_TYPE]),
           ]),


### PR DESCRIPTION
[compiler] Make use of i31 literals

Make the optimized form of variant actually i31 without assuming the representation during generics specialization. Then we do the `i * 2 + 1` conversion during LIR printing and wasm lowering. Eventually, the WASM one will be replaced by the actual WASM i31.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1208).
* __->__ #1208
* #1207