### PR TITLE
[wasm][ast] Store lir::Type instead of String in wasm ast

### DIFF
--- a/crates/samlang-ast/src/lir.rs
+++ b/crates/samlang-ast/src/lir.rs
@@ -49,7 +49,7 @@ impl Type {
     Type::Fn(Self::new_fn_unwrapped(argument_types, return_type))
   }
 
-  fn pretty_print(&self, collector: &mut String, heap: &Heap, table: &SymbolTable) {
+  pub fn pretty_print(&self, collector: &mut String, heap: &Heap, table: &SymbolTable) {
     match self {
       Type::Int32 => collector.push_str("number"),
       Type::Int31 => collector.push_str("i31"),


### PR DESCRIPTION
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/SamChou19815/samlang/pull/1235).
* #1237
* #1236
* __->__ #1235
* #1234