### PR TITLE
[ast][ir] Introduce i31 type and `0 as i31` in HIR

### DIFF
--- a/crates/samlang-ast/src/hir.rs
+++ b/crates/samlang-ast/src/hir.rs
@@ -62,7 +62,8 @@ impl FunctionType {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, EnumAsInner)]
 pub enum Type {
-  Int,
+  Int32,
+  Int31,
   Id(IdType),
 }
 
@@ -99,13 +100,15 @@ impl Type {
 
   pub fn pretty_print(&self, heap: &samlang_heap::Heap) -> String {
     match self {
-      Type::Int => "int".to_string(),
+      Type::Int32 => "int".to_string(),
+      Type::Int31 => "i31".to_string(),
       Type::Id(id) => id.pretty_print(heap),
     }
   }
 }
 
-pub const INT_TYPE: Type = Type::Int;
+pub const INT_TYPE: Type = Type::Int32;
+pub const INT31_TYPE: Type = Type::Int31;
 pub const STRING_TYPE: Type = Type::Id(IdType {
   name: TypeName { module_reference: Some(ModuleReference::ROOT), type_name: PStr::STR_TYPE },
   type_arguments: vec![],
@@ -288,6 +291,7 @@ impl FunctionNameExpression {
 #[derive(Debug, Clone, PartialEq, Eq, EnumAsInner)]
 pub enum Expression {
   IntLiteral(i32),
+  Int31Zero,
   StringName(PStr),
   Variable(VariableName),
 }
@@ -304,6 +308,7 @@ impl Expression {
   pub fn type_(&self) -> &Type {
     match self {
       Expression::IntLiteral(_) => &INT_TYPE,
+      Expression::Int31Zero => &INT31_TYPE,
       Expression::StringName(_) => STRING_TYPE_REF,
       Expression::Variable(v) => &v.type_,
     }
@@ -312,6 +317,7 @@ impl Expression {
   pub fn debug_print(&self, heap: &samlang_heap::Heap) -> String {
     match self {
       Expression::IntLiteral(i) => i.to_string(),
+      Expression::Int31Zero => "0 as i31".to_string(),
       Expression::StringName(n) => format!("\"{}\"", n.as_str(heap)),
       Expression::Variable(v) => v.debug_print(heap),
     }
@@ -319,7 +325,7 @@ impl Expression {
 
   pub fn convert_to_callee(self) -> Option<Callee> {
     match self {
-      Expression::IntLiteral(_) | Expression::StringName(_) => None,
+      Expression::IntLiteral(_) | Expression::Int31Zero | Expression::StringName(_) => None,
       Expression::Variable(v) => Some(Callee::Variable(v)),
     }
   }

--- a/crates/samlang-ast/src/hir_tests.rs
+++ b/crates/samlang-ast/src/hir_tests.rs
@@ -11,8 +11,8 @@ mod tests {
 
     assert!(ZERO.as_int_literal().is_some());
     Type::new_id(PStr::UPPER_A, vec![INT_TYPE, Type::new_id_no_targs(PStr::UPPER_B)]).as_id();
-    Type::new_id(PStr::UPPER_A, vec![INT_TYPE, Type::new_id_no_targs(PStr::UPPER_B)]).is_int();
-    assert!(INT_TYPE.is_int());
+    Type::new_id(PStr::UPPER_A, vec![INT_TYPE, Type::new_id_no_targs(PStr::UPPER_B)]).is_int32();
+    assert!(INT_TYPE.is_int32());
     assert!(INT_TYPE.as_id().is_none());
     format!(
       "{:?}",
@@ -25,7 +25,10 @@ mod tests {
       "{:?}",
       Expression::var_name(
         PStr::LOWER_A,
-        Type::new_id(PStr::UPPER_A, vec![INT_TYPE, Type::new_id_no_targs(PStr::UPPER_B)])
+        Type::new_id(
+          PStr::UPPER_A,
+          vec![INT_TYPE, INT31_TYPE, Type::new_id_no_targs(PStr::UPPER_B)]
+        )
       )
     );
     format!("{:?}", TypeName::new_for_test(PStr::UPPER_A));
@@ -63,6 +66,7 @@ mod tests {
     format!("{:?}", BinaryOperator::MINUS.partial_cmp(&BinaryOperator::GE));
     format!("{:?}", BinaryOperator::MINUS.cmp(&BinaryOperator::GE));
     format!("{:?}", ZERO.type_());
+    format!("{:?}", Expression::Int31Zero.type_());
     format!("{:?}", Expression::StringName(PStr::LOWER_A).type_().as_id());
     assert!(Expression::StringName(PStr::LOWER_A).type_().as_id().is_some());
     assert_eq!(
@@ -146,8 +150,10 @@ mod tests {
     let heap = &mut Heap::new();
 
     assert_eq!("int", INT_TYPE.pretty_print(heap));
+    assert_eq!("i31", INT31_TYPE.pretty_print(heap));
     assert_eq!("_Str", STRING_TYPE.pretty_print(heap));
     assert_eq!("0", ZERO.clone().debug_print(heap));
+    assert_eq!("0 as i31", Expression::Int31Zero.debug_print(heap));
     assert_eq!("(a: int)", Expression::var_name(PStr::LOWER_A, INT_TYPE).debug_print(heap));
     assert_eq!(
       "(a: DUMMY_A<int, DUMMY_B>)",

--- a/crates/samlang-compiler/src/hir_lowering.rs
+++ b/crates/samlang-compiler/src/hir_lowering.rs
@@ -32,7 +32,7 @@ type LoweringContext = LocalStackedContext<PStr, hir::Expression>;
 
 fn bind_value(cx: &mut LoweringContext, name: PStr, value: hir::Expression) {
   match &value {
-    hir::Expression::IntLiteral(_) | hir::Expression::Variable(_) => {
+    hir::Expression::IntLiteral(_) | hir::Expression::Int31Zero | hir::Expression::Variable(_) => {
       cx.insert(name, value);
     }
     hir::Expression::StringName(n) => {

--- a/crates/samlang-compiler/src/hir_type_conversion.rs
+++ b/crates/samlang-compiler/src/hir_type_conversion.rs
@@ -91,7 +91,7 @@ fn collect_used_generic_types_visitor(
   collector: &mut HashSet<PStr>,
 ) {
   match type_ {
-    Type::Int => {}
+    Type::Int32 | Type::Int31 => {}
     Type::Id(IdType { name, type_arguments }) => {
       if name.module_reference.is_none() && generic_types.contains(&name.type_name) {
         collector.insert(name.type_name);
@@ -117,7 +117,8 @@ pub(super) fn collect_used_generic_types(
 
 pub(super) fn type_application(type_: &Type, replacement_map: &HashMap<PStr, Type>) -> Type {
   match type_ {
-    Type::Int => Type::Int,
+    Type::Int32 => Type::Int32,
+    Type::Int31 => Type::Int31,
     Type::Id(id) => {
       if id.name.module_reference.is_none() {
         replacement_map.get(&id.name.type_name).cloned().unwrap()
@@ -161,7 +162,7 @@ impl TypeLoweringManager {
       type_::Type::Any(reason, placeholder) => {
         panic!("any(placeholder={}) at {:?}", placeholder, reason)
       }
-      type_::Type::Primitive(_, _) => Type::Int,
+      type_::Type::Primitive(_, _) => Type::Int32,
       type_::Type::Nominal(id) => {
         let id_string = id.id;
         Type::Id(IdType {
@@ -292,7 +293,7 @@ mod tests {
   use super::*;
   use pretty_assertions::assert_eq;
   use samlang_ast::{
-    hir::INT_TYPE,
+    hir::{INT31_TYPE, INT_TYPE},
     source::{test_builder, NO_COMMENT_REFERENCE},
     Location, Reason,
   };
@@ -442,6 +443,7 @@ mod tests {
     let heap = &mut Heap::new();
 
     assert_eq!("int", type_application(&INT_TYPE, &HashMap::new()).pretty_print(heap));
+    assert_eq!("i31", type_application(&INT31_TYPE, &HashMap::new()).pretty_print(heap));
 
     assert_eq!(
       "DUMMY_A<int>",

--- a/crates/samlang-compiler/src/mir_generics_specialization.rs
+++ b/crates/samlang-compiler/src/mir_generics_specialization.rs
@@ -375,6 +375,7 @@ impl Rewriter {
   ) -> mir::Expression {
     match expression {
       hir::Expression::IntLiteral(i) => mir::Expression::Int32Literal(*i),
+      hir::Expression::Int31Zero => mir::Expression::Int31Literal(0),
       hir::Expression::StringName(s) => {
         self.used_string_names.insert(*s);
         mir::Expression::StringName(*s)
@@ -490,7 +491,8 @@ impl Rewriter {
     generics_replacement_map: &HashMap<PStr, mir::Type>,
   ) -> mir::Type {
     match type_ {
-      hir::Type::Int => mir::Type::Int32,
+      hir::Type::Int32 => mir::Type::Int32,
+      hir::Type::Int31 => mir::Type::Int31,
       hir::Type::Id(id) => self.rewrite_id_type(heap, id, generics_replacement_map),
     }
   }
@@ -1497,12 +1499,15 @@ sources.mains = [_DUMMY_I$main]"#,
               hir::Statement::Call {
                 callee: hir::Callee::Variable(hir::VariableName {
                   name: heap.alloc_str_for_test("v"),
-                  type_: hir::INT_TYPE,
+                  type_: hir::INT31_TYPE,
                 }),
-                arguments: vec![hir::Expression::var_name(
-                  PStr::LOWER_B,
-                  hir::Type::new_id_no_targs(heap.alloc_str_for_test("StrOption")),
-                )],
+                arguments: vec![
+                  hir::Expression::var_name(
+                    PStr::LOWER_B,
+                    hir::Type::new_id_no_targs(heap.alloc_str_for_test("StrOption")),
+                  ),
+                  hir::Expression::Int31Zero,
+                ],
                 return_type: hir::Type::new_id_no_targs(PStr::UPPER_J),
                 return_collector: None,
               },
@@ -1525,7 +1530,7 @@ function _DUMMY_I$creatorJ(): DUMMY_J {
 
 function _DUMMY_I$main(): int {
   _DUMMY_I$creatorJ();
-  (v: int)((b: DUMMY_StrOption));
+  (v: i31)((b: DUMMY_StrOption), 0 as i31);
   return "creatorJ";
 }
 


### PR DESCRIPTION
It will be used to model the class id reference.
