### PR TITLE
[parser] Eliminate unconsume

### DIFF
--- a/crates/samlang-checker/src/main_checker.rs
+++ b/crates/samlang-checker/src/main_checker.rs
@@ -309,7 +309,7 @@ fn check_tuple(
     14 => PStr::TUPLE_14,
     15 => PStr::TUPLE_15,
     16 => PStr::TUPLE_16,
-    _ => panic!("Invalid tuple length"),
+    l => panic!("Invalid tuple length {l}"),
   };
   let type_ = Rc::new(Type::Nominal(NominalType {
     reason: Reason::new(common.loc, None),

--- a/crates/samlang-parser/src/lexer.rs
+++ b/crates/samlang-parser/src/lexer.rs
@@ -666,6 +666,13 @@ pub(super) enum TokenContent {
 }
 
 impl TokenContent {
+  pub(super) fn is_comment(&self) -> bool {
+    matches!(
+      self,
+      TokenContent::LineComment(_) | TokenContent::BlockComment(_) | TokenContent::DocComment(_)
+    )
+  }
+
   pub(super) fn pretty_print(&self, heap: &Heap) -> String {
     match self {
       TokenContent::Keyword(k) => k.as_str().to_string(),


### PR DESCRIPTION

Finally, we will only have additional lookup, instead of backtracking. In this way, we don't have to compute all the tokens up front.
